### PR TITLE
fix: optimize secrets in AddSecret method

### DIFF
--- a/dtos/k8sProjectDto.go
+++ b/dtos/k8sProjectDto.go
@@ -1,6 +1,7 @@
 package dtos
 
 import (
+	"mogenius-k8s-manager/assert"
 	"mogenius-k8s-manager/logging"
 
 	punqUtils "github.com/mogenius/punq/utils"
@@ -41,9 +42,17 @@ func K8sProjectDtoExampleData() K8sProjectDto {
 }
 
 func (p *K8sProjectDto) AddSecretsToRedaction() {
-	logging.AddSecret(p.GitAccessToken)
-	logging.AddSecret(p.GitUserId)
-	logging.AddSecret(&p.ClusterMfaId)
-	logging.AddSecret(p.ContainerRegistryUser)
-	logging.AddSecret(p.ContainerRegistryPat)
+	assert.Assert(p.GitAccessToken != nil)
+	logging.AddSecret(*p.GitAccessToken)
+
+	assert.Assert(p.GitUserId != nil)
+	logging.AddSecret(*p.GitUserId)
+
+	logging.AddSecret(p.ClusterMfaId)
+
+	assert.Assert(p.ContainerRegistryUser != nil)
+	logging.AddSecret(*p.ContainerRegistryUser)
+
+	assert.Assert(p.ContainerRegistryPat != nil)
+	logging.AddSecret(*p.ContainerRegistryPat)
 }

--- a/dtos/k8sServiceDto.go
+++ b/dtos/k8sServiceDto.go
@@ -1,6 +1,7 @@
 package dtos
 
 import (
+	"mogenius-k8s-manager/assert"
 	"mogenius-k8s-manager/logging"
 )
 
@@ -19,11 +20,13 @@ type K8sServiceDto struct {
 
 func (s *K8sServiceDto) AddSecretsToRedaction() {
 	for _, container := range s.Containers {
-		logging.AddSecret(container.ContainerImageRepoSecretDecryptValue)
-		logging.AddSecret(container.ContainerImageRepoSecretId)
+		assert.Assert(container.ContainerImageRepoSecretDecryptValue != nil)
+		logging.AddSecret(*container.ContainerImageRepoSecretDecryptValue)
+		assert.Assert(container.ContainerImageRepoSecretId != nil)
+		logging.AddSecret(*container.ContainerImageRepoSecretId)
 		for _, envVar := range container.EnvVars {
 			if envVar.Type == EnvVarKeyVault && envVar.Data.VaultType == EnvVarVaultTypeMogeniusVault {
-				logging.AddSecret(&envVar.Value)
+				logging.AddSecret(envVar.Value)
 			}
 		}
 	}

--- a/dtos/syncRepoDto.go
+++ b/dtos/syncRepoDto.go
@@ -32,7 +32,7 @@ type SyncRepoData struct {
 
 func (p *SyncRepoData) AddSecretsToRedaction() {
 	if p.Pat != "***" {
-		logging.AddSecret(&p.Pat)
+		logging.AddSecret(p.Pat)
 	}
 }
 

--- a/iac-manager/iacmanager.go
+++ b/iac-manager/iacmanager.go
@@ -526,7 +526,7 @@ func insertPATIntoURL(gitRepoURL, pat string) string {
 	if !strings.HasPrefix(gitRepoURL, "https://") {
 		return gitRepoURL // Non-HTTPS URLs are not handled here
 	}
-	logging.AddSecret(&utils.CONFIG.Iac.RepoPat)
+	logging.AddSecret(utils.CONFIG.Iac.RepoPat)
 	return strings.Replace(gitRepoURL, "https://", "https://"+pat+"@", 1)
 }
 

--- a/services/files-service.go
+++ b/services/files-service.go
@@ -286,7 +286,7 @@ type ClusterIssuerInstallRequest struct {
 }
 
 func (p *ClusterIssuerInstallRequest) AddSecretsToRedaction() {
-	logging.AddSecret(&p.Email)
+	logging.AddSecret(p.Email)
 }
 
 func ClusterIssuerInstallRequestExample() ClusterIssuerInstallRequest {

--- a/structs/build-job.go
+++ b/structs/build-job.go
@@ -2,6 +2,7 @@ package structs
 
 import (
 	"fmt"
+	"mogenius-k8s-manager/assert"
 	"mogenius-k8s-manager/dtos"
 	"mogenius-k8s-manager/logging"
 	"mogenius-k8s-manager/utils"
@@ -27,8 +28,11 @@ type ScanImageRequest struct {
 }
 
 func (s *ScanImageRequest) AddSecretsToRedaction() {
-	logging.AddSecret(s.ContainerRegistryUser)
-	logging.AddSecret(s.ContainerRegistryPat)
+	assert.Assert(s.ContainerRegistryUser != nil)
+	logging.AddSecret(*s.ContainerRegistryUser)
+
+	assert.Assert(s.ContainerRegistryPat != nil)
+	logging.AddSecret(*s.ContainerRegistryPat)
 }
 
 func ScanImageRequestExample() ScanImageRequest {

--- a/xterm/xterm.go
+++ b/xterm/xterm.go
@@ -111,8 +111,8 @@ type LogEntry struct {
 }
 
 func (p *ScanImageLogConnectionRequest) AddSecretsToRedaction() {
-	logging.AddSecret(&p.ContainerRegistryUser)
-	logging.AddSecret(&p.ContainerRegistryPat)
+	logging.AddSecret(p.ContainerRegistryUser)
+	logging.AddSecret(p.ContainerRegistryPat)
 }
 
 type ClusterToolConnectionRequest struct {


### PR DESCRIPTION
Using pointers has three issues:

- Racing whenever the values change
- Nullability is unclear
- Mutations are hidden

**Risk**

By enforcing explicite copy in the existing codebase there is a chance this is breaking some current usage. Assertions will tell **if** there are issues but only as soon as they reach an environment in which they fail. Locally the application works.