### PR TITLE
fix: support deployment names different from our default

### DIFF
--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -250,6 +250,12 @@ func LoadConfigDeclarations(configModule *config.Config) {
 		Envs:         []string{"OWN_NODE_NAME"},
 	})
 	configModule.Declare(config.ConfigDeclaration{
+		Key:          "OWN_DEPLOYMENT_NAME",
+		DefaultValue: utils.Pointer("mogenius-k8s-manager"),
+		Description:  utils.Pointer("the name of the deployment this application is running in"),
+		Envs:         []string{"OWN_DEPLOYMENT_NAME"},
+	})
+	configModule.Declare(config.ConfigDeclaration{
 		Key:         "MO_API_SERVER",
 		Description: utils.Pointer("URL of API Server"),
 		Validate: func(value string) error {

--- a/src/core/kubernetes.go
+++ b/src/core/kubernetes.go
@@ -122,7 +122,7 @@ func (self *moKubernetes) writeMogeniusSecret(secretClient v1.SecretInterface, e
 }
 
 func (self *moKubernetes) getDeploymentName() string {
-	return "mogenius-k8s-manager"
+	return self.config.Get("MO_DEPLOYMENT_NAME")
 }
 
 func (self *moKubernetes) createOptions() metav1.CreateOptions {

--- a/src/core/kubernetes.go
+++ b/src/core/kubernetes.go
@@ -122,7 +122,7 @@ func (self *moKubernetes) writeMogeniusSecret(secretClient v1.SecretInterface, e
 }
 
 func (self *moKubernetes) getDeploymentName() string {
-	return self.config.Get("MO_DEPLOYMENT_NAME")
+	return self.config.Get("OWN_DEPLOYMENT_NAME")
 }
 
 func (self *moKubernetes) createOptions() metav1.CreateOptions {

--- a/src/core/nodemetricscollector.go
+++ b/src/core/nodemetricscollector.go
@@ -93,9 +93,13 @@ func (self *nodeMetricsCollector) Orchestrate() {
 		return
 	}
 
-	daemonSetName := "mogenius-k8s-manager-nodemetrics"
+	ownDeploymentName := self.config.Get("OWN_DEPLOYMENT_NAME")
+	assert.Assert(ownDeploymentName != "")
+
 	namespace := self.config.Get("MO_OWN_NAMESPACE")
 	assert.Assert("MO_OWN_NAMESPACE" != "")
+
+	daemonSetName := fmt.Sprintf("%s-nodemetrics", ownDeploymentName)
 
 	if self.clientProvider.RunsInCluster() {
 		self.leaderElector.OnLeading(func() {
@@ -105,7 +109,7 @@ func (self *nodeMetricsCollector) Orchestrate() {
 				return
 			}
 
-			ownDeployment, err := clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "mogenius-k8s-manager", metav1.GetOptions{})
+			ownDeployment, err := clientset.AppsV1().Deployments(namespace).Get(context.TODO(), ownDeploymentName, metav1.GetOptions{})
 			if err != nil {
 				self.logger.Error("failed to get own deployment for image name determination", "error", err)
 				return

--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -1593,7 +1593,7 @@ func (self *socketApi) registerPatterns() {
 			}
 			data.Service.AddSecretsToRedaction()
 			data.Project.AddSecretsToRedaction()
-			return services.UpdateService(self.eventsClient, data)
+			return services.UpdateService(self.eventsClient, data, self.config)
 		},
 	)
 
@@ -1724,7 +1724,7 @@ func (self *socketApi) registerPatterns() {
 				return err
 			}
 			data.Service.AddSecretsToRedaction()
-			return services.Restart(self.eventsClient, data)
+			return services.Restart(self.eventsClient, data, self.config)
 		},
 	)
 
@@ -1741,7 +1741,7 @@ func (self *socketApi) registerPatterns() {
 				return err
 			}
 			data.Service.AddSecretsToRedaction()
-			return services.StopService(self.eventsClient, data)
+			return services.StopService(self.eventsClient, data, self.config)
 		},
 	)
 
@@ -1758,7 +1758,7 @@ func (self *socketApi) registerPatterns() {
 				return err
 			}
 			data.Service.AddSecretsToRedaction()
-			return services.StartService(self.eventsClient, data)
+			return services.StartService(self.eventsClient, data, self.config)
 		},
 	)
 
@@ -1776,7 +1776,7 @@ func (self *socketApi) registerPatterns() {
 			}
 			data.Project.AddSecretsToRedaction()
 			data.Service.AddSecretsToRedaction()
-			return services.UpdateService(self.eventsClient, data)
+			return services.UpdateService(self.eventsClient, data, self.config)
 		},
 	)
 

--- a/src/kubernetes/addresources.go
+++ b/src/kubernetes/addresources.go
@@ -99,7 +99,7 @@ func applyNamespace() {
 
 	applyOptions := metav1.ApplyOptions{
 		Force:        true,
-		FieldManager: DEPLOYMENTNAME,
+		FieldManager: GetOwnDeploymentName(),
 	}
 
 	k8sLogger.Info("Creating mogenius-k8s-manager namespace ...")
@@ -236,7 +236,7 @@ func addDeployment() {
 
 	deploymentContainer := applyconfcore.Container()
 	deploymentContainer.WithImagePullPolicy(core.PullAlways)
-	deploymentContainer.WithName(DEPLOYMENTNAME)
+	deploymentContainer.WithName(GetOwnDeploymentName())
 	deploymentContainer.WithImage(DEPLOYMENTIMAGE)
 
 	envVars := []applyconfcore.EnvVarApplyConfiguration{}
@@ -261,7 +261,7 @@ func addDeployment() {
 	}
 	agentResources := applyconfcore.ResourceRequirements().WithRequests(agentResourceRequests).WithLimits(agentResourceLimits)
 	deploymentContainer.WithResources(agentResources)
-	deploymentContainer.WithName(DEPLOYMENTNAME)
+	deploymentContainer.WithName(GetOwnDeploymentName())
 
 	podSpec := applyconfcore.PodSpec()
 	podSpec.WithTerminationGracePeriodSeconds(0)
@@ -271,19 +271,19 @@ func addDeployment() {
 
 	applyOptions := metav1.ApplyOptions{
 		Force:        true,
-		FieldManager: DEPLOYMENTNAME,
+		FieldManager: GetOwnDeploymentName(),
 	}
 
 	labelSelector := applyconfmeta.LabelSelector()
-	labelSelector.WithMatchLabels(map[string]string{"app": DEPLOYMENTNAME})
+	labelSelector.WithMatchLabels(map[string]string{"app": GetOwnDeploymentName()})
 
 	podTemplate := applyconfcore.PodTemplateSpec()
 	podTemplate.WithLabels(map[string]string{
-		"app": DEPLOYMENTNAME,
+		"app": GetOwnDeploymentName(),
 	})
 	podTemplate.WithSpec(podSpec)
 
-	deployment := applyconfapp.Deployment(DEPLOYMENTNAME, config.Get("MO_OWN_NAMESPACE"))
+	deployment := applyconfapp.Deployment(GetOwnDeploymentName(), config.Get("MO_OWN_NAMESPACE"))
 	deployment.WithSpec(applyconfapp.DeploymentSpec().WithSelector(labelSelector).WithTemplate(podTemplate))
 
 	// Create Deployment

--- a/src/kubernetes/backup.go
+++ b/src/kubernetes/backup.go
@@ -83,7 +83,7 @@ func RestoreNamespace(inputYaml string, namespaceName string) (NamespaceRestoreR
 		ns, err := namespaceClient.Get(context.TODO(), namespaceName, v1.GetOptions{})
 		if err != nil || ns == nil {
 			newNs := applyconfcore.Namespace(namespaceName)
-			_, err = namespaceClient.Apply(context.TODO(), newNs, v1.ApplyOptions{FieldManager: DEPLOYMENTNAME})
+			_, err = namespaceClient.Apply(context.TODO(), newNs, v1.ApplyOptions{FieldManager: GetOwnDeploymentName()})
 			time.Sleep(3 * time.Second) // Wait for 3 for namespace to be created
 			if err != nil {
 				k8sLogger.Error(err.Error())
@@ -155,7 +155,7 @@ func ApplyUnstructured(ctx context.Context, dynamicClient dynamic.Interface, res
 	unstructuredObj.SetManagedFields(nil)
 
 	force := true
-	opts := v1.PatchOptions{FieldManager: DEPLOYMENTNAME, Force: &force}
+	opts := v1.PatchOptions{FieldManager: GetOwnDeploymentName(), Force: &force}
 	if _, err := dri.Patch(ctx, unstructuredObj.GetName(), types.ApplyPatchType, b, opts); err != nil {
 		if isIncompatibleServerError(err) {
 			err = fmt.Errorf("server-side apply not available on the server: (%v)", err)

--- a/src/kubernetes/backup.go
+++ b/src/kubernetes/backup.go
@@ -83,7 +83,7 @@ func RestoreNamespace(inputYaml string, namespaceName string) (NamespaceRestoreR
 		ns, err := namespaceClient.Get(context.TODO(), namespaceName, v1.GetOptions{})
 		if err != nil || ns == nil {
 			newNs := applyconfcore.Namespace(namespaceName)
-			_, err = namespaceClient.Apply(context.TODO(), newNs, v1.ApplyOptions{FieldManager: GetOwnDeploymentName()})
+			_, err = namespaceClient.Apply(context.TODO(), newNs, v1.ApplyOptions{FieldManager: GetOwnDeploymentName(config)})
 			time.Sleep(3 * time.Second) // Wait for 3 for namespace to be created
 			if err != nil {
 				k8sLogger.Error(err.Error())
@@ -155,7 +155,7 @@ func ApplyUnstructured(ctx context.Context, dynamicClient dynamic.Interface, res
 	unstructuredObj.SetManagedFields(nil)
 
 	force := true
-	opts := v1.PatchOptions{FieldManager: GetOwnDeploymentName(), Force: &force}
+	opts := v1.PatchOptions{FieldManager: GetOwnDeploymentName(config), Force: &force}
 	if _, err := dri.Patch(ctx, unstructuredObj.GetName(), types.ApplyPatchType, b, opts); err != nil {
 		if isIncompatibleServerError(err) {
 			err = fmt.Errorf("server-side apply not available on the server: (%v)", err)

--- a/src/kubernetes/configmap.go
+++ b/src/kubernetes/configmap.go
@@ -36,7 +36,7 @@ func EnsureConfigMapExists(namespace string, configMap v1Core.ConfigMap) error {
 	_, err := client.Get(context.TODO(), configMap.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			_, err = client.Create(context.TODO(), &configMap, MoCreateOptions())
+			_, err = client.Create(context.TODO(), &configMap, MoCreateOptions(config))
 			if err != nil {
 				k8sLogger.Error("InitNetworkPolicyConfigMap", "error", err)
 				return err

--- a/src/kubernetes/cronjobs.go
+++ b/src/kubernetes/cronjobs.go
@@ -194,10 +194,10 @@ func UpdateCronJob(eventClient websocket.WebsocketClient, job *structs.Job, name
 
 		newCronJob := newController.(*apibatchv1.CronJob)
 
-		_, err = cronJobClient.Update(context.TODO(), newCronJob, MoUpdateOptions())
+		_, err = cronJobClient.Update(context.TODO(), newCronJob, MoUpdateOptions(config))
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				_, err = cronJobClient.Create(context.TODO(), newCronJob, MoCreateOptions())
+				_, err = cronJobClient.Create(context.TODO(), newCronJob, MoCreateOptions(config))
 				if err != nil {
 					cmd.Fail(eventClient, job, fmt.Sprintf("CreateCronJob ERROR: %s", err.Error()))
 				} else {

--- a/src/kubernetes/deleteresources.go
+++ b/src/kubernetes/deleteresources.go
@@ -20,7 +20,7 @@ func removeDeployment() {
 	// DELETE Deployment
 	k8sLogger.Info("Deleting mogenius-k8s-manager deployment ...")
 	deletePolicy := metav1.DeletePropagationForeground
-	err := deploymentClient.Delete(context.TODO(), DEPLOYMENTNAME, metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
+	err := deploymentClient.Delete(context.TODO(), GetOwnDeploymentName(), metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
 	if err != nil {
 		k8sLogger.Error("Error deleting mogenius-k8s-manager deployment", "error", err.Error())
 		return

--- a/src/kubernetes/deleteresources.go
+++ b/src/kubernetes/deleteresources.go
@@ -20,7 +20,7 @@ func removeDeployment() {
 	// DELETE Deployment
 	k8sLogger.Info("Deleting mogenius-k8s-manager deployment ...")
 	deletePolicy := metav1.DeletePropagationForeground
-	err := deploymentClient.Delete(context.TODO(), GetOwnDeploymentName(), metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
+	err := deploymentClient.Delete(context.TODO(), GetOwnDeploymentName(config), metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
 	if err != nil {
 		k8sLogger.Error("Error deleting mogenius-k8s-manager deployment", "error", err.Error())
 		return

--- a/src/kubernetes/deployment.go
+++ b/src/kubernetes/deployment.go
@@ -84,10 +84,10 @@ func UpdateDeployment(eventClient websocket.WebsocketClient, job *structs.Job, n
 		}
 
 		deployment := newController.(*v1.Deployment)
-		_, err = deploymentClient.Update(context.TODO(), deployment, MoUpdateOptions())
+		_, err = deploymentClient.Update(context.TODO(), deployment, MoUpdateOptions(config))
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				_, err = deploymentClient.Create(context.TODO(), deployment, MoCreateOptions())
+				_, err = deploymentClient.Create(context.TODO(), deployment, MoCreateOptions(config))
 				if err != nil {
 					cmd.Fail(eventClient, job, fmt.Sprintf("CreateDeployment ERROR: %s", err.Error()))
 				} else {

--- a/src/kubernetes/hpa.go
+++ b/src/kubernetes/hpa.go
@@ -117,10 +117,10 @@ func CreateOrUpdateHpa(eventClient websocket.WebsocketClient, job *structs.Job, 
 			return
 		}
 
-		_, err = hpaClient.Update(context.TODO(), newHpa, MoUpdateOptions())
+		_, err = hpaClient.Update(context.TODO(), newHpa, MoUpdateOptions(config))
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				_, err = hpaClient.Create(context.TODO(), newHpa, MoCreateOptions())
+				_, err = hpaClient.Create(context.TODO(), newHpa, MoCreateOptions(config))
 				if err != nil {
 					cmd.Fail(eventClient, job, fmt.Sprintf("Creating hpa ERROR: %s", err.Error()))
 				} else {

--- a/src/kubernetes/ingress.go
+++ b/src/kubernetes/ingress.go
@@ -195,7 +195,7 @@ func UpdateIngress(eventClient websocket.WebsocketClient, job *structs.Job, name
 				cmd.Success(eventClient, job, fmt.Sprintf("Ingress '%s' deleted (not needed anymore)", ingressName))
 			} else {
 				// create
-				_, err := ingressClient.Create(context.TODO(), ingressToUpdate, metav1.CreateOptions{FieldManager: DEPLOYMENTNAME})
+				_, err := ingressClient.Create(context.TODO(), ingressToUpdate, metav1.CreateOptions{FieldManager: GetOwnDeploymentName()})
 				if err != nil {
 					cmd.Fail(eventClient, job, fmt.Sprintf("Create Ingress ERROR: %s", err.Error()))
 					return

--- a/src/kubernetes/ingress.go
+++ b/src/kubernetes/ingress.go
@@ -92,7 +92,7 @@ func UpdateIngress(eventClient websocket.WebsocketClient, job *structs.Job, name
 			ingressToUpdate = existingIngress.DeepCopy()
 		}
 
-		ingressToUpdate.Labels = MoUpdateLabels(&ingressToUpdate.Labels, &job.ProjectId, &namespace, &service)
+		ingressToUpdate.Labels = MoUpdateLabels(&ingressToUpdate.Labels, &job.ProjectId, &namespace, &service, config)
 		ingressToUpdate.Annotations = loadDefaultAnnotations() // TODO MERGE MAPS INSTEAD OF OVERWRITE
 
 		if IsLocalClusterSetup() {
@@ -195,7 +195,7 @@ func UpdateIngress(eventClient websocket.WebsocketClient, job *structs.Job, name
 				cmd.Success(eventClient, job, fmt.Sprintf("Ingress '%s' deleted (not needed anymore)", ingressName))
 			} else {
 				// create
-				_, err := ingressClient.Create(context.TODO(), ingressToUpdate, metav1.CreateOptions{FieldManager: GetOwnDeploymentName()})
+				_, err := ingressClient.Create(context.TODO(), ingressToUpdate, metav1.CreateOptions{FieldManager: GetOwnDeploymentName(config)})
 				if err != nil {
 					cmd.Fail(eventClient, job, fmt.Sprintf("Create Ingress ERROR: %s", err.Error()))
 					return

--- a/src/kubernetes/labelednetworkpolicies.go
+++ b/src/kubernetes/labelednetworkpolicies.go
@@ -65,7 +65,7 @@ func AttachLabeledNetworkPolicy(controllerName string,
 		deployment.Spec.Template.ObjectMeta.Labels[label] = "true"
 		deployment.ObjectMeta.Labels[label] = "true"
 
-		_, err = client.Deployments(namespaceName).Update(context.TODO(), deployment, MoUpdateOptions())
+		_, err = client.Deployments(namespaceName).Update(context.TODO(), deployment, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
@@ -83,7 +83,7 @@ func AttachLabeledNetworkPolicy(controllerName string,
 		daemonset.Spec.Template.ObjectMeta.Labels[label] = "true"
 		daemonset.ObjectMeta.Labels[label] = "true"
 
-		_, err = client.DaemonSets(namespaceName).Update(context.TODO(), daemonset, MoUpdateOptions())
+		_, err = client.DaemonSets(namespaceName).Update(context.TODO(), daemonset, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
@@ -101,7 +101,7 @@ func AttachLabeledNetworkPolicy(controllerName string,
 		statefulset.Spec.Template.ObjectMeta.Labels[label] = "true"
 		statefulset.ObjectMeta.Labels[label] = "true"
 
-		_, err = client.StatefulSets(namespaceName).Update(context.TODO(), statefulset, MoUpdateOptions())
+		_, err = client.StatefulSets(namespaceName).Update(context.TODO(), statefulset, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
@@ -179,17 +179,17 @@ func AttachLabeledNetworkPolicies(controllerName string,
 
 	switch controllerType {
 	case dtos.DEPLOYMENT:
-		_, err = client.Deployments(namespaceName).Update(context.TODO(), deployment, MoUpdateOptions())
+		_, err = client.Deployments(namespaceName).Update(context.TODO(), deployment, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
 	case dtos.DAEMON_SET:
-		_, err = client.DaemonSets(namespaceName).Update(context.TODO(), daemonSet, MoUpdateOptions())
+		_, err = client.DaemonSets(namespaceName).Update(context.TODO(), daemonSet, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
 	case dtos.STATEFUL_SET:
-		_, err = client.StatefulSets(namespaceName).Update(context.TODO(), statefulSet, MoUpdateOptions())
+		_, err = client.StatefulSets(namespaceName).Update(context.TODO(), statefulSet, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
@@ -216,7 +216,7 @@ func DetachLabeledNetworkPolicy(controllerName string,
 		}
 		delete(deployment.Spec.Template.ObjectMeta.Labels, label)
 		delete(deployment.ObjectMeta.Labels, label)
-		_, err = client.Deployments(namespaceName).Update(context.TODO(), deployment, MoUpdateOptions())
+		_, err = client.Deployments(namespaceName).Update(context.TODO(), deployment, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
@@ -227,7 +227,7 @@ func DetachLabeledNetworkPolicy(controllerName string,
 		}
 		delete(daemonset.Spec.Template.ObjectMeta.Labels, label)
 		delete(daemonset.ObjectMeta.Labels, label)
-		_, err = client.DaemonSets(namespaceName).Update(context.TODO(), daemonset, MoUpdateOptions())
+		_, err = client.DaemonSets(namespaceName).Update(context.TODO(), daemonset, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
@@ -238,7 +238,7 @@ func DetachLabeledNetworkPolicy(controllerName string,
 		}
 		delete(statefulset.Spec.Template.ObjectMeta.Labels, label)
 		delete(statefulset.ObjectMeta.Labels, label)
-		_, err = client.StatefulSets(namespaceName).Update(context.TODO(), statefulset, MoUpdateOptions())
+		_, err = client.StatefulSets(namespaceName).Update(context.TODO(), statefulset, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
@@ -303,17 +303,17 @@ func DetachLabeledNetworkPolicies(controllerName string,
 
 	switch controllerType {
 	case dtos.DEPLOYMENT:
-		_, err = client.Deployments(namespaceName).Update(context.TODO(), deployment, MoUpdateOptions())
+		_, err = client.Deployments(namespaceName).Update(context.TODO(), deployment, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
 	case dtos.DAEMON_SET:
-		_, err = client.DaemonSets(namespaceName).Update(context.TODO(), daemonSet, MoUpdateOptions())
+		_, err = client.DaemonSets(namespaceName).Update(context.TODO(), daemonSet, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
 	case dtos.STATEFUL_SET:
-		_, err = client.StatefulSets(namespaceName).Update(context.TODO(), statefulSet, MoUpdateOptions())
+		_, err = client.StatefulSets(namespaceName).Update(context.TODO(), statefulSet, MoUpdateOptions(config))
 		if err != nil {
 			return fmt.Errorf("AttachLabeledNetworkPolicy ERROR: %s", err)
 		}
@@ -446,7 +446,7 @@ func EnsureLabeledNetworkPolicy(namespaceName string, labelPolicy dtos.K8sLabele
 
 	clientset := clientProvider.K8sClientSet()
 	netPolClient := clientset.NetworkingV1().NetworkPolicies(namespaceName)
-	_, err := netPolClient.Create(context.TODO(), &netpol, MoCreateOptions())
+	_, err := netPolClient.Create(context.TODO(), &netpol, MoCreateOptions(config))
 	if err != nil && !strings.Contains(err.Error(), "already exists") {
 		k8sLogger.Error("CreateNetworkPolicyServiceWithLabel ERROR: %s, trying to create labelPolicy %v ", err.Error(), labelPolicy)
 		return err
@@ -516,7 +516,7 @@ func EnsureLabeledNetworkPolicies(namespaceName string, labelPolicy []dtos.K8sLa
 
 		clientset := clientProvider.K8sClientSet()
 		netPolClient := clientset.NetworkingV1().NetworkPolicies(namespaceName)
-		_, err := netPolClient.Create(context.TODO(), &netpol, MoCreateOptions())
+		_, err := netPolClient.Create(context.TODO(), &netpol, MoCreateOptions(config))
 		if err != nil && !strings.Contains(err.Error(), "already exists") {
 			k8sLogger.Error("CreateNetworkPolicyServiceWithLabel ERROR: %s, trying to create labelPolicy %v ", err.Error(), labelPolicy)
 			return err
@@ -591,7 +591,7 @@ func CreateDenyAllIngressNetworkPolicy(namespaceName string) error {
 	_, err := netPolClient.Get(context.TODO(), DenyAllIngressNetPolName, metav1.GetOptions{})
 	if err != nil {
 		// create the deny-all-ingress policy
-		_, err := netPolClient.Create(context.TODO(), &netpol, MoCreateOptions())
+		_, err := netPolClient.Create(context.TODO(), &netpol, MoCreateOptions(config))
 		if err != nil {
 			k8sLogger.Error("CreateDenyAllIngressNetworkPolicy", "error", err)
 			return err
@@ -600,7 +600,7 @@ func CreateDenyAllIngressNetworkPolicy(namespaceName string) error {
 	}
 
 	// update the deny-all-ingress policy
-	_, err = netPolClient.Update(context.TODO(), &netpol, MoUpdateOptions())
+	_, err = netPolClient.Update(context.TODO(), &netpol, MoUpdateOptions(config))
 	if err != nil {
 		k8sLogger.Error("CreateDenyAllIngressNetworkPolicy", "error", err)
 		return err
@@ -637,7 +637,7 @@ func CreateAllowNamespaceCommunicationNetworkPolicy(namespaceName string) error 
 	_, err := netPolClient.Get(context.TODO(), AllowNamespaceCommunicationNetPolName, metav1.GetOptions{})
 	if err != nil {
 		// create the deny-all-ingress policy
-		_, err := netPolClient.Create(context.TODO(), &netpol, MoCreateOptions())
+		_, err := netPolClient.Create(context.TODO(), &netpol, MoCreateOptions(config))
 		if err != nil {
 			k8sLogger.Error("CreateAllowNamespaceCommunicationNetworkPolicy", "error", err)
 			return err
@@ -646,7 +646,7 @@ func CreateAllowNamespaceCommunicationNetworkPolicy(namespaceName string) error 
 	}
 
 	// update the deny-all-ingress policy
-	_, err = netPolClient.Update(context.TODO(), &netpol, MoUpdateOptions())
+	_, err = netPolClient.Update(context.TODO(), &netpol, MoUpdateOptions(config))
 	if err != nil {
 		k8sLogger.Error("CreateAllowNamespaceCommunicationNetworkPolicy", "error", err)
 		return err
@@ -713,7 +713,7 @@ func UpdateNetworkPolicyTemplate(policies []NetworkPolicy) error {
 	_, err = client.Update(context.TODO(), cfgMap, metav1.UpdateOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			_, err = client.Create(context.TODO(), cfgMap, MoCreateOptions())
+			_, err = client.Create(context.TODO(), cfgMap, MoCreateOptions(config))
 			if err != nil {
 				k8sLogger.Error("InitNetworkPolicyConfigMap", "error", err)
 				return err
@@ -912,7 +912,7 @@ func DeleteNetworkPolicyByName(namespaceName string, policyName string) error {
 		_, err = dynamicClient.Resource(gvr).Namespace(namespaceName).Update(
 			context.TODO(),
 			latestObject,
-			MoUpdateOptions(),
+			MoUpdateOptions(config),
 		)
 		if err != nil {
 			k8sLogger.Error("DeleteNetworkPolicyByName", "error", err)

--- a/src/kubernetes/namespace.go
+++ b/src/kubernetes/namespace.go
@@ -22,10 +22,10 @@ func CreateNamespace(eventClient websocket.WebsocketClient, job *structs.Job, pr
 
 	applyOptions := metav1.ApplyOptions{
 		Force:        true,
-		FieldManager: GetOwnDeploymentName(),
+		FieldManager: GetOwnDeploymentName(config),
 	}
 
-	newNamespace.WithLabels(MoUpdateLabels(&map[string]string{"name": namespace.Name}, &project.Id, &namespace, nil))
+	newNamespace.WithLabels(MoUpdateLabels(&map[string]string{"name": namespace.Name}, &project.Id, &namespace, nil, config))
 
 	_, err := namespaceClient.Apply(context.TODO(), newNamespace, applyOptions)
 	if err != nil {

--- a/src/kubernetes/namespace.go
+++ b/src/kubernetes/namespace.go
@@ -22,7 +22,7 @@ func CreateNamespace(eventClient websocket.WebsocketClient, job *structs.Job, pr
 
 	applyOptions := metav1.ApplyOptions{
 		Force:        true,
-		FieldManager: DEPLOYMENTNAME,
+		FieldManager: GetOwnDeploymentName(),
 	}
 
 	newNamespace.WithLabels(MoUpdateLabels(&map[string]string{"name": namespace.Name}, &project.Id, &namespace, nil))

--- a/src/kubernetes/secret.go
+++ b/src/kubernetes/secret.go
@@ -87,7 +87,7 @@ func CreateOrUpdateClusterImagePullSecret(eventClient websocket.WebsocketClient,
 		secret := utils.InitContainerSecret()
 		secret.ObjectMeta.Name = secretName
 		secret.ObjectMeta.Namespace = namespace.Name
-		secret.Labels = MoUpdateLabels(&secret.Labels, nil, nil, nil)
+		secret.Labels = MoUpdateLabels(&secret.Labels, nil, nil, nil, config)
 
 		secretStringData := make(map[string]string)
 
@@ -99,13 +99,13 @@ func CreateOrUpdateClusterImagePullSecret(eventClient websocket.WebsocketClient,
 		secret.StringData = secretStringData
 
 		// Check if exists
-		_, err := secretClient.Update(context.TODO(), &secret, MoUpdateOptions())
+		_, err := secretClient.Update(context.TODO(), &secret, MoUpdateOptions(config))
 		if err == nil {
 			// UPDATED
 			cmd.Success(eventClient, job, "Created Cluster ImagePullSecret")
 		} else {
 			if apierrors.IsNotFound(err) {
-				_, err = secretClient.Create(context.TODO(), &secret, MoCreateOptions())
+				_, err = secretClient.Create(context.TODO(), &secret, MoCreateOptions(config))
 				if err != nil {
 					cmd.Fail(eventClient, job, fmt.Sprintf("CreateOrUpdateClusterImagePullSecret (create) ERROR: %s", err.Error()))
 				} else {
@@ -172,16 +172,16 @@ func CreateOrUpdateContainerImagePullSecret(eventClient websocket.WebsocketClien
 		secretStringData[".dockerconfigjson"] = *service.GetImageRepoSecretDecryptValue()
 		secret.StringData = secretStringData
 
-		secret.Labels = MoUpdateLabels(&secret.Labels, nil, nil, nil)
+		secret.Labels = MoUpdateLabels(&secret.Labels, nil, nil, nil, config)
 
 		// Check if exists
-		_, err := secretClient.Update(context.TODO(), &secret, MoUpdateOptions())
+		_, err := secretClient.Update(context.TODO(), &secret, MoUpdateOptions(config))
 		if err == nil {
 			// UPDATED
 			cmd.Success(eventClient, job, "Created Container ImagePullSecret")
 		} else {
 			if apierrors.IsNotFound(err) {
-				_, err = secretClient.Create(context.TODO(), &secret, MoCreateOptions())
+				_, err = secretClient.Create(context.TODO(), &secret, MoCreateOptions(config))
 				if err != nil {
 					cmd.Fail(eventClient, job, fmt.Sprintf("CreateOrUpdateContainerImagePullSecret (create) ERROR: %s", err.Error()))
 				} else {
@@ -287,10 +287,10 @@ func UpdateOrCreateControllerSecret(eventClient websocket.WebsocketClient, job *
 			return
 		}
 
-		_, err := secretClient.Update(context.TODO(), &secret, MoUpdateOptions())
+		_, err := secretClient.Update(context.TODO(), &secret, MoUpdateOptions(config))
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				_, err = secretClient.Create(context.TODO(), &secret, MoCreateOptions())
+				_, err = secretClient.Create(context.TODO(), &secret, MoCreateOptions(config))
 				if err != nil {
 					cmd.Fail(eventClient, job, fmt.Sprintf("UpdateOrCreateControllerSecrete ERROR: %s", err.Error()))
 				} else {

--- a/src/kubernetes/service.go
+++ b/src/kubernetes/service.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	cfg "mogenius-k8s-manager/src/config"
 	"mogenius-k8s-manager/src/dtos"
 	"mogenius-k8s-manager/src/structs"
 	"mogenius-k8s-manager/src/websocket"
@@ -55,7 +56,7 @@ func DeleteService(eventClient websocket.WebsocketClient, job *structs.Job, name
 	}(wg)
 }
 
-func UpdateService(eventClient websocket.WebsocketClient, job *structs.Job, namespace dtos.K8sNamespaceDto, service dtos.K8sServiceDto, wg *sync.WaitGroup) {
+func UpdateService(eventClient websocket.WebsocketClient, job *structs.Job, namespace dtos.K8sNamespaceDto, service dtos.K8sServiceDto, wg *sync.WaitGroup, config cfg.ConfigModule) {
 	cmd := structs.CreateCommand(eventClient, "update", "Update Application", job)
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {
@@ -72,7 +73,7 @@ func UpdateService(eventClient websocket.WebsocketClient, job *structs.Job, name
 		updateService := generateService(existingService, namespace, service)
 
 		updateOptions := metav1.UpdateOptions{
-			FieldManager: GetOwnDeploymentName(),
+			FieldManager: GetOwnDeploymentName(config),
 		}
 
 		// bind/unbind ports globally

--- a/src/kubernetes/service.go
+++ b/src/kubernetes/service.go
@@ -72,7 +72,7 @@ func UpdateService(eventClient websocket.WebsocketClient, job *structs.Job, name
 		updateService := generateService(existingService, namespace, service)
 
 		updateOptions := metav1.UpdateOptions{
-			FieldManager: DEPLOYMENTNAME,
+			FieldManager: GetOwnDeploymentName(),
 		}
 
 		// bind/unbind ports globally

--- a/src/kubernetes/serviceaccount.go
+++ b/src/kubernetes/serviceaccount.go
@@ -16,7 +16,7 @@ func ApplyServiceAccount(serviceAccountName string, namespace string, annotation
 		},
 	}
 	clientset := clientProvider.K8sClientSet()
-	_, err := clientset.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), serviceAccount, MoCreateOptions())
+	_, err := clientset.CoreV1().ServiceAccounts(namespace).Create(context.TODO(), serviceAccount, MoCreateOptions(config))
 	if err == nil {
 		k8sLogger.Info("ServiceAccount created successfully ✅")
 	} else {

--- a/src/kubernetes/upgrade.go
+++ b/src/kubernetes/upgrade.go
@@ -21,7 +21,7 @@ func ClusterForceReconnect() bool {
 	podClient := clientset.CoreV1().Pods(config.Get("MO_OWN_NAMESPACE"))
 
 	podsToKill := []string{}
-	podsToKill = append(podsToKill, AllPodNamesForLabel(config.Get("MO_OWN_NAMESPACE"), "app", DEPLOYMENTNAME)...)
+	podsToKill = append(podsToKill, AllPodNamesForLabel(config.Get("MO_OWN_NAMESPACE"), "app", GetOwnDeploymentName())...)
 
 	for _, podName := range podsToKill {
 		k8sLogger.Warn("Restarting pod ...", "podName", podName)
@@ -45,7 +45,7 @@ func ClusterForceDisconnect() bool {
 
 	// stop k8s-manager
 	deploymentClient := clientset.AppsV1().Deployments(config.Get("MO_OWN_NAMESPACE"))
-	deployment, _ := deploymentClient.Get(context.TODO(), DEPLOYMENTNAME, metav1.GetOptions{})
+	deployment, _ := deploymentClient.Get(context.TODO(), GetOwnDeploymentName(), metav1.GetOptions{})
 	deployment.Spec.Replicas = utils.Pointer[int32](0)
 	_, err := deploymentClient.Update(context.TODO(), deployment, metav1.UpdateOptions{})
 	if err != nil {
@@ -53,7 +53,7 @@ func ClusterForceDisconnect() bool {
 	}
 
 	podsToKill := []string{}
-	podsToKill = append(podsToKill, AllPodNamesForLabel(config.Get("MO_OWN_NAMESPACE"), "app", DEPLOYMENTNAME)...)
+	podsToKill = append(podsToKill, AllPodNamesForLabel(config.Get("MO_OWN_NAMESPACE"), "app", GetOwnDeploymentName())...)
 
 	for _, podName := range podsToKill {
 		k8sLogger.Warn("Restarting pod...", "pod", podName)

--- a/src/kubernetes/upgrade.go
+++ b/src/kubernetes/upgrade.go
@@ -21,7 +21,7 @@ func ClusterForceReconnect() bool {
 	podClient := clientset.CoreV1().Pods(config.Get("MO_OWN_NAMESPACE"))
 
 	podsToKill := []string{}
-	podsToKill = append(podsToKill, AllPodNamesForLabel(config.Get("MO_OWN_NAMESPACE"), "app", GetOwnDeploymentName())...)
+	podsToKill = append(podsToKill, AllPodNamesForLabel(config.Get("MO_OWN_NAMESPACE"), "app", GetOwnDeploymentName(config))...)
 
 	for _, podName := range podsToKill {
 		k8sLogger.Warn("Restarting pod ...", "podName", podName)
@@ -45,7 +45,7 @@ func ClusterForceDisconnect() bool {
 
 	// stop k8s-manager
 	deploymentClient := clientset.AppsV1().Deployments(config.Get("MO_OWN_NAMESPACE"))
-	deployment, _ := deploymentClient.Get(context.TODO(), GetOwnDeploymentName(), metav1.GetOptions{})
+	deployment, _ := deploymentClient.Get(context.TODO(), GetOwnDeploymentName(config), metav1.GetOptions{})
 	deployment.Spec.Replicas = utils.Pointer[int32](0)
 	_, err := deploymentClient.Update(context.TODO(), deployment, metav1.UpdateOptions{})
 	if err != nil {
@@ -53,7 +53,7 @@ func ClusterForceDisconnect() bool {
 	}
 
 	podsToKill := []string{}
-	podsToKill = append(podsToKill, AllPodNamesForLabel(config.Get("MO_OWN_NAMESPACE"), "app", GetOwnDeploymentName())...)
+	podsToKill = append(podsToKill, AllPodNamesForLabel(config.Get("MO_OWN_NAMESPACE"), "app", GetOwnDeploymentName(config))...)
 
 	for _, podName := range podsToKill {
 		k8sLogger.Warn("Restarting pod...", "pod", podName)
@@ -90,7 +90,7 @@ func UpgradeMyself(eventClient websocket.WebsocketClient, job *structs.Job, comm
 		_, err := configmapClient.Get(context.TODO(), configmap.Name, metav1.GetOptions{})
 		if err != nil {
 			// CREATE
-			_, err = configmapClient.Create(context.TODO(), &configmap, MoCreateOptions())
+			_, err = configmapClient.Create(context.TODO(), &configmap, MoCreateOptions(config))
 			if err != nil {
 				cmd.Fail(eventClient, job, fmt.Sprintf("UpgradeMyself (configmap) ERROR: %s", err.Error()))
 				return
@@ -108,7 +108,7 @@ func UpgradeMyself(eventClient websocket.WebsocketClient, job *structs.Job, comm
 		_, err = jobClient.Get(context.TODO(), k8sjob.Name, metav1.GetOptions{})
 		if err != nil {
 			// CREATE
-			_, err = jobClient.Create(context.TODO(), &k8sjob, MoCreateOptions())
+			_, err = jobClient.Create(context.TODO(), &k8sjob, MoCreateOptions(config))
 			if err != nil {
 				cmd.Fail(eventClient, job, fmt.Sprintf("UpgradeMyself (job) ERROR: %s", err.Error()))
 				return

--- a/src/kubernetes/utils.go
+++ b/src/kubernetes/utils.go
@@ -5,12 +5,12 @@ import (
 	json1 "encoding/json"
 	"fmt"
 	"mogenius-k8s-manager/src/assert"
+	cfg "mogenius-k8s-manager/src/config"
 	"mogenius-k8s-manager/src/dtos"
 	"mogenius-k8s-manager/src/shutdown"
 	"mogenius-k8s-manager/src/structs"
 	"mogenius-k8s-manager/src/utils"
 	"mogenius-k8s-manager/src/version"
-	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -175,23 +175,23 @@ func KubernetesVersion() *version2.Info {
 	return info
 }
 
-func MoCreateOptions() metav1.CreateOptions {
+func MoCreateOptions(config cfg.ConfigModule) metav1.CreateOptions {
 	return metav1.CreateOptions{
-		FieldManager: GetOwnDeploymentName(),
+		FieldManager: GetOwnDeploymentName(config),
 	}
 }
 
-func MoUpdateOptions() metav1.UpdateOptions {
+func MoUpdateOptions(config cfg.ConfigModule) metav1.UpdateOptions {
 	return metav1.UpdateOptions{
-		FieldManager: GetOwnDeploymentName(),
+		FieldManager: GetOwnDeploymentName(config),
 	}
 }
 
-func GetOwnDeploymentName() string {
-	return os.Getenv("OWN_DEPLOYMENT_NAME")
+func GetOwnDeploymentName(config cfg.ConfigModule) string {
+	return config.Get("OWN_DEPLOYMENT_NAME")
 }
 
-func MoUpdateLabels(labels *map[string]string, projectId *string, namespace *dtos.K8sNamespaceDto, service *dtos.K8sServiceDto) map[string]string {
+func MoUpdateLabels(labels *map[string]string, projectId *string, namespace *dtos.K8sNamespaceDto, service *dtos.K8sServiceDto, config cfg.ConfigModule) map[string]string {
 	resultingLabels := map[string]string{}
 
 	// transfer existing values
@@ -202,7 +202,7 @@ func MoUpdateLabels(labels *map[string]string, projectId *string, namespace *dto
 	}
 
 	// populate with mo labels
-	resultingLabels[MO_LABEL_CREATED_BY] = GetOwnDeploymentName()
+	resultingLabels[MO_LABEL_CREATED_BY] = GetOwnDeploymentName(config)
 	if service != nil {
 		resultingLabels[MO_LABEL_APP_NAME] = service.ControllerName
 	}

--- a/src/kubernetes/utils.go
+++ b/src/kubernetes/utils.go
@@ -10,6 +10,7 @@ import (
 	"mogenius-k8s-manager/src/structs"
 	"mogenius-k8s-manager/src/utils"
 	"mogenius-k8s-manager/src/version"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -33,7 +34,6 @@ import (
 )
 
 var (
-	DEPLOYMENTNAME  = "mogenius-k8s-manager"
 	DEPLOYMENTIMAGE = "ghcr.io/mogenius/mogenius-k8s-manager:" + version.Ver
 
 	SERVICEACCOUNTNAME     = "mogenius-k8s-manager-service-account-app"
@@ -177,14 +177,18 @@ func KubernetesVersion() *version2.Info {
 
 func MoCreateOptions() metav1.CreateOptions {
 	return metav1.CreateOptions{
-		FieldManager: DEPLOYMENTNAME,
+		FieldManager: GetOwnDeploymentName(),
 	}
 }
 
 func MoUpdateOptions() metav1.UpdateOptions {
 	return metav1.UpdateOptions{
-		FieldManager: DEPLOYMENTNAME,
+		FieldManager: GetOwnDeploymentName(),
 	}
+}
+
+func GetOwnDeploymentName() string {
+	return os.Getenv("OWN_DEPLOYMENT_NAME")
 }
 
 func MoUpdateLabels(labels *map[string]string, projectId *string, namespace *dtos.K8sNamespaceDto, service *dtos.K8sServiceDto) map[string]string {
@@ -198,7 +202,7 @@ func MoUpdateLabels(labels *map[string]string, projectId *string, namespace *dto
 	}
 
 	// populate with mo labels
-	resultingLabels[MO_LABEL_CREATED_BY] = DEPLOYMENTNAME
+	resultingLabels[MO_LABEL_CREATED_BY] = GetOwnDeploymentName()
 	if service != nil {
 		resultingLabels[MO_LABEL_APP_NAME] = service.ControllerName
 	}

--- a/src/services/serviceservice.go
+++ b/src/services/serviceservice.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	cfg "mogenius-k8s-manager/src/config"
 	"mogenius-k8s-manager/src/dtos"
 	"mogenius-k8s-manager/src/gitmanager"
 	"mogenius-k8s-manager/src/kubernetes"
@@ -16,7 +17,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func UpdateService(eventClient websocket.WebsocketClient, r ServiceUpdateRequest) *structs.Job {
+func UpdateService(eventClient websocket.WebsocketClient, r ServiceUpdateRequest, config cfg.ConfigModule) *structs.Job {
 	var wg sync.WaitGroup
 	job := structs.CreateJob(eventClient, "Update Service "+r.Project.DisplayName+"/"+r.Namespace.DisplayName, r.Project.Id, r.Namespace.Name, r.Service.ControllerName)
 	job.Start(eventClient)
@@ -37,7 +38,7 @@ func UpdateService(eventClient websocket.WebsocketClient, r ServiceUpdateRequest
 	mokubernetes.CreateOrUpdateClusterImagePullSecret(eventClient, job, r.Project, r.Namespace, &wg)
 	mokubernetes.CreateOrUpdateContainerImagePullSecret(eventClient, job, r.Namespace, r.Service, &wg)
 	mokubernetes.UpdateOrCreateControllerSecret(eventClient, job, r.Namespace, r.Service, &wg)
-	mokubernetes.UpdateService(eventClient, job, r.Namespace, r.Service, &wg)
+	mokubernetes.UpdateService(eventClient, job, r.Namespace, r.Service, &wg, config)
 	// mokubernetes.CreateOrUpdateNetworkPolicyService(job, r.Namespace, r.Service, &wg)
 	mokubernetes.UpdateIngress(eventClient, job, r.Namespace, r.Service, &wg)
 
@@ -133,14 +134,14 @@ func TriggerJobService(eventClient websocket.WebsocketClient, r ServiceTriggerJo
 	return job
 }
 
-func Restart(eventClient websocket.WebsocketClient, r ServiceRestartRequest) *structs.Job {
+func Restart(eventClient websocket.WebsocketClient, r ServiceRestartRequest, config cfg.ConfigModule) *structs.Job {
 	var wg sync.WaitGroup
 	job := structs.CreateJob(eventClient, "Restart Service "+r.Namespace.DisplayName, r.Project.Id, r.Namespace.Name, r.Service.ControllerName)
 	job.Start(eventClient)
 
 	mokubernetes.CreateOrUpdateClusterImagePullSecret(eventClient, job, r.Project, r.Namespace, &wg)
 	mokubernetes.CreateOrUpdateContainerImagePullSecret(eventClient, job, r.Namespace, r.Service, &wg)
-	mokubernetes.UpdateService(eventClient, job, r.Namespace, r.Service, &wg)
+	mokubernetes.UpdateService(eventClient, job, r.Namespace, r.Service, &wg, config)
 	mokubernetes.UpdateOrCreateControllerSecret(eventClient, job, r.Namespace, r.Service, &wg)
 	// mokubernetes.CreateOrUpdateNetworkPolicyService(job, r.Namespace, r.Service, &wg)
 	mokubernetes.UpdateIngress(eventClient, job, r.Namespace, r.Service, &wg)
@@ -160,7 +161,7 @@ func Restart(eventClient websocket.WebsocketClient, r ServiceRestartRequest) *st
 	return job
 }
 
-func StopService(eventClient websocket.WebsocketClient, r ServiceStopRequest) *structs.Job {
+func StopService(eventClient websocket.WebsocketClient, r ServiceStopRequest, config cfg.ConfigModule) *structs.Job {
 	var wg sync.WaitGroup
 	job := structs.CreateJob(eventClient, "Stop Service "+r.Namespace.DisplayName, r.ProjectId, r.Namespace.Name, r.Service.ControllerName)
 	job.Start(eventClient)
@@ -172,7 +173,7 @@ func StopService(eventClient websocket.WebsocketClient, r ServiceStopRequest) *s
 		mokubernetes.StopCronJob(eventClient, job, r.Namespace, r.Service, &wg)
 	}
 
-	mokubernetes.UpdateService(eventClient, job, r.Namespace, r.Service, &wg)
+	mokubernetes.UpdateService(eventClient, job, r.Namespace, r.Service, &wg, config)
 	mokubernetes.UpdateIngress(eventClient, job, r.Namespace, r.Service, &wg)
 
 	go func() {
@@ -183,7 +184,7 @@ func StopService(eventClient websocket.WebsocketClient, r ServiceStopRequest) *s
 	return job
 }
 
-func StartService(eventClient websocket.WebsocketClient, r ServiceStartRequest) *structs.Job {
+func StartService(eventClient websocket.WebsocketClient, r ServiceStartRequest, config cfg.ConfigModule) *structs.Job {
 	var wg sync.WaitGroup
 
 	job := structs.CreateJob(eventClient, "Start Service "+r.Service.DisplayName, r.Project.Id, r.Namespace.Name, r.Service.ControllerName)
@@ -191,7 +192,7 @@ func StartService(eventClient websocket.WebsocketClient, r ServiceStartRequest) 
 
 	mokubernetes.CreateOrUpdateClusterImagePullSecret(eventClient, job, r.Project, r.Namespace, &wg)
 	mokubernetes.CreateOrUpdateContainerImagePullSecret(eventClient, job, r.Namespace, r.Service, &wg)
-	mokubernetes.UpdateService(eventClient, job, r.Namespace, r.Service, &wg)
+	mokubernetes.UpdateService(eventClient, job, r.Namespace, r.Service, &wg, config)
 	mokubernetes.UpdateOrCreateControllerSecret(eventClient, job, r.Namespace, r.Service, &wg)
 	// mokubernetes.CreateOrUpdateNetworkPolicyService(job, r.Namespace, r.Service, &wg)
 	mokubernetes.UpdateIngress(eventClient, job, r.Namespace, r.Service, &wg)


### PR DESCRIPTION
Supporting Deployment names different than `mogenius-k8s-manager`, default will still be `mogenius-k8s-manager`