### PR TITLE
fix: add NFS TCP/UDP Ports 2046-2049

### DIFF
--- a/src/utils/yaml-templates/networkpolicies-default-ports.yaml
+++ b/src/utils/yaml-templates/networkpolicies-default-ports.yaml
@@ -73,6 +73,38 @@ data:
       protocol: TCP
       port: 111
       createAt: 2024-10-22T00:00:00Z
+    - name: nfs-2046-tcp
+      protocol: TCP
+      port: 2046
+      createAt: 2025-03-10T00:00:00Z
+    - name: nfs-2046-udp
+      protocol: UDP
+      port: 2046
+      createAt: 2025-03-10T00:00:00Z
+    - name: nfs-2047-tcp
+      protocol: TCP
+      port: 2047
+      createAt: 2025-03-10T00:00:00Z
+    - name: nfs-2047-udp
+      protocol: UDP
+      port: 2047
+      createAt: 2025-03-10T00:00:00Z
+    - name: nfs-2068-tcp
+      protocol: TCP
+      port: 2048
+      createAt: 2025-03-10T00:00:00Z
+    - name: nfs-2048-udp
+      protocol: UDP
+      port: 2048
+      createAt: 2025-03-10T00:00:00Z
+    - name: nfs-2029-tcp
+      protocol: TCP
+      port: 2049
+      createAt: 2025-03-10T00:00:00Z
+    - name: nfs-2049-udp
+      protocol: UDP
+      port: 2049
+      createAt: 2024-10-22T00:00:00Z
     - name: ntp
       protocol: UDP
       port: 123


### PR DESCRIPTION
Add NFS TCP/UDP ports 2046-2049, as the NFS storage is not accessible with active network policies.
Services using Mogenius NFS storage as volumes cannot start because the connection to the NFS server is refused.