### PR TITLE
fix: provide empty `MO_CLUSTER_MFA_ID` in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,8 @@ ENV HELM_REGISTRY_CONFIG="/db/helm-data/helm/config.json"
 ENV HELM_REPOSITORY_CACHE="/db/helm-data/helm/cache/repository"
 ENV HELM_REPOSITORY_CONFIG="/db/helm-data/helm/repositories.yaml"
 # e.g. "--dns 1.1.1.1"
-ENV DOCKERD_ARGS="" 
+ENV DOCKERD_ARGS=""
+ENV MO_CLUSTER_MFA_ID=""
 
 # Todo: remove when logs is configurable
 RUN ln -sf /db/logs /app/logs


### PR DESCRIPTION
- Locally: We want to fail to start the application. Thats why the application does **not** provide a default value
- Cluster: We want to start the application. The secret is lazily initialized in kubernetes.

Given these circumstances a default-empty `MO_CLUSTER_MFA_ID` is provided by the image rather than the application.