### PR TITLE
fix: remove ingress server snippet and nginx.ingress.kubernetes.io/*

### DIFF
--- a/src/kubernetes/ingress.go
+++ b/src/kubernetes/ingress.go
@@ -247,17 +247,7 @@ func DeleteIngress(job *structs.Job, namespace dtos.K8sNamespaceDto, service dto
 
 func loadDefaultAnnotations() map[string]string {
 	result := map[string]string{
-		"cert-manager.io/cluster-issuer":                 "letsencrypt-cluster-issuer",
-		"nginx.ingress.kubernetes.io/rewrite-target":     "/",
-		"nginx.ingress.kubernetes.io/use-regex":          "true",
-		"nginx.ingress.kubernetes.io/cors-allow-headers": "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,correlation-id,device-version,device,access-token,refresh-token",
-		"nginx.ingress.kubernetes.io/proxy-body-size":    "200m",
-		"nginx.ingress.kubernetes.io/server-snippet": `location @custom {
-			proxy_pass https://errorpages.mogenius.io;
-			proxy_set_header Host            \"errorpages.mogenius.io\";
-			internal;
-		}
-		error_page 400 401 403 404 405 406 408 413 417 500 502 503 504 @custom;`,
+		"cert-manager.io/cluster-issuer": "letsencrypt-cluster-issuer",
 	}
 
 	defaultIngAnnotations := ConfigMapFor(config.Get("MO_OWN_NAMESPACE"), "mogenius-default-ingress-values", false)


### PR DESCRIPTION
Server Snippet werden nicht mehr benötigt. Dann können wir auch errorpage.mogenius.io abschalten und das Docker Image löschen. 

Die andere Annotation werden auch nicht mehr benötigt, da Traefik eingesetzt wird. 
Falls die Werte gesetzt werden müssen, dann funktionieren diese aktuell eh nicht und müssen über eine Traefik Middleware in den ingress eingefügt werden.