### PR TITLE
fix: update watched resources configmap

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -58,7 +58,7 @@ var clusterCmd = &cobra.Command{
 			shutdown.SendShutdownSignalAndBlockForever(true)
 			select {}
 		}
-		clusterConfigmap, err := mokubernetes.CreateOrUpdateClusterConfigmap(nil)
+		clusterConfigmap, err := mokubernetes.CreateAndUpdateClusterConfigmap()
 		if err != nil {
 			cmdLogger.Error("Error retrieving cluster configmap. Aborting.", "error", err.Error())
 			shutdown.SendShutdownSignalAndBlockForever(true)

--- a/kubernetes/watcher.go
+++ b/kubernetes/watcher.go
@@ -224,6 +224,7 @@ func WatchAllResources(watcher interfaces.KubernetesWatcher) {
 		Factor:   2.0,
 		Jitter:   0.1,
 	}, apierrors.IsServiceUnavailable, func() error {
+		// TODO: this has to keep running and Watch/Unwatch resources instead of only registering on startup
 		for _, v := range utils.CONFIG.Iac.SyncWorkloads {
 			err := watcher.Watch(interfaces.KubernetesWatcherResourceIdentifier{
 				Name:         v.Name,

--- a/utils/config.go
+++ b/utils/config.go
@@ -71,14 +71,13 @@ func (s *SyncResourceEntry) YamlString() string {
 	return string(bytes)
 }
 
-func YamlStringFromSyncResource(s []SyncResourceEntry) string {
-	bytes, err := yaml.Marshal(s)
+func ToYaml(data interface{}) (string, error) {
+	bytes, err := yaml.Marshal(data)
 	if err != nil {
-		utilsLogger.Error("Error marshalling SyncResourceEntry", "error", err)
-		return ""
+		return "", err
 	}
 
-	return string(bytes)
+	return string(bytes), nil
 }
 
 func YamlStringFromSyncResourceDescription(s []SyncResourceEntry) string {


### PR DESCRIPTION
The update logic for the mogenius ConfigMap did not work. This led to accidentally "caching" old resources even after they've been uninstalled from the cluster.

This changeset fixes the update logic for the ConfigMap.

This resolves spam:

![image](https://github.com/user-attachments/assets/f80ebdbf-42bd-4a9d-a055-f3e2785fc172)