### PR TITLE
fix(socketapi): use generic type deducation for all registered patterns

### DIFF
--- a/generated/client.ts
+++ b/generated/client.ts
@@ -514,17 +514,39 @@ export type ATTACH_LABELED_NETWORK_POLICY_REQUEST = ATTACH_LABELED_NETWORK_POLIC
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.AttachLabeledNetworkPolicyRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.AttachLabeledNetworkPolicyRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.AttachLabeledNetworkPolicyRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type ATTACH_LABELED_NETWORK_POLICY_RESPONSE = string;
+export type ATTACH_LABELED_NETWORK_POLICY_RESPONSE = ATTACH_LABELED_NETWORK_POLICY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_ATTACHLABELEDNETWORKPOLICYREQUEST_STRING;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_0:
+ *         properties: {}
+ * typeInfo:
+ *     pointer: true
+ *     structRef: ANON_STRUCT_0
+ *     type: struct
+ * ```
+ *
  */
-export type CLUSTERFORCEDISCONNECT_REQUEST = any;
+export type CLUSTERFORCEDISCONNECT_REQUEST = CLUSTERFORCEDISCONNECT_REQUEST__ANON_STRUCT_0|undefined;
 
 /**
  * #### Source
@@ -538,9 +560,20 @@ export type CLUSTERFORCEDISCONNECT_REQUEST = any;
 export type CLUSTERFORCEDISCONNECT_RESPONSE = boolean;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_0:
+ *         properties: {}
+ * typeInfo:
+ *     pointer: true
+ *     structRef: ANON_STRUCT_0
+ *     type: struct
+ * ```
+ *
  */
-export type CLUSTERFORCERECONNECT_REQUEST = any;
+export type CLUSTERFORCERECONNECT_REQUEST = CLUSTERFORCERECONNECT_REQUEST__ANON_STRUCT_0|undefined;
 
 /**
  * #### Source
@@ -554,9 +587,20 @@ export type CLUSTERFORCERECONNECT_REQUEST = any;
 export type CLUSTERFORCERECONNECT_RESPONSE = boolean;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_0:
+ *         properties: {}
+ * typeInfo:
+ *     pointer: true
+ *     structRef: ANON_STRUCT_0
+ *     type: struct
+ * ```
+ *
  */
-export type CLUSTERRESOURCEINFO_REQUEST = any;
+export type CLUSTERRESOURCEINFO_REQUEST = CLUSTERRESOURCEINFO_REQUEST__ANON_STRUCT_0|undefined;
 
 /**
  * #### Source
@@ -741,33 +785,32 @@ export type CLUSTERRESOURCEINFO_REQUEST = any;
 export type CLUSTERRESOURCEINFO_RESPONSE = CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESPONSE;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_0:
+ *         properties: {}
+ * typeInfo:
+ *     pointer: true
+ *     structRef: ANON_STRUCT_0
+ *     type: struct
+ * ```
+ *
  */
-export type CLUSTER_BACKUP_REQUEST = any;
+export type CLUSTER_BACKUP_REQUEST = CLUSTER_BACKUP_REQUEST__ANON_STRUCT_0|undefined;
 
 /**
  * #### Source
  *
  * ```yaml
- * structs:
- *     mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse:
- *         name: mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse
- *         properties:
- *             data:
- *                 type: string
- *             messages:
- *                 elementType:
- *                     type: string
- *                 type: array
- *             namespaceName:
- *                 type: string
  * typeInfo:
- *     structRef: mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse
- *     type: struct
+ *     pointer: true
+ *     type: any
  * ```
  *
  */
-export type CLUSTER_BACKUP_RESPONSE = CLUSTER_BACKUP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_NAMESPACEBACKUPRESPONSE;
+export type CLUSTER_BACKUP_RESPONSE = any;
 
 /**
  * #### Source
@@ -795,12 +838,23 @@ export type CLUSTER_CLEAR_VALKEY_CACHE_REQUEST = CLUSTER_CLEAR_VALKEY_CACHE_REQU
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·5,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·5,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·5,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_CLEAR_VALKEY_CACHE_RESPONSE = string;
+export type CLUSTER_CLEAR_VALKEY_CACHE_RESPONSE = CLUSTER_CLEAR_VALKEY_CACHE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST5_STRING;
 
 /**
  * #### Source
@@ -850,9 +904,30 @@ export type CLUSTER_CLEAR_VALKEY_CACHE_RESPONSE = string;
 export type CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_REQUEST = CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_COMPONENTLOGCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.ComponentLogConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.ComponentLogConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.ComponentLogConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_RESPONSE = any;
+export type CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_RESPONSE = CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_COMPONENTLOGCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -886,12 +961,23 @@ export type CLUSTER_HELM_CHART_INSTALL_REQUEST = CLUSTER_HELM_CHART_INSTALL_REQU
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_CHART_INSTALL_RESPONSE = string;
+export type CLUSTER_HELM_CHART_INSTALL_RESPONSE = CLUSTER_HELM_CHART_INSTALL_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINSTALLUPGRADEREQUEST_STRING;
 
 /**
  * #### Source
@@ -931,12 +1017,23 @@ export type CLUSTER_HELM_CHART_INSTALL_OCI_REQUEST = CLUSTER_HELM_CHART_INSTALL_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartOciInstallUpgradeRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartOciInstallUpgradeRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartOciInstallUpgradeRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_CHART_INSTALL_OCI_RESPONSE = string;
+export type CLUSTER_HELM_CHART_INSTALL_OCI_RESPONSE = CLUSTER_HELM_CHART_INSTALL_OCI_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTOCIINSTALLUPGRADEREQUEST_STRING;
 
 /**
  * #### Source
@@ -960,12 +1057,23 @@ export type CLUSTER_HELM_CHART_REMOVE_REQUEST = CLUSTER_HELM_CHART_REMOVE_REQUES
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoRemoveRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoRemoveRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoRemoveRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_CHART_REMOVE_RESPONSE = string;
+export type CLUSTER_HELM_CHART_REMOVE_RESPONSE = CLUSTER_HELM_CHART_REMOVE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOREMOVEREQUEST_STRING;
 
 /**
  * #### Source
@@ -990,6 +1098,18 @@ export type CLUSTER_HELM_CHART_SEARCH_REQUEST = CLUSTER_HELM_CHART_SEARCH_REQUES
  *
  * ```yaml
  * structs:
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartSearchRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartSearchRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/helm.HelmChartInfo
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/helm.HelmChartInfo:
  *         name: mogenius-k8s-manager/src/helm.HelmChartInfo
  *         properties:
@@ -1002,14 +1122,12 @@ export type CLUSTER_HELM_CHART_SEARCH_REQUEST = CLUSTER_HELM_CHART_SEARCH_REQUES
  *             version:
  *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/helm.HelmChartInfo
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartSearchRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_CHART_SEARCH_RESPONSE = CLUSTER_HELM_CHART_SEARCH_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO[];
+export type CLUSTER_HELM_CHART_SEARCH_RESPONSE = CLUSTER_HELM_CHART_SEARCH_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTSEARCHREQUEST_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO;
 
 /**
  * #### Source
@@ -1035,12 +1153,23 @@ export type CLUSTER_HELM_CHART_SHOW_REQUEST = CLUSTER_HELM_CHART_SHOW_REQUEST__M
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartShowRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartShowRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartShowRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_CHART_SHOW_RESPONSE = string;
+export type CLUSTER_HELM_CHART_SHOW_RESPONSE = CLUSTER_HELM_CHART_SHOW_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTSHOWREQUEST_STRING;
 
 /**
  * #### Source
@@ -1065,6 +1194,18 @@ export type CLUSTER_HELM_CHART_VERSIONS_REQUEST = CLUSTER_HELM_CHART_VERSIONS_RE
  *
  * ```yaml
  * structs:
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartVersionRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartVersionRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/helm.HelmChartInfo
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/helm.HelmChartInfo:
  *         name: mogenius-k8s-manager/src/helm.HelmChartInfo
  *         properties:
@@ -1077,14 +1218,12 @@ export type CLUSTER_HELM_CHART_VERSIONS_REQUEST = CLUSTER_HELM_CHART_VERSIONS_RE
  *             version:
  *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/helm.HelmChartInfo
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartVersionRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_CHART_VERSIONS_RESPONSE = CLUSTER_HELM_CHART_VERSIONS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO[];
+export type CLUSTER_HELM_CHART_VERSIONS_RESPONSE = CLUSTER_HELM_CHART_VERSIONS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTVERSIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO;
 
 /**
  * #### Source
@@ -1112,12 +1251,23 @@ export type CLUSTER_HELM_RELEASE_GET_REQUEST = CLUSTER_HELM_RELEASE_GET_REQUEST_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_RELEASE_GET_RESPONSE = string;
+export type CLUSTER_HELM_RELEASE_GET_RESPONSE = CLUSTER_HELM_RELEASE_GET_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEGETREQUEST_STRING;
 
 /**
  * #### Source
@@ -1174,15 +1324,25 @@ export type CLUSTER_HELM_RELEASE_GET_WORKLOADS_REQUEST = CLUSTER_HELM_RELEASE_GE
  *                 valueType:
  *                     pointer: true
  *                     type: any
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetWorkloadsRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetWorkloadsRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetWorkloadsRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_RELEASE_GET_WORKLOADS_RESPONSE = CLUSTER_HELM_RELEASE_GET_WORKLOADS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED[];
+export type CLUSTER_HELM_RELEASE_GET_WORKLOADS_RESPONSE = CLUSTER_HELM_RELEASE_GET_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEGETWORKLOADSREQUEST_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED;
 
 /**
  * #### Source
@@ -1456,19 +1616,29 @@ export type CLUSTER_HELM_RELEASE_HISTORY_REQUEST = CLUSTER_HELM_RELEASE_HISTORY_
  *             Time:
  *                 structRef: time.Time
  *                 type: struct
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseHistoryRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseHistoryRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     pointer: true
+ *                     structRef: helm.sh/helm/v3/pkg/release.Release
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     time.Time:
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     elementType:
- *         pointer: true
- *         structRef: helm.sh/helm/v3/pkg/release.Release
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseHistoryRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE = CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_RELEASE|undefined[];
+export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE = CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEHISTORYREQUEST_HELM_SH_HELM_V3_PKG_RELEASE_RELEASE;
 
 /**
  * #### Source
@@ -1740,19 +1910,29 @@ export type CLUSTER_HELM_RELEASE_LIST_REQUEST = CLUSTER_HELM_RELEASE_LIST_REQUES
  *             Time:
  *                 structRef: time.Time
  *                 type: struct
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseListRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseListRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     pointer: true
+ *                     structRef: helm.sh/helm/v3/pkg/release.Release
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     time.Time:
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     elementType:
- *         pointer: true
- *         structRef: helm.sh/helm/v3/pkg/release.Release
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseListRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_RELEASE_LIST_RESPONSE = CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_RELEASE|undefined[];
+export type CLUSTER_HELM_RELEASE_LIST_RESPONSE = CLUSTER_HELM_RELEASE_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASELISTREQUEST_HELM_SH_HELM_V3_PKG_RELEASE_RELEASE;
 
 /**
  * #### Source
@@ -1780,12 +1960,23 @@ export type CLUSTER_HELM_RELEASE_ROLLBACK_REQUEST = CLUSTER_HELM_RELEASE_ROLLBAC
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseRollbackRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseRollbackRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseRollbackRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_RELEASE_ROLLBACK_RESPONSE = string;
+export type CLUSTER_HELM_RELEASE_ROLLBACK_RESPONSE = CLUSTER_HELM_RELEASE_ROLLBACK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEROLLBACKREQUEST_STRING;
 
 /**
  * #### Source
@@ -1812,6 +2003,17 @@ export type CLUSTER_HELM_RELEASE_STATUS_REQUEST = CLUSTER_HELM_RELEASE_STATUS_RE
  *
  * ```yaml
  * structs:
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseStatusRequest,*mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseStatusRequest,*mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo:
  *         name: mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo
  *         properties:
@@ -1832,13 +2034,12 @@ export type CLUSTER_HELM_RELEASE_STATUS_REQUEST = CLUSTER_HELM_RELEASE_STATUS_RE
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     pointer: true
- *     structRef: mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseStatusRequest,*mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo]
  *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_RELEASE_STATUS_RESPONSE = CLUSTER_HELM_RELEASE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASESTATUSINFO|undefined;
+export type CLUSTER_HELM_RELEASE_STATUS_RESPONSE = CLUSTER_HELM_RELEASE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASESTATUSREQUEST_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASESTATUSINFO;
 
 /**
  * #### Source
@@ -1866,12 +2067,23 @@ export type CLUSTER_HELM_RELEASE_UNINSTALL_REQUEST = CLUSTER_HELM_RELEASE_UNINST
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseUninstallRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseUninstallRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseUninstallRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_RELEASE_UNINSTALL_RESPONSE = string;
+export type CLUSTER_HELM_RELEASE_UNINSTALL_RESPONSE = CLUSTER_HELM_RELEASE_UNINSTALL_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEUNINSTALLREQUEST_STRING;
 
 /**
  * #### Source
@@ -1905,12 +2117,23 @@ export type CLUSTER_HELM_RELEASE_UPGRADE_REQUEST = CLUSTER_HELM_RELEASE_UPGRADE_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_RELEASE_UPGRADE_RESPONSE = string;
+export type CLUSTER_HELM_RELEASE_UPGRADE_RESPONSE = CLUSTER_HELM_RELEASE_UPGRADE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINSTALLUPGRADEREQUEST_STRING;
 
 /**
  * #### Source
@@ -1944,12 +2167,23 @@ export type CLUSTER_HELM_REPO_ADD_REQUEST = CLUSTER_HELM_REPO_ADD_REQUEST__MOGEN
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoAddRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoAddRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoAddRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_REPO_ADD_RESPONSE = string;
+export type CLUSTER_HELM_REPO_ADD_RESPONSE = CLUSTER_HELM_REPO_ADD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOADDREQUEST_STRING;
 
 /**
  * #### Source
@@ -1972,6 +2206,19 @@ export type CLUSTER_HELM_REPO_LIST_REQUEST = CLUSTER_HELM_REPO_LIST_REQUEST__ANO
  *
  * ```yaml
  * structs:
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]*mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]*mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     pointer: true
+ *                     structRef: mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword:
  *         name: mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword
  *         properties:
@@ -1984,15 +2231,12 @@ export type CLUSTER_HELM_REPO_LIST_REQUEST = CLUSTER_HELM_REPO_LIST_REQUEST__ANO
  *             url:
  *                 type: string
  * typeInfo:
- *     elementType:
- *         pointer: true
- *         structRef: mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]*mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_REPO_LIST_RESPONSE = CLUSTER_HELM_REPO_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYWITHOUTPASSWORD|undefined[];
+export type CLUSTER_HELM_REPO_LIST_RESPONSE = CLUSTER_HELM_REPO_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYWITHOUTPASSWORD;
 
 /**
  * #### Source
@@ -2028,12 +2272,23 @@ export type CLUSTER_HELM_REPO_PATCH_REQUEST = CLUSTER_HELM_REPO_PATCH_REQUEST__M
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoPatchRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoPatchRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoPatchRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_REPO_PATCH_RESPONSE = string;
+export type CLUSTER_HELM_REPO_PATCH_RESPONSE = CLUSTER_HELM_REPO_PATCH_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOPATCHREQUEST_STRING;
 
 /**
  * #### Source
@@ -2056,6 +2311,18 @@ export type CLUSTER_HELM_REPO_UPDATE_REQUEST = CLUSTER_HELM_REPO_UPDATE_REQUEST_
  *
  * ```yaml
  * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/helm.HelmEntryStatus]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/helm.HelmEntryStatus]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/helm.HelmEntryStatus
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/helm.HelmEntryStatus:
  *         name: mogenius-k8s-manager/src/helm.HelmEntryStatus
  *         properties:
@@ -2079,14 +2346,12 @@ export type CLUSTER_HELM_REPO_UPDATE_REQUEST = CLUSTER_HELM_REPO_UPDATE_REQUEST_
  *             url:
  *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/helm.HelmEntryStatus
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/helm.HelmEntryStatus]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_HELM_REPO_UPDATE_RESPONSE = CLUSTER_HELM_REPO_UPDATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYSTATUS[];
+export type CLUSTER_HELM_REPO_UPDATE_RESPONSE = CLUSTER_HELM_REPO_UPDATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYSTATUS;
 
 /**
  * #### Source
@@ -2405,18 +2670,28 @@ export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_REQUEST = CLUSTER_LIST_PERSIST
  *                 type: string
  *             kind:
  *                 type: string
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/services.ClusterListWorkloads,[]k8s.io/api/core/v1.PersistentVolumeClaim]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/services.ClusterListWorkloads,[]k8s.io/api/core/v1.PersistentVolumeClaim]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: k8s.io/api/core/v1.PersistentVolumeClaim
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     time.Time:
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     elementType:
- *         structRef: k8s.io/api/core/v1.PersistentVolumeClaim
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/services.ClusterListWorkloads,[]k8s.io/api/core/v1.PersistentVolumeClaim]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE = CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__K8S_IO_API_CORE_V1_PERSISTENTVOLUMECLAIM[];
+export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE = CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_SERVICES_CLUSTERLISTWORKLOADS_K8S_IO_API_CORE_V1_PERSISTENTVOLUMECLAIM;
 
 /**
  * #### Source
@@ -2443,20 +2718,30 @@ export type CLUSTER_MACHINE_STATS_REQUEST = CLUSTER_MACHINE_STATS_REQUEST__MOGEN
  *
  * ```yaml
  * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·17,[]mogenius-k8s-manager/src/structs.MachineStats]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·17,[]mogenius-k8s-manager/src/structs.MachineStats]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/structs.MachineStats
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/structs.MachineStats:
  *         name: mogenius-k8s-manager/src/structs.MachineStats
  *         properties:
  *             btfSupport:
  *                 type: bool
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/structs.MachineStats
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·17,[]mogenius-k8s-manager/src/structs.MachineStats]
+ *     type: struct
  * ```
  *
  */
-export type CLUSTER_MACHINE_STATS_RESPONSE = CLUSTER_MACHINE_STATS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_MACHINESTATS[];
+export type CLUSTER_MACHINE_STATS_RESPONSE = CLUSTER_MACHINE_STATS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST17_MOGENIUS_K8S_MANAGER_SRC_STRUCTS_MACHINESTATS;
 
 /**
  * #### Source
@@ -2479,7 +2764,14 @@ export type CLUSTER_MACHINE_STATS_RESPONSE = CLUSTER_MACHINE_STATS_RESPONSE__MOG
 export type CLUSTER_UPDATE_LOCAL_TLS_SECRET_REQUEST = CLUSTER_UPDATE_LOCAL_TLS_SECRET_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_CLUSTERUPDATELOCALTLSSECRET;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type CLUSTER_UPDATE_LOCAL_TLS_SECRET_RESPONSE = any;
 
@@ -2513,12 +2805,23 @@ export type CREATE_GRANT_REQUEST = CREATE_GRANT_REQUEST__MOGENIUS_K8S_MANAGER_SR
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·29,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·29,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·29,string]
+ *     type: struct
  * ```
  *
  */
-export type CREATE_GRANT_RESPONSE = string;
+export type CREATE_GRANT_RESPONSE = CREATE_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST29_STRING;
 
 /**
  * #### Source
@@ -2564,14 +2867,24 @@ export type CREATE_NEW_WORKLOAD_REQUEST = CREATE_NEW_WORKLOAD_REQUEST__MOGENIUS_
  *                 valueType:
  *                     pointer: true
  *                     type: any
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
  *     type: struct
  * ```
  *
  */
-export type CREATE_NEW_WORKLOAD_RESPONSE = CREATE_NEW_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED|undefined;
+export type CREATE_NEW_WORKLOAD_RESPONSE = CREATE_NEW_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEDATA_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED;
 
 /**
  * #### Source
@@ -2616,12 +2929,23 @@ export type CREATE_USER_REQUEST = CREATE_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·24,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·24,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·24,string]
+ *     type: struct
  * ```
  *
  */
-export type CREATE_USER_RESPONSE = string;
+export type CREATE_USER_RESPONSE = CREATE_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST24_STRING;
 
 /**
  * #### Source
@@ -2661,12 +2985,23 @@ export type CREATE_WORKSPACE_REQUEST = CREATE_WORKSPACE_REQUEST__MOGENIUS_K8S_MA
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·18,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·18,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·18,string]
+ *     type: struct
  * ```
  *
  */
-export type CREATE_WORKSPACE_RESPONSE = string;
+export type CREATE_WORKSPACE_RESPONSE = CREATE_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST18_STRING;
 
 /**
  * #### Source
@@ -2690,12 +3025,23 @@ export type DELETE_GRANT_REQUEST = DELETE_GRANT_REQUEST__MOGENIUS_K8S_MANAGER_SR
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·32,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·32,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·32,string]
+ *     type: struct
  * ```
  *
  */
-export type DELETE_GRANT_RESPONSE = string;
+export type DELETE_GRANT_RESPONSE = DELETE_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST32_STRING;
 
 /**
  * #### Source
@@ -2719,12 +3065,23 @@ export type DELETE_USER_REQUEST = DELETE_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·27,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·27,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·27,string]
+ *     type: struct
  * ```
  *
  */
-export type DELETE_USER_RESPONSE = string;
+export type DELETE_USER_RESPONSE = DELETE_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST27_STRING;
 
 /**
  * #### Source
@@ -2759,16 +3116,26 @@ export type DELETE_WORKLOAD_REQUEST = DELETE_WORKLOAD_REQUEST__MOGENIUS_K8S_MANA
  *
  * ```yaml
  * structs:
- *     ANON_STRUCT_0:
+ *     ANON_STRUCT_1:
  *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: ANON_STRUCT_0
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,mogenius-k8s-manager/src/core.Void]
  *     type: struct
  * ```
  *
  */
-export type DELETE_WORKLOAD_RESPONSE = DELETE_WORKLOAD_RESPONSE__ANON_STRUCT_0|undefined;
+export type DELETE_WORKLOAD_RESPONSE = DELETE_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -2792,12 +3159,23 @@ export type DELETE_WORKSPACE_REQUEST = DELETE_WORKSPACE_REQUEST__MOGENIUS_K8S_MA
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·22,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·22,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·22,string]
+ *     type: struct
  * ```
  *
  */
-export type DELETE_WORKSPACE_RESPONSE = string;
+export type DELETE_WORKSPACE_RESPONSE = DELETE_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST22_STRING;
 
 /**
  * #### Source
@@ -2820,14 +3198,14 @@ export type DESCRIBE_REQUEST = DESCRIBE_REQUEST__ANON_STRUCT_0|undefined;
  *
  * ```yaml
  * structs:
- *     ANON_STRUCT_1:
+ *     ANON_STRUCT_2:
  *         properties:
  *             buildType:
  *                 type: string
  *             version:
  *                 structRef: mogenius-k8s-manager/src/version.Version
  *                 type: struct
- *     ANON_STRUCT_3:
+ *     ANON_STRUCT_4:
  *         properties: {}
  *     mogenius-k8s-manager/src/core.PatternConfig:
  *         name: mogenius-k8s-manager/src/core.PatternConfig
@@ -2836,6 +3214,8 @@ export type DESCRIBE_REQUEST = DESCRIBE_REQUEST__ANON_STRUCT_0|undefined;
  *                 type: bool
  *             deprecatedMessage:
  *                 type: string
+ *             legacyResponseLayout:
+ *                 type: bool
  *             needsUser:
  *                 type: bool
  *             requestSchema:
@@ -2850,10 +3230,10 @@ export type DESCRIBE_REQUEST = DESCRIBE_REQUEST__ANON_STRUCT_0|undefined;
  *         name: mogenius-k8s-manager/src/core.Response
  *         properties:
  *             buildInfo:
- *                 structRef: ANON_STRUCT_1
+ *                 structRef: ANON_STRUCT_2
  *                 type: struct
  *             features:
- *                 structRef: ANON_STRUCT_3
+ *                 structRef: ANON_STRUCT_4
  *                 type: struct
  *             patterns:
  *                 keyType:
@@ -2862,6 +3242,16 @@ export type DESCRIBE_REQUEST = DESCRIBE_REQUEST__ANON_STRUCT_0|undefined;
  *                 valueType:
  *                     structRef: mogenius-k8s-manager/src/core.PatternConfig
  *                     type: struct
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Response·2]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Response·2]
+ *         properties:
+ *             data:
+ *                 structRef: mogenius-k8s-manager/src/core.Response
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/schema.Schema:
  *         name: mogenius-k8s-manager/src/schema.Schema
  *         properties:
@@ -2926,12 +3316,12 @@ export type DESCRIBE_REQUEST = DESCRIBE_REQUEST__ANON_STRUCT_0|undefined;
  *             version:
  *                 type: string
  * typeInfo:
- *     structRef: mogenius-k8s-manager/src/core.Response
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Response·2]
  *     type: struct
  * ```
  *
  */
-export type DESCRIBE_RESPONSE = DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESPONSE;
+export type DESCRIBE_RESPONSE = DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_CORE_RESPONSE2;
 
 /**
  * #### Source
@@ -2965,12 +3355,23 @@ export type DESCRIBE_WORKLOAD_REQUEST = DESCRIBE_WORKLOAD_REQUEST__MOGENIUS_K8S_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]
+ *     type: struct
  * ```
  *
  */
-export type DESCRIBE_WORKLOAD_RESPONSE = string;
+export type DESCRIBE_WORKLOAD_RESPONSE = DESCRIBE_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_STRING;
 
 /**
  * #### Source
@@ -3014,12 +3415,23 @@ export type DETACH_LABELED_NETWORK_POLICY_REQUEST = DETACH_LABELED_NETWORK_POLIC
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DetachLabeledNetworkPolicyRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DetachLabeledNetworkPolicyRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DetachLabeledNetworkPolicyRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type DETACH_LABELED_NETWORK_POLICY_RESPONSE = string;
+export type DETACH_LABELED_NETWORK_POLICY_RESPONSE = DETACH_LABELED_NETWORK_POLICY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_DETACHLABELEDNETWORKPOLICYREQUEST_STRING;
 
 /**
  * #### Source
@@ -3044,16 +3456,26 @@ export type DISABLE_NETWORK_POLICY_MANAGER_REQUEST = DISABLE_NETWORK_POLICY_MANA
  *
  * ```yaml
  * structs:
- *     ANON_STRUCT_0:
+ *     ANON_STRUCT_1:
  *         properties: {}
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DisableNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DisableNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: ANON_STRUCT_0
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DisableNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
  *     type: struct
  * ```
  *
  */
-export type DISABLE_NETWORK_POLICY_MANAGER_RESPONSE = DISABLE_NETWORK_POLICY_MANAGER_RESPONSE__ANON_STRUCT_0|undefined;
+export type DISABLE_NETWORK_POLICY_MANAGER_RESPONSE = DISABLE_NETWORK_POLICY_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_DISABLENETWORKPOLICYMANAGERREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -3078,16 +3500,26 @@ export type ENFORCE_NETWORK_POLICY_MANAGER_REQUEST = ENFORCE_NETWORK_POLICY_MANA
  *
  * ```yaml
  * structs:
- *     ANON_STRUCT_0:
+ *     ANON_STRUCT_1:
  *         properties: {}
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.EnforceNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.EnforceNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: ANON_STRUCT_0
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.EnforceNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
  *     type: struct
  * ```
  *
  */
-export type ENFORCE_NETWORK_POLICY_MANAGER_RESPONSE = ENFORCE_NETWORK_POLICY_MANAGER_RESPONSE__ANON_STRUCT_0|undefined;
+export type ENFORCE_NETWORK_POLICY_MANAGER_RESPONSE = ENFORCE_NETWORK_POLICY_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_ENFORCENETWORKPOLICYMANAGERREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -3295,7 +3727,14 @@ export type EXTERNAL_SECRET_STORE_LIST_RESPONSE = EXTERNAL_SECRET_STORE_LIST_RES
 export type FILES_CHMOD_REQUEST = FILES_CHMOD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type FILES_CHMOD_RESPONSE = any;
 
@@ -3332,7 +3771,14 @@ export type FILES_CHMOD_RESPONSE = any;
 export type FILES_CHOWN_REQUEST = FILES_CHOWN_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type FILES_CHOWN_RESPONSE = any;
 
@@ -3365,7 +3811,14 @@ export type FILES_CHOWN_RESPONSE = any;
 export type FILES_CREATE_FOLDER_REQUEST = FILES_CREATE_FOLDER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type FILES_CREATE_FOLDER_RESPONSE = any;
 
@@ -3398,7 +3851,14 @@ export type FILES_CREATE_FOLDER_RESPONSE = any;
 export type FILES_DELETE_REQUEST = FILES_DELETE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type FILES_DELETE_RESPONSE = any;
 
@@ -3433,9 +3893,24 @@ export type FILES_DELETE_RESPONSE = any;
 export type FILES_DOWNLOAD_REQUEST = FILES_DOWNLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/services.FilesDownloadResponse:
+ *         name: mogenius-k8s-manager/src/services.FilesDownloadResponse
+ *         properties:
+ *             error:
+ *                 type: string
+ *             sizeInBytes:
+ *                 type: int
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/services.FilesDownloadResponse
+ *     type: struct
+ * ```
+ *
  */
-export type FILES_DOWNLOAD_RESPONSE = any;
+export type FILES_DOWNLOAD_RESPONSE = FILES_DOWNLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_FILESDOWNLOADRESPONSE;
 
 /**
  * #### Source
@@ -3464,22 +3939,42 @@ export type FILES_INFO_REQUEST = FILES_INFO_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DT
  *
  * ```yaml
  * structs:
- *     mogenius-k8s-manager/src/dtos.PersistentFileRequestDto:
- *         name: mogenius-k8s-manager/src/dtos.PersistentFileRequestDto
+ *     mogenius-k8s-manager/src/dtos.PersistentFileDto:
+ *         name: mogenius-k8s-manager/src/dtos.PersistentFileDto
  *         properties:
- *             path:
+ *             contentType:
  *                 type: string
- *             volumeName:
+ *             createdAt:
  *                 type: string
- *             volumeNamespace:
+ *             extension:
+ *                 type: string
+ *             hash:
+ *                 type: string
+ *             mimeType:
+ *                 type: string
+ *             mode:
+ *                 type: string
+ *             modifiedAt:
+ *                 type: string
+ *             name:
+ *                 type: string
+ *             relativePath:
+ *                 type: string
+ *             size:
+ *                 type: string
+ *             sizeInBytes:
+ *                 type: int
+ *             type:
+ *                 type: string
+ *             uid_gid:
  *                 type: string
  * typeInfo:
- *     structRef: mogenius-k8s-manager/src/dtos.PersistentFileRequestDto
+ *     structRef: mogenius-k8s-manager/src/dtos.PersistentFileDto
  *     type: struct
  * ```
  *
  */
-export type FILES_INFO_RESPONSE = FILES_INFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEREQUESTDTO;
+export type FILES_INFO_RESPONSE = FILES_INFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEDTO;
 
 /**
  * #### Source
@@ -3584,7 +4079,14 @@ export type FILES_LIST_RESPONSE = FILES_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_
 export type FILES_RENAME_REQUEST = FILES_RENAME_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type FILES_RENAME_RESPONSE = any;
 
@@ -3718,6 +4220,17 @@ export type GET_GRANT_REQUEST = GET_GRANT_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE
  *                 type: string
  *             kind:
  *                 type: string
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·30,*mogenius-k8s-manager/src/crds/v1alpha1.Grant]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·30,*mogenius-k8s-manager/src/crds/v1alpha1.Grant]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: mogenius-k8s-manager/src/crds/v1alpha1.Grant
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/crds/v1alpha1.Grant:
  *         name: mogenius-k8s-manager/src/crds/v1alpha1.Grant
  *         properties:
@@ -3751,13 +4264,12 @@ export type GET_GRANT_REQUEST = GET_GRANT_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     pointer: true
- *     structRef: mogenius-k8s-manager/src/crds/v1alpha1.Grant
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·30,*mogenius-k8s-manager/src/crds/v1alpha1.Grant]
  *     type: struct
  * ```
  *
  */
-export type GET_GRANT_RESPONSE = GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT|undefined;
+export type GET_GRANT_RESPONSE = GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST30_MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT;
 
 /**
  * #### Source
@@ -3893,6 +4405,18 @@ export type GET_GRANTS_REQUEST = GET_GRANTS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CO
  *                 type: string
  *             kind:
  *                 type: string
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·28,[]mogenius-k8s-manager/src/crds/v1alpha1.Grant]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·28,[]mogenius-k8s-manager/src/crds/v1alpha1.Grant]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/crds/v1alpha1.Grant
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/crds/v1alpha1.Grant:
  *         name: mogenius-k8s-manager/src/crds/v1alpha1.Grant
  *         properties:
@@ -3926,14 +4450,12 @@ export type GET_GRANTS_REQUEST = GET_GRANTS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CO
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/crds/v1alpha1.Grant
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·28,[]mogenius-k8s-manager/src/crds/v1alpha1.Grant]
+ *     type: struct
  * ```
  *
  */
-export type GET_GRANTS_RESPONSE = GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT[];
+export type GET_GRANTS_RESPONSE = GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST28_MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT;
 
 /**
  * #### Source
@@ -4009,13 +4531,23 @@ export type GET_LABELED_WORKLOAD_LIST_REQUEST = GET_LABELED_WORKLOAD_LIST_REQUES
  *                     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
  *                     type: struct
  *                 type: array
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredLabeledResourceListRequest,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredLabeledResourceListRequest,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
+ *         properties:
+ *             data:
+ *                 structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredLabeledResourceListRequest,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
  *     type: struct
  * ```
  *
  */
-export type GET_LABELED_WORKLOAD_LIST_RESPONSE = GET_LABELED_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST;
+export type GET_LABELED_WORKLOAD_LIST_RESPONSE = GET_LABELED_WORKLOAD_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETUNSTRUCTUREDLABELEDRESOURCELISTREQUEST_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST;
 
 /**
  * #### Source
@@ -4076,15 +4608,25 @@ export type GET_NAMESPACE_WORKLOAD_LIST_REQUEST = GET_NAMESPACE_WORKLOAD_LIST_RE
  *                 valueType:
  *                     pointer: true
  *                     type: any
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredNamespaceResourceListRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredNamespaceResourceListRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredNamespaceResourceListRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     type: struct
  * ```
  *
  */
-export type GET_NAMESPACE_WORKLOAD_LIST_RESPONSE = GET_NAMESPACE_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED[];
+export type GET_NAMESPACE_WORKLOAD_LIST_RESPONSE = GET_NAMESPACE_WORKLOAD_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETUNSTRUCTUREDNAMESPACERESOURCELISTREQUEST_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED;
 
 /**
  * #### Source
@@ -4227,6 +4769,17 @@ export type GET_USER_REQUEST = GET_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_R
  *                 type: string
  *             kind:
  *                 type: string
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·25,*mogenius-k8s-manager/src/crds/v1alpha1.User]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·25,*mogenius-k8s-manager/src/crds/v1alpha1.User]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: mogenius-k8s-manager/src/crds/v1alpha1.User
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/crds/v1alpha1.User:
  *         name: mogenius-k8s-manager/src/crds/v1alpha1.User
  *         properties:
@@ -4262,13 +4815,12 @@ export type GET_USER_REQUEST = GET_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_R
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     pointer: true
- *     structRef: mogenius-k8s-manager/src/crds/v1alpha1.User
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·25,*mogenius-k8s-manager/src/crds/v1alpha1.User]
  *     type: struct
  * ```
  *
  */
-export type GET_USER_RESPONSE = GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER|undefined;
+export type GET_USER_RESPONSE = GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST25_MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER;
 
 /**
  * #### Source
@@ -4412,6 +4964,18 @@ export type GET_USERS_REQUEST = GET_USERS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE
  *                 type: string
  *             kind:
  *                 type: string
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·23,[]mogenius-k8s-manager/src/crds/v1alpha1.User]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·23,[]mogenius-k8s-manager/src/crds/v1alpha1.User]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/crds/v1alpha1.User
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/crds/v1alpha1.User:
  *         name: mogenius-k8s-manager/src/crds/v1alpha1.User
  *         properties:
@@ -4447,14 +5011,12 @@ export type GET_USERS_REQUEST = GET_USERS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/crds/v1alpha1.User
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·23,[]mogenius-k8s-manager/src/crds/v1alpha1.User]
+ *     type: struct
  * ```
  *
  */
-export type GET_USERS_RESPONSE = GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER[];
+export type GET_USERS_RESPONSE = GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST23_MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER;
 
 /**
  * #### Source
@@ -4499,14 +5061,24 @@ export type GET_WORKLOAD_REQUEST = GET_WORKLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SR
  *                 valueType:
  *                     pointer: true
  *                     type: any
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
  *     type: struct
  * ```
  *
  */
-export type GET_WORKLOAD_RESPONSE = GET_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED|undefined;
+export type GET_WORKLOAD_RESPONSE = GET_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED;
 
 /**
  * #### Source
@@ -4540,12 +5112,23 @@ export type GET_WORKLOAD_EXAMPLE_REQUEST = GET_WORKLOAD_EXAMPLE_REQUEST__MOGENIU
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]
+ *     type: struct
  * ```
  *
  */
-export type GET_WORKLOAD_EXAMPLE_RESPONSE = string;
+export type GET_WORKLOAD_EXAMPLE_RESPONSE = GET_WORKLOAD_EXAMPLE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_STRING;
 
 /**
  * #### Source
@@ -4604,13 +5187,23 @@ export type GET_WORKLOAD_LIST_REQUEST = GET_WORKLOAD_LIST_REQUEST__MOGENIUS_K8S_
  *                     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
  *                     type: struct
  *                 type: array
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceEntry,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceEntry,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
+ *         properties:
+ *             data:
+ *                 structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceEntry,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
  *     type: struct
  * ```
  *
  */
-export type GET_WORKLOAD_LIST_RESPONSE = GET_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST;
+export type GET_WORKLOAD_LIST_RESPONSE = GET_WORKLOAD_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST;
 
 /**
  * #### Source
@@ -4868,6 +5461,18 @@ export type GET_WORKLOAD_STATUS_REQUEST = GET_WORKLOAD_STATUS_REQUEST__MOGENIUS_
  *                 type: string
  *             kind:
  *                 type: string
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetWorkloadStatusRequest,[]mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetWorkloadStatusRequest,[]mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto:
  *         name: mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto
  *         properties:
@@ -4917,14 +5522,12 @@ export type GET_WORKLOAD_STATUS_REQUEST = GET_WORKLOAD_STATUS_REQUEST__MOGENIUS_
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetWorkloadStatusRequest,[]mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto]
+ *     type: struct
  * ```
  *
  */
-export type GET_WORKLOAD_STATUS_RESPONSE = GET_WORKLOAD_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_WORKLOADSTATUSDTO[];
+export type GET_WORKLOAD_STATUS_RESPONSE = GET_WORKLOAD_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETWORKLOADSTATUSREQUEST_MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_WORKLOADSTATUSDTO;
 
 /**
  * #### Source
@@ -4968,6 +5571,17 @@ export type GET_WORKSPACE_REQUEST = GET_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_
  *                     structRef: mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier
  *                     type: struct
  *                 type: array
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·19,*mogenius-k8s-manager/src/core.GetWorkspaceResult]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·19,*mogenius-k8s-manager/src/core.GetWorkspaceResult]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: mogenius-k8s-manager/src/core.GetWorkspaceResult
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier:
  *         name: mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier
  *         properties:
@@ -4981,13 +5595,12 @@ export type GET_WORKSPACE_REQUEST = GET_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     pointer: true
- *     structRef: mogenius-k8s-manager/src/core.GetWorkspaceResult
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·19,*mogenius-k8s-manager/src/core.GetWorkspaceResult]
  *     type: struct
  * ```
  *
  */
-export type GET_WORKSPACE_RESPONSE = GET_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT|undefined;
+export type GET_WORKSPACE_RESPONSE = GET_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST19_MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT;
 
 /**
  * #### Source
@@ -5029,6 +5642,18 @@ export type GET_WORKSPACES_REQUEST = GET_WORKSPACES_REQUEST__ANON_STRUCT_0|undef
  *                     structRef: mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier
  *                     type: struct
  *                 type: array
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/core.GetWorkspaceResult]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/core.GetWorkspaceResult]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/core.GetWorkspaceResult
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier:
  *         name: mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier
  *         properties:
@@ -5042,14 +5667,12 @@ export type GET_WORKSPACES_REQUEST = GET_WORKSPACES_REQUEST__ANON_STRUCT_0|undef
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/core.GetWorkspaceResult
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/core.GetWorkspaceResult]
+ *     type: struct
  * ```
  *
  */
-export type GET_WORKSPACES_RESPONSE = GET_WORKSPACES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT[];
+export type GET_WORKSPACES_RESPONSE = GET_WORKSPACES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT;
 
 /**
  * #### Source
@@ -5114,15 +5737,25 @@ export type GET_WORKSPACE_WORKLOADS_REQUEST = GET_WORKSPACE_WORKLOADS_REQUEST__M
  *                 valueType:
  *                     pointer: true
  *                     type: any
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·33,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·33,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·33,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     type: struct
  * ```
  *
  */
-export type GET_WORKSPACE_WORKLOADS_RESPONSE = GET_WORKSPACE_WORKLOADS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED[];
+export type GET_WORKSPACE_WORKLOADS_RESPONSE = GET_WORKSPACE_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST33_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED;
 
 /**
  * #### Source
@@ -5144,12 +5777,23 @@ export type INSTALL_CERT_MANAGER_REQUEST = INSTALL_CERT_MANAGER_REQUEST__ANON_ST
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type INSTALL_CERT_MANAGER_RESPONSE = string;
+export type INSTALL_CERT_MANAGER_RESPONSE = INSTALL_CERT_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -5173,12 +5817,23 @@ export type INSTALL_CLUSTER_ISSUER_REQUEST = INSTALL_CLUSTER_ISSUER_REQUEST__MOG
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·6,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·6,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·6,string]
+ *     type: struct
  * ```
  *
  */
-export type INSTALL_CLUSTER_ISSUER_RESPONSE = string;
+export type INSTALL_CLUSTER_ISSUER_RESPONSE = INSTALL_CLUSTER_ISSUER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST6_STRING;
 
 /**
  * #### Source
@@ -5200,12 +5855,23 @@ export type INSTALL_INGRESS_CONTROLLER_TRAEFIK_REQUEST = INSTALL_INGRESS_CONTROL
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type INSTALL_INGRESS_CONTROLLER_TRAEFIK_RESPONSE = string;
+export type INSTALL_INGRESS_CONTROLLER_TRAEFIK_RESPONSE = INSTALL_INGRESS_CONTROLLER_TRAEFIK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -5227,12 +5893,23 @@ export type INSTALL_KEPLER_REQUEST = INSTALL_KEPLER_REQUEST__ANON_STRUCT_0|undef
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type INSTALL_KEPLER_RESPONSE = string;
+export type INSTALL_KEPLER_RESPONSE = INSTALL_KEPLER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -5254,12 +5931,23 @@ export type INSTALL_METALLB_REQUEST = INSTALL_METALLB_REQUEST__ANON_STRUCT_0|und
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type INSTALL_METALLB_RESPONSE = string;
+export type INSTALL_METALLB_RESPONSE = INSTALL_METALLB_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -5281,22 +5969,65 @@ export type INSTALL_METRICS_SERVER_REQUEST = INSTALL_METRICS_SERVER_REQUEST__ANO
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type INSTALL_METRICS_SERVER_RESPONSE = string;
+export type INSTALL_METRICS_SERVER_RESPONSE = INSTALL_METRICS_SERVER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_0:
+ *         properties: {}
+ * typeInfo:
+ *     pointer: true
+ *     structRef: ANON_STRUCT_0
+ *     type: struct
+ * ```
+ *
  */
-export type K8SNOTIFICATION_REQUEST = any;
+export type K8SNOTIFICATION_REQUEST = K8SNOTIFICATION_REQUEST__ANON_STRUCT_0|undefined;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type K8SNOTIFICATION_RESPONSE = any;
+export type K8SNOTIFICATION_RESPONSE = K8SNOTIFICATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -5487,6 +6218,18 @@ export type LIST_ALL_NETWORK_POLICIES_REQUEST = LIST_ALL_NETWORK_POLICIES_REQUES
  *                     structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
  *                     type: struct
  *                 type: array
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto:
  *         name: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
  *         properties:
@@ -5499,14 +6242,12 @@ export type LIST_ALL_NETWORK_POLICIES_REQUEST = LIST_ALL_NETWORK_POLICIES_REQUES
  *             type:
  *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+ *     type: struct
  * ```
  *
  */
-export type LIST_ALL_NETWORK_POLICIES_RESPONSE = LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE[];
+export type LIST_ALL_NETWORK_POLICIES_RESPONSE = LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE;
 
 /**
  * #### Source
@@ -5529,6 +6270,18 @@ export type LIST_ALL_WORKLOADS_REQUEST = LIST_ALL_WORKLOADS_REQUEST__ANON_STRUCT
  *
  * ```yaml
  * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/utils.ResourceEntry]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/utils.ResourceEntry]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/utils.ResourceEntry
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/utils.ResourceEntry:
  *         name: mogenius-k8s-manager/src/utils.ResourceEntry
  *         properties:
@@ -5544,14 +6297,12 @@ export type LIST_ALL_WORKLOADS_REQUEST = LIST_ALL_WORKLOADS_REQUEST__ANON_STRUCT
  *             version:
  *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/utils.ResourceEntry
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/utils.ResourceEntry]
+ *     type: struct
  * ```
  *
  */
-export type LIST_ALL_WORKLOADS_RESPONSE = LIST_ALL_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY[];
+export type LIST_ALL_WORKLOADS_RESPONSE = LIST_ALL_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY;
 
 /**
  * #### Source
@@ -5704,15 +6455,25 @@ export type LIST_CONFLICTING_NETWORK_POLICIES_REQUEST = LIST_CONFLICTING_NETWORK
  *             spec:
  *                 structRef: k8s.io/api/networking/v1.NetworkPolicySpec
  *                 type: struct
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListConflictingNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListConflictingNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListConflictingNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto]
+ *     type: struct
  * ```
  *
  */
-export type LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE = LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO[];
+export type LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE = LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONFLICTINGNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO;
 
 /**
  * #### Source
@@ -5755,6 +6516,16 @@ export type LIST_CONTROLLER_NETWORK_POLICIES_REQUEST = LIST_CONTROLLER_NETWORK_P
  *                 type: array
  *             namespaceName:
  *                 type: string
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesRequest,mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesRequest,mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse]
+ *         properties:
+ *             data:
+ *                 structRef: mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto:
  *         name: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
  *         properties:
@@ -5767,12 +6538,12 @@ export type LIST_CONTROLLER_NETWORK_POLICIES_REQUEST = LIST_CONTROLLER_NETWORK_P
  *             type:
  *                 type: string
  * typeInfo:
- *     structRef: mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesRequest,mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse]
  *     type: struct
  * ```
  *
  */
-export type LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE = LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONTROLLERLABELEDNETWORKPOLICIESRESPONSE;
+export type LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE = LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONTROLLERLABELEDNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONTROLLERLABELEDNETWORKPOLICIESRESPONSE;
 
 /**
  * #### Source
@@ -5797,9 +6568,63 @@ export type LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE = LIST_CONTROLLER_NETWORK_
 export type LIST_CRONJOB_JOBS_REQUEST = LIST_CRONJOB_JOBS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/kubernetes.JobInfo:
+ *         name: mogenius-k8s-manager/src/kubernetes.JobInfo
+ *         properties:
+ *             durationInMs:
+ *                 type: int
+ *             jobId:
+ *                 type: string
+ *             jobName:
+ *                 type: string
+ *             message:
+ *                 pointer: true
+ *                 structRef: mogenius-k8s-manager/src/kubernetes.StatusMessage
+ *                 type: struct
+ *             podName:
+ *                 type: string
+ *             schedule:
+ *                 structRef: time.Time
+ *                 type: struct
+ *             status:
+ *                 type: string
+ *             tileType:
+ *                 type: string
+ *     mogenius-k8s-manager/src/kubernetes.ListJobInfoResponse:
+ *         name: mogenius-k8s-manager/src/kubernetes.ListJobInfoResponse
+ *         properties:
+ *             controllerName:
+ *                 type: string
+ *             jobsInfo:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/kubernetes.JobInfo
+ *                     type: struct
+ *                 type: array
+ *             namespaceName:
+ *                 type: string
+ *             projectId:
+ *                 type: string
+ *     mogenius-k8s-manager/src/kubernetes.StatusMessage:
+ *         name: mogenius-k8s-manager/src/kubernetes.StatusMessage
+ *         properties:
+ *             message:
+ *                 type: string
+ *             reason:
+ *                 type: string
+ *     time.Time:
+ *         name: time.Time
+ *         properties: {}
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/kubernetes.ListJobInfoResponse
+ *     type: struct
+ * ```
+ *
  */
-export type LIST_CRONJOB_JOBS_RESPONSE = any;
+export type LIST_CRONJOB_JOBS_RESPONSE = LIST_CRONJOB_JOBS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_LISTJOBINFORESPONSE;
 
 /**
  * #### Source
@@ -5822,6 +6647,18 @@ export type LIST_LABELED_NETWORK_POLICY_PORTS_REQUEST = LIST_LABELED_NETWORK_POL
  *
  * ```yaml
  * structs:
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto:
  *         name: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
  *         properties:
@@ -5834,14 +6671,12 @@ export type LIST_LABELED_NETWORK_POLICY_PORTS_REQUEST = LIST_LABELED_NETWORK_POL
  *             type:
  *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto]
+ *     type: struct
  * ```
  *
  */
-export type LIST_LABELED_NETWORK_POLICY_PORTS_RESPONSE = LIST_LABELED_NETWORK_POLICY_PORTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO[];
+export type LIST_LABELED_NETWORK_POLICY_PORTS_RESPONSE = LIST_LABELED_NETWORK_POLICY_PORTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO;
 
 /**
  * #### Source
@@ -6034,6 +6869,18 @@ export type LIST_NAMESPACE_NETWORK_POLICIES_REQUEST = LIST_NAMESPACE_NETWORK_POL
  *                     structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
  *                     type: struct
  *                 type: array
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto:
  *         name: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
  *         properties:
@@ -6046,14 +6893,12 @@ export type LIST_NAMESPACE_NETWORK_POLICIES_REQUEST = LIST_NAMESPACE_NETWORK_POL
  *             type:
  *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+ *     type: struct
  * ```
  *
  */
-export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE = LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE[];
+export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE = LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNAMESPACELABELEDNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE;
 
 /**
  * #### Source
@@ -6227,15 +7072,25 @@ export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_REQUEST = LIST_ONLY_NAMESPACE_N
  *                     structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
  *                     type: struct
  *                 type: array
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace]
+ *     type: struct
  * ```
  *
  */
-export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE = LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTMANAGEDANDUNMANAGEDNETWORKPOLICYNAMESPACE[];
+export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE = LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNAMESPACELABELEDNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTMANAGEDANDUNMANAGEDNETWORKPOLICYNAMESPACE;
 
 /**
  * #### Source
@@ -6268,9 +7123,30 @@ export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE = LIST_ONLY_NAMESPACE_
 export type LIVE_STREAM_NODES_CPU_REQUEST = LIVE_STREAM_NODES_CPU_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type LIVE_STREAM_NODES_CPU_RESPONSE = any;
+export type LIVE_STREAM_NODES_CPU_RESPONSE = LIVE_STREAM_NODES_CPU_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -6303,9 +7179,30 @@ export type LIVE_STREAM_NODES_CPU_RESPONSE = any;
 export type LIVE_STREAM_NODES_MEMORY_REQUEST = LIVE_STREAM_NODES_MEMORY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type LIVE_STREAM_NODES_MEMORY_RESPONSE = any;
+export type LIVE_STREAM_NODES_MEMORY_RESPONSE = LIVE_STREAM_NODES_MEMORY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -6338,9 +7235,30 @@ export type LIVE_STREAM_NODES_MEMORY_RESPONSE = any;
 export type LIVE_STREAM_NODES_TRAFFIC_REQUEST = LIVE_STREAM_NODES_TRAFFIC_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type LIVE_STREAM_NODES_TRAFFIC_RESPONSE = any;
+export type LIVE_STREAM_NODES_TRAFFIC_RESPONSE = LIVE_STREAM_NODES_TRAFFIC_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -6373,9 +7291,30 @@ export type LIVE_STREAM_NODES_TRAFFIC_RESPONSE = any;
 export type LIVE_STREAM_POD_CPU_REQUEST = LIVE_STREAM_POD_CPU_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type LIVE_STREAM_POD_CPU_RESPONSE = any;
+export type LIVE_STREAM_POD_CPU_RESPONSE = LIVE_STREAM_POD_CPU_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -6408,9 +7347,30 @@ export type LIVE_STREAM_POD_CPU_RESPONSE = any;
 export type LIVE_STREAM_POD_MEMORY_REQUEST = LIVE_STREAM_POD_MEMORY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type LIVE_STREAM_POD_MEMORY_RESPONSE = any;
+export type LIVE_STREAM_POD_MEMORY_RESPONSE = LIVE_STREAM_POD_MEMORY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -6443,9 +7403,30 @@ export type LIVE_STREAM_POD_MEMORY_RESPONSE = any;
 export type LIVE_STREAM_POD_TRAFFIC_REQUEST = LIVE_STREAM_POD_TRAFFIC_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type LIVE_STREAM_POD_TRAFFIC_RESPONSE = any;
+export type LIVE_STREAM_POD_TRAFFIC_RESPONSE = LIVE_STREAM_POD_TRAFFIC_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -6478,7 +7459,14 @@ export type LIVE_STREAM_POD_TRAFFIC_RESPONSE = any;
 export type LIVE_STREAM_WORKSPACE_CPU_REQUEST = LIVE_STREAM_WORKSPACE_CPU_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type LIVE_STREAM_WORKSPACE_CPU_RESPONSE = any;
 
@@ -6513,7 +7501,14 @@ export type LIVE_STREAM_WORKSPACE_CPU_RESPONSE = any;
 export type LIVE_STREAM_WORKSPACE_MEMORY_REQUEST = LIVE_STREAM_WORKSPACE_MEMORY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type LIVE_STREAM_WORKSPACE_MEMORY_RESPONSE = any;
 
@@ -6548,7 +7543,14 @@ export type LIVE_STREAM_WORKSPACE_MEMORY_RESPONSE = any;
 export type LIVE_STREAM_WORKSPACE_TRAFFIC_REQUEST = LIVE_STREAM_WORKSPACE_TRAFFIC_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * typeInfo:
+ *     pointer: true
+ *     type: any
+ * ```
+ *
  */
 export type LIVE_STREAM_WORKSPACE_TRAFFIC_RESPONSE = any;
 
@@ -6665,25 +7667,13 @@ export type NAMESPACE_BACKUP_REQUEST = NAMESPACE_BACKUP_REQUEST__MOGENIUS_K8S_MA
  * #### Source
  *
  * ```yaml
- * structs:
- *     mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse:
- *         name: mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse
- *         properties:
- *             data:
- *                 type: string
- *             messages:
- *                 elementType:
- *                     type: string
- *                 type: array
- *             namespaceName:
- *                 type: string
  * typeInfo:
- *     structRef: mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse
- *     type: struct
+ *     pointer: true
+ *     type: any
  * ```
  *
  */
-export type NAMESPACE_BACKUP_RESPONSE = NAMESPACE_BACKUP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_NAMESPACEBACKUPRESPONSE;
+export type NAMESPACE_BACKUP_RESPONSE = any;
 
 /**
  * #### Source
@@ -6954,9 +7944,20 @@ export type NAMESPACE_DELETE_REQUEST = NAMESPACE_DELETE_REQUEST__MOGENIUS_K8S_MA
 export type NAMESPACE_DELETE_RESPONSE = NAMESPACE_DELETE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_JOB|undefined;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_0:
+ *         properties: {}
+ * typeInfo:
+ *     pointer: true
+ *     structRef: ANON_STRUCT_0
+ *     type: struct
+ * ```
+ *
  */
-export type PRINT_CURRENT_CONFIG_REQUEST = any;
+export type PRINT_CURRENT_CONFIG_REQUEST = PRINT_CURRENT_CONFIG_REQUEST__ANON_STRUCT_0|undefined;
 
 /**
  * #### Source
@@ -6999,13 +8000,24 @@ export type PROMETHEUS_CHARTS_ADD_REQUEST = PROMETHEUS_CHARTS_ADD_REQUEST__MOGEN
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]
+ *     type: struct
  * ```
  *
  */
-export type PROMETHEUS_CHARTS_ADD_RESPONSE = string|undefined;
+export type PROMETHEUS_CHARTS_ADD_RESPONSE = PROMETHEUS_CHARTS_ADD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS_STRING;
 
 /**
  * #### Source
@@ -7048,17 +8060,27 @@ export type PROMETHEUS_CHARTS_GET_REQUEST = PROMETHEUS_CHARTS_GET_REQUEST__MOGEN
  *                 type: string
  *             step:
  *                 type: int
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*mogenius-k8s-manager/src/core.PrometheusStoreObject]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*mogenius-k8s-manager/src/core.PrometheusStoreObject]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: mogenius-k8s-manager/src/core.PrometheusStoreObject
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     time.Time:
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     pointer: true
- *     structRef: mogenius-k8s-manager/src/core.PrometheusStoreObject
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*mogenius-k8s-manager/src/core.PrometheusStoreObject]
  *     type: struct
  * ```
  *
  */
-export type PROMETHEUS_CHARTS_GET_RESPONSE = PROMETHEUS_CHARTS_GET_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT|undefined;
+export type PROMETHEUS_CHARTS_GET_RESPONSE = PROMETHEUS_CHARTS_GET_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS_MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT;
 
 /**
  * #### Source
@@ -7095,20 +8117,30 @@ export type PROMETHEUS_CHARTS_LIST_REQUEST = PROMETHEUS_CHARTS_LIST_REQUEST__MOG
  *                 type: string
  *             step:
  *                 type: int
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedisList,map[string]mogenius-k8s-manager/src/core.PrometheusStoreObject]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedisList,map[string]mogenius-k8s-manager/src/core.PrometheusStoreObject]
+ *         properties:
+ *             data:
+ *                 keyType:
+ *                     type: string
+ *                 type: map
+ *                 valueType:
+ *                     structRef: mogenius-k8s-manager/src/core.PrometheusStoreObject
+ *                     type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  *     time.Time:
  *         name: time.Time
  *         properties: {}
  * typeInfo:
- *     keyType:
- *         type: string
- *     type: map
- *     valueType:
- *         structRef: mogenius-k8s-manager/src/core.PrometheusStoreObject
- *         type: struct
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedisList,map[string]mogenius-k8s-manager/src/core.PrometheusStoreObject]
+ *     type: struct
  * ```
  *
  */
-export type PROMETHEUS_CHARTS_LIST_RESPONSE = Record<string, PROMETHEUS_CHARTS_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT>;
+export type PROMETHEUS_CHARTS_LIST_RESPONSE = PROMETHEUS_CHARTS_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDISLIST_MAPSTRINGMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT;
 
 /**
  * #### Source
@@ -7140,13 +8172,24 @@ export type PROMETHEUS_CHARTS_REMOVE_REQUEST = PROMETHEUS_CHARTS_REMOVE_REQUEST_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]
+ *     type: struct
  * ```
  *
  */
-export type PROMETHEUS_CHARTS_REMOVE_RESPONSE = string|undefined;
+export type PROMETHEUS_CHARTS_REMOVE_RESPONSE = PROMETHEUS_CHARTS_REMOVE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS_STRING;
 
 /**
  * #### Source
@@ -7182,12 +8225,23 @@ export type PROMETHEUS_IS_REACHABLE_REQUEST = PROMETHEUS_IS_REACHABLE_REQUEST__M
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,bool]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,bool]
+ *         properties:
+ *             data:
+ *                 type: bool
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: bool
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,bool]
+ *     type: struct
  * ```
  *
  */
-export type PROMETHEUS_IS_REACHABLE_RESPONSE = boolean;
+export type PROMETHEUS_IS_REACHABLE_RESPONSE = PROMETHEUS_IS_REACHABLE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST_BOOL;
 
 /**
  * #### Source
@@ -7224,7 +8278,7 @@ export type PROMETHEUS_QUERY_REQUEST = PROMETHEUS_QUERY_REQUEST__MOGENIUS_K8S_MA
  *
  * ```yaml
  * structs:
- *     ANON_STRUCT_1:
+ *     ANON_STRUCT_2:
  *         properties:
  *             result:
  *                 elementType:
@@ -7237,7 +8291,7 @@ export type PROMETHEUS_QUERY_REQUEST = PROMETHEUS_QUERY_REQUEST__MOGENIUS_K8S_MA
  *         name: mogenius-k8s-manager/src/core.PrometheusQueryResponse
  *         properties:
  *             data:
- *                 structRef: ANON_STRUCT_1
+ *                 structRef: ANON_STRUCT_2
  *                 type: struct
  *             error:
  *                 type: string
@@ -7245,14 +8299,24 @@ export type PROMETHEUS_QUERY_REQUEST = PROMETHEUS_QUERY_REQUEST__MOGENIUS_K8S_MA
  *                 type: string
  *             status:
  *                 type: string
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,*mogenius-k8s-manager/src/core.PrometheusQueryResponse]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,*mogenius-k8s-manager/src/core.PrometheusQueryResponse]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: mogenius-k8s-manager/src/core.PrometheusQueryResponse
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: mogenius-k8s-manager/src/core.PrometheusQueryResponse
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,*mogenius-k8s-manager/src/core.PrometheusQueryResponse]
  *     type: struct
  * ```
  *
  */
-export type PROMETHEUS_QUERY_RESPONSE = PROMETHEUS_QUERY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSQUERYRESPONSE|undefined;
+export type PROMETHEUS_QUERY_RESPONSE = PROMETHEUS_QUERY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSQUERYRESPONSE;
 
 /**
  * #### Source
@@ -7288,14 +8352,25 @@ export type PROMETHEUS_VALUES_REQUEST = PROMETHEUS_VALUES_REQUEST__MOGENIUS_K8S_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,[]string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,[]string]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     type: string
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         type: string
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,[]string]
+ *     type: struct
  * ```
  *
  */
-export type PROMETHEUS_VALUES_RESPONSE = string[];
+export type PROMETHEUS_VALUES_RESPONSE = PROMETHEUS_VALUES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST_STRING;
 
 /**
  * #### Source
@@ -7319,12 +8394,23 @@ export type REMOVE_CONFLICTING_NETWORK_POLICIES_REQUEST = REMOVE_CONFLICTING_NET
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveConflictingNetworkPoliciesRequest,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveConflictingNetworkPoliciesRequest,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveConflictingNetworkPoliciesRequest,string]
+ *     type: struct
  * ```
  *
  */
-export type REMOVE_CONFLICTING_NETWORK_POLICIES_RESPONSE = string;
+export type REMOVE_CONFLICTING_NETWORK_POLICIES_RESPONSE = REMOVE_CONFLICTING_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_REMOVECONFLICTINGNETWORKPOLICIESREQUEST_STRING;
 
 /**
  * #### Source
@@ -7353,16 +8439,26 @@ export type REMOVE_UNMANAGED_NETWORK_POLICIES_REQUEST = REMOVE_UNMANAGED_NETWORK
  *
  * ```yaml
  * structs:
- *     ANON_STRUCT_0:
+ *     ANON_STRUCT_1:
  *         properties: {}
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveUnmanagedNetworkPoliciesRequest,mogenius-k8s-manager/src/core.Void]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveUnmanagedNetworkPoliciesRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: ANON_STRUCT_0
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveUnmanagedNetworkPoliciesRequest,mogenius-k8s-manager/src/core.Void]
  *     type: struct
  * ```
  *
  */
-export type REMOVE_UNMANAGED_NETWORK_POLICIES_RESPONSE = REMOVE_UNMANAGED_NETWORK_POLICIES_RESPONSE__ANON_STRUCT_0|undefined;
+export type REMOVE_UNMANAGED_NETWORK_POLICIES_RESPONSE = REMOVE_UNMANAGED_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_REMOVEUNMANAGEDNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -8639,9 +9735,30 @@ export type SERVICE_DELETE_RESPONSE = SERVICE_DELETE_RESPONSE__MOGENIUS_K8S_MANA
 export type SERVICE_EXEC_SH_CONNECTION_REQUEST_REQUEST = SERVICE_EXEC_SH_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_PODCMDCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type SERVICE_EXEC_SH_CONNECTION_REQUEST_RESPONSE = any;
+export type SERVICE_EXEC_SH_CONNECTION_REQUEST_RESPONSE = SERVICE_EXEC_SH_CONNECTION_REQUEST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_PODCMDCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -8690,9 +9807,30 @@ export type SERVICE_EXEC_SH_CONNECTION_REQUEST_RESPONSE = any;
 export type SERVICE_LOG_STREAM_CONNECTION_REQUEST_REQUEST = SERVICE_LOG_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_PODCMDCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type SERVICE_LOG_STREAM_CONNECTION_REQUEST_RESPONSE = any;
+export type SERVICE_LOG_STREAM_CONNECTION_REQUEST_RESPONSE = SERVICE_LOG_STREAM_CONNECTION_REQUEST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_PODCMDCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -10909,9 +12047,30 @@ export type SERVICE_PODS_RESPONSE = SERVICE_PODS_RESPONSE__K8S_IO_API_CORE_V1_PO
 export type SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_REQUEST = SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_PODEVENTCONNECTIONREQUEST;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_1:
+ *         properties: {}
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodEventConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodEventConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
+ * typeInfo:
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodEventConnectionRequest,mogenius-k8s-manager/src/core.Void]
+ *     type: struct
+ * ```
+ *
  */
-export type SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_RESPONSE = any;
+export type SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_RESPONSE = SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_PODEVENTCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -15656,68 +16815,13 @@ export type SERVICE_UPDATE_SERVICE_REQUEST = SERVICE_UPDATE_SERVICE_REQUEST__MOG
  * #### Source
  *
  * ```yaml
- * structs:
- *     mogenius-k8s-manager/src/structs.Command:
- *         name: mogenius-k8s-manager/src/structs.Command
- *         properties:
- *             command:
- *                 type: string
- *             finished:
- *                 structRef: time.Time
- *                 type: struct
- *             id:
- *                 type: string
- *             message:
- *                 type: string
- *             started:
- *                 structRef: time.Time
- *                 type: struct
- *             state:
- *                 type: string
- *             title:
- *                 type: string
- *     mogenius-k8s-manager/src/structs.Job:
- *         name: mogenius-k8s-manager/src/structs.Job
- *         properties:
- *             commands:
- *                 elementType:
- *                     pointer: true
- *                     structRef: mogenius-k8s-manager/src/structs.Command
- *                     type: struct
- *                 type: array
- *             containerName:
- *                 type: string
- *             controllerName:
- *                 type: string
- *             finished:
- *                 structRef: time.Time
- *                 type: struct
- *             id:
- *                 type: string
- *             message:
- *                 type: string
- *             namespaceName:
- *                 type: string
- *             projectId:
- *                 type: string
- *             started:
- *                 structRef: time.Time
- *                 type: struct
- *             state:
- *                 type: string
- *             title:
- *                 type: string
- *     time.Time:
- *         name: time.Time
- *         properties: {}
  * typeInfo:
  *     pointer: true
- *     structRef: mogenius-k8s-manager/src/structs.Job
- *     type: struct
+ *     type: any
  * ```
  *
  */
-export type SERVICE_UPDATE_SERVICE_RESPONSE = SERVICE_UPDATE_SERVICE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_JOB|undefined;
+export type SERVICE_UPDATE_SERVICE_RESPONSE = any;
 
 /**
  * #### Source
@@ -16129,15 +17233,25 @@ export type STATS_WORKSPACE_CPU_UTILIZATION_REQUEST = STATS_WORKSPACE_CPU_UTILIZ
  *                 type: string
  *             value:
  *                 type: float
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/core.GenericChartEntry
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/core.GenericChartEntry
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+ *     type: struct
  * ```
  *
  */
-export type STATS_WORKSPACE_CPU_UTILIZATION_RESPONSE = STATS_WORKSPACE_CPU_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY[];
+export type STATS_WORKSPACE_CPU_UTILIZATION_RESPONSE = STATS_WORKSPACE_CPU_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST9_MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY;
 
 /**
  * #### Source
@@ -16171,15 +17285,25 @@ export type STATS_WORKSPACE_MEMORY_UTILIZATION_REQUEST = STATS_WORKSPACE_MEMORY_
  *                 type: string
  *             value:
  *                 type: float
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/core.GenericChartEntry
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/core.GenericChartEntry
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+ *     type: struct
  * ```
  *
  */
-export type STATS_WORKSPACE_MEMORY_UTILIZATION_RESPONSE = STATS_WORKSPACE_MEMORY_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY[];
+export type STATS_WORKSPACE_MEMORY_UTILIZATION_RESPONSE = STATS_WORKSPACE_MEMORY_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST9_MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY;
 
 /**
  * #### Source
@@ -16213,15 +17337,25 @@ export type STATS_WORKSPACE_TRAFFIC_UTILIZATION_REQUEST = STATS_WORKSPACE_TRAFFI
  *                 type: string
  *             value:
  *                 type: float
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+ *         properties:
+ *             data:
+ *                 elementType:
+ *                     structRef: mogenius-k8s-manager/src/core.GenericChartEntry
+ *                     type: struct
+ *                 type: array
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     elementType:
- *         structRef: mogenius-k8s-manager/src/core.GenericChartEntry
- *         type: struct
- *     type: array
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+ *     type: struct
  * ```
  *
  */
-export type STATS_WORKSPACE_TRAFFIC_UTILIZATION_RESPONSE = STATS_WORKSPACE_TRAFFIC_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY[];
+export type STATS_WORKSPACE_TRAFFIC_UTILIZATION_RESPONSE = STATS_WORKSPACE_TRAFFIC_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST9_MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY;
 
 /**
  * #### Source
@@ -16462,9 +17596,20 @@ export type STORAGE_STATUS_REQUEST = STORAGE_STATUS_REQUEST__MOGENIUS_K8S_MANAGE
 export type STORAGE_STATUS_RESPONSE = STORAGE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NFSSTATUSRESPONSE;
 
 /**
- * api schema has not been defined by the operator
+ * #### Source
+ *
+ * ```yaml
+ * structs:
+ *     ANON_STRUCT_0:
+ *         properties: {}
+ * typeInfo:
+ *     pointer: true
+ *     structRef: ANON_STRUCT_0
+ *     type: struct
+ * ```
+ *
  */
-export type SYSTEM_CHECK_REQUEST = any;
+export type SYSTEM_CHECK_REQUEST = SYSTEM_CHECK_REQUEST__ANON_STRUCT_0|undefined;
 
 /**
  * #### Source
@@ -16566,14 +17711,24 @@ export type TRIGGER_WORKLOAD_REQUEST = TRIGGER_WORKLOAD_REQUEST__MOGENIUS_K8S_MA
  *                 valueType:
  *                     pointer: true
  *                     type: any
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
  *     type: struct
  * ```
  *
  */
-export type TRIGGER_WORKLOAD_RESPONSE = TRIGGER_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED|undefined;
+export type TRIGGER_WORKLOAD_RESPONSE = TRIGGER_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED;
 
 /**
  * #### Source
@@ -16595,12 +17750,23 @@ export type UNINSTALL_CERT_MANAGER_REQUEST = UNINSTALL_CERT_MANAGER_REQUEST__ANO
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UNINSTALL_CERT_MANAGER_RESPONSE = string;
+export type UNINSTALL_CERT_MANAGER_RESPONSE = UNINSTALL_CERT_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -16622,12 +17788,23 @@ export type UNINSTALL_CLUSTER_ISSUER_REQUEST = UNINSTALL_CLUSTER_ISSUER_REQUEST_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UNINSTALL_CLUSTER_ISSUER_RESPONSE = string;
+export type UNINSTALL_CLUSTER_ISSUER_RESPONSE = UNINSTALL_CLUSTER_ISSUER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -16649,12 +17826,23 @@ export type UNINSTALL_INGRESS_CONTROLLER_TRAEFIK_REQUEST = UNINSTALL_INGRESS_CON
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UNINSTALL_INGRESS_CONTROLLER_TRAEFIK_RESPONSE = string;
+export type UNINSTALL_INGRESS_CONTROLLER_TRAEFIK_RESPONSE = UNINSTALL_INGRESS_CONTROLLER_TRAEFIK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -16676,12 +17864,23 @@ export type UNINSTALL_KEPLER_REQUEST = UNINSTALL_KEPLER_REQUEST__ANON_STRUCT_0|u
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UNINSTALL_KEPLER_RESPONSE = string;
+export type UNINSTALL_KEPLER_RESPONSE = UNINSTALL_KEPLER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -16703,12 +17902,23 @@ export type UNINSTALL_METALLB_REQUEST = UNINSTALL_METALLB_REQUEST__ANON_STRUCT_0
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UNINSTALL_METALLB_RESPONSE = string;
+export type UNINSTALL_METALLB_RESPONSE = UNINSTALL_METALLB_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -16730,12 +17940,23 @@ export type UNINSTALL_METRICS_SERVER_REQUEST = UNINSTALL_METRICS_SERVER_REQUEST_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UNINSTALL_METRICS_SERVER_RESPONSE = string;
+export type UNINSTALL_METRICS_SERVER_RESPONSE = UNINSTALL_METRICS_SERVER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -16767,12 +17988,23 @@ export type UPDATE_GRANT_REQUEST = UPDATE_GRANT_REQUEST__MOGENIUS_K8S_MANAGER_SR
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·31,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·31,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·31,string]
+ *     type: struct
  * ```
  *
  */
-export type UPDATE_GRANT_RESPONSE = string;
+export type UPDATE_GRANT_RESPONSE = UPDATE_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST31_STRING;
 
 /**
  * #### Source
@@ -16805,16 +18037,26 @@ export type UPDATE_NETWORK_POLICIES_TEMPLATE_REQUEST = UPDATE_NETWORK_POLICIES_T
  *
  * ```yaml
  * structs:
- *     ANON_STRUCT_0:
+ *     ANON_STRUCT_1:
  *         properties: {}
+ *     mogenius-k8s-manager/src/core.Result[[]mogenius-k8s-manager/src/kubernetes.NetworkPolicy,mogenius-k8s-manager/src/core.Void]:
+ *         name: mogenius-k8s-manager/src/core.Result[[]mogenius-k8s-manager/src/kubernetes.NetworkPolicy,mogenius-k8s-manager/src/core.Void]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: ANON_STRUCT_1
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: ANON_STRUCT_0
+ *     structRef: mogenius-k8s-manager/src/core.Result[[]mogenius-k8s-manager/src/kubernetes.NetworkPolicy,mogenius-k8s-manager/src/core.Void]
  *     type: struct
  * ```
  *
  */
-export type UPDATE_NETWORK_POLICIES_TEMPLATE_RESPONSE = UPDATE_NETWORK_POLICIES_TEMPLATE_RESPONSE__ANON_STRUCT_0|undefined;
+export type UPDATE_NETWORK_POLICIES_TEMPLATE_RESPONSE = UPDATE_NETWORK_POLICIES_TEMPLATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_KUBERNETES_NETWORKPOLICY_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID;
 
 /**
  * #### Source
@@ -16859,12 +18101,23 @@ export type UPDATE_USER_REQUEST = UPDATE_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·26,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·26,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·26,string]
+ *     type: struct
  * ```
  *
  */
-export type UPDATE_USER_RESPONSE = string;
+export type UPDATE_USER_RESPONSE = UPDATE_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST26_STRING;
 
 /**
  * #### Source
@@ -16910,14 +18163,24 @@ export type UPDATE_WORKLOAD_REQUEST = UPDATE_WORKLOAD_REQUEST__MOGENIUS_K8S_MANA
  *                 valueType:
  *                     pointer: true
  *                     type: any
+ *     ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *     :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+ *         properties:
+ *             data:
+ *                 pointer: true
+ *                 structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     pointer: true
- *     structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
  *     type: struct
  * ```
  *
  */
-export type UPDATE_WORKLOAD_RESPONSE = UPDATE_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED|undefined;
+export type UPDATE_WORKLOAD_RESPONSE = UPDATE_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEDATA_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED;
 
 /**
  * #### Source
@@ -16957,12 +18220,23 @@ export type UPDATE_WORKSPACE_REQUEST = UPDATE_WORKSPACE_REQUEST__MOGENIUS_K8S_MA
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·21,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·21,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·21,string]
+ *     type: struct
  * ```
  *
  */
-export type UPDATE_WORKSPACE_RESPONSE = string;
+export type UPDATE_WORKSPACE_RESPONSE = UPDATE_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST21_STRING;
 
 /**
  * #### Source
@@ -17069,12 +18343,23 @@ export type UPGRADE_CERT_MANAGER_REQUEST = UPGRADE_CERT_MANAGER_REQUEST__ANON_ST
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UPGRADE_CERT_MANAGER_RESPONSE = string;
+export type UPGRADE_CERT_MANAGER_RESPONSE = UPGRADE_CERT_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -17096,12 +18381,23 @@ export type UPGRADE_INGRESS_CONTROLLER_TRAEFIK_REQUEST = UPGRADE_INGRESS_CONTROL
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UPGRADE_INGRESS_CONTROLLER_TRAEFIK_RESPONSE = string;
+export type UPGRADE_INGRESS_CONTROLLER_TRAEFIK_RESPONSE = UPGRADE_INGRESS_CONTROLLER_TRAEFIK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -17123,12 +18419,23 @@ export type UPGRADE_KEPLER_REQUEST = UPGRADE_KEPLER_REQUEST__ANON_STRUCT_0|undef
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UPGRADE_KEPLER_RESPONSE = string;
+export type UPGRADE_KEPLER_RESPONSE = UPGRADE_KEPLER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -17150,12 +18457,23 @@ export type UPGRADE_METALLB_REQUEST = UPGRADE_METALLB_REQUEST__ANON_STRUCT_0|und
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UPGRADE_METALLB_RESPONSE = string;
+export type UPGRADE_METALLB_RESPONSE = UPGRADE_METALLB_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -17177,12 +18495,23 @@ export type UPGRADE_METRICS_SERVER_REQUEST = UPGRADE_METRICS_SERVER_REQUEST__ANO
  * #### Source
  *
  * ```yaml
+ * structs:
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *         properties:
+ *             data:
+ *                 type: string
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     type: string
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+ *     type: struct
  * ```
  *
  */
-export type UPGRADE_METRICS_SERVER_RESPONSE = string;
+export type UPGRADE_METRICS_SERVER_RESPONSE = UPGRADE_METRICS_SERVER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING;
 
 /**
  * #### Source
@@ -17270,13 +18599,23 @@ export type WORKSPACE_CLEAN_UP_REQUEST = WORKSPACE_CLEAN_UP_REQUEST__MOGENIUS_K8
  *                 type: string
  *             reason:
  *                 type: string
+ *     mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·20,mogenius-k8s-manager/src/core.CleanUpResult]:
+ *         name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·20,mogenius-k8s-manager/src/core.CleanUpResult]
+ *         properties:
+ *             data:
+ *                 structRef: mogenius-k8s-manager/src/core.CleanUpResult
+ *                 type: struct
+ *             message:
+ *                 type: string
+ *             status:
+ *                 type: string
  * typeInfo:
- *     structRef: mogenius-k8s-manager/src/core.CleanUpResult
+ *     structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·20,mogenius-k8s-manager/src/core.CleanUpResult]
  *     type: struct
  * ```
  *
  */
-export type WORKSPACE_CLEAN_UP_RESPONSE = WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULT;
+export type WORKSPACE_CLEAN_UP_RESPONSE = WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST20_MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULT;
 
 
 //===============================================================
@@ -17285,6 +18624,10 @@ export type WORKSPACE_CLEAN_UP_RESPONSE = WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_
 
 export type ATTACH_LABELED_NETWORK_POLICY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_ATTACHLABELEDNETWORKPOLICYREQUEST = {"controllerName": string,"controllerType": string,"labeledNetworkPolicies": ATTACH_LABELED_NETWORK_POLICY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO[],"namespaceName": string};
 export type ATTACH_LABELED_NETWORK_POLICY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO = {"name": string,"port": number,"portType": string,"type": string};
+export type ATTACH_LABELED_NETWORK_POLICY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_ATTACHLABELEDNETWORKPOLICYREQUEST_STRING = {"data": string,"message": string,"status": string};
+export type CLUSTERFORCEDISCONNECT_REQUEST__ANON_STRUCT_0 = {};
+export type CLUSTERFORCERECONNECT_REQUEST__ANON_STRUCT_0 = {};
+export type CLUSTERRESOURCEINFO_REQUEST__ANON_STRUCT_0 = {};
 export type CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESPONSE = {"cniConfig": CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_CNIDATA[],"country": CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_UTILS_COUNTRYDETAILS|undefined,"loadBalancerExternalIps": string[],"nodeStats": CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_NODESTAT[],"provider": string};
 export type CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_NODESTAT = {"architecture": string,"cpuInCores": number,"cpuInCoresLimited": number,"cpuInCoresRequested": number,"cpuInCoresUtilized": number,"ephemeralInBytes": number,"kubletVersion": string,"machineStats": CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_MACHINESTATS|undefined,"maschineId": string,"maxPods": number,"memoryInBytes": number,"memoryInBytesLimited": number,"memoryInBytesRequested": number,"memoryInBytesUtilized": number,"name": string,"osImage": string,"osKernelVersion": string,"osType": string,"totalPods": number};
 export type CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_CNICAPABILITIES = {"bandwidth": boolean,"portMappings": boolean};
@@ -17294,22 +18637,33 @@ export type CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_CNIPO
 export type CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_MACHINESTATS = {"btfSupport": boolean};
 export type CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_PLUGIN = {"capabilities": CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_CNICAPABILITIES|undefined,"datastore_type": string,"ipam": CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_CNIIPAM|undefined,"log_file_path": string,"log_level": string,"mtu": number,"nodename": string,"policy": CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_CNIPOLICY|undefined,"snat": boolean|undefined,"type": string};
 export type CLUSTERRESOURCEINFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_UTILS_COUNTRYDETAILS = {"capitalCity": string,"capitalCityLat": number,"capitalCityLng": number,"code": string,"code3": string,"continent": string,"currency": string,"currencyName": string,"domainTld": string,"isActive": boolean,"isEuMember": boolean,"isoId": number,"languages": string[],"name": string,"phoneNumberPrefix": string,"taxPercent": number};
-export type CLUSTER_BACKUP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_NAMESPACEBACKUPRESPONSE = {"data": string,"messages": string[],"namespaceName": string};
+export type CLUSTER_BACKUP_REQUEST__ANON_STRUCT_0 = {};
 export type CLUSTER_CLEAR_VALKEY_CACHE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"includeNodeStats": boolean,"includePodStats": boolean,"includeTraffic": boolean};
+export type CLUSTER_CLEAR_VALKEY_CACHE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST5_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_COMPONENTLOGCONNECTIONREQUEST = {"component": string,"controller": string|undefined,"namespace": string|undefined,"release": string|undefined,"wsConnectionRequest": CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST};
 export type CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_RESPONSE__ANON_STRUCT_1 = {};
+export type CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_COMPONENTLOGCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": CLUSTER_COMPONENT_LOG_STREAM_CONNECTION_REQUEST_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type CLUSTER_HELM_CHART_INSTALL_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINSTALLUPGRADEREQUEST = {"chart": string,"dryRun": boolean,"namespace": string,"release": string,"values": string,"version": string};
+export type CLUSTER_HELM_CHART_INSTALL_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINSTALLUPGRADEREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_CHART_INSTALL_OCI_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTOCIINSTALLUPGRADEREQUEST = {"chart": string,"dryRun": boolean,"namespace": string,"password": string,"registryUrl": string,"release": string,"username": string,"values": string,"version": string};
+export type CLUSTER_HELM_CHART_INSTALL_OCI_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTOCIINSTALLUPGRADEREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_CHART_REMOVE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOREMOVEREQUEST = {"name": string};
+export type CLUSTER_HELM_CHART_REMOVE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOREMOVEREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_CHART_SEARCH_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTSEARCHREQUEST = {"name": string};
+export type CLUSTER_HELM_CHART_SEARCH_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTSEARCHREQUEST_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO = {"data": CLUSTER_HELM_CHART_SEARCH_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO[],"message": string,"status": string};
 export type CLUSTER_HELM_CHART_SEARCH_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO = {"app_version": string,"description": string,"name": string,"version": string};
 export type CLUSTER_HELM_CHART_SHOW_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTSHOWREQUEST = {"chart": string,"format": string};
+export type CLUSTER_HELM_CHART_SHOW_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTSHOWREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_CHART_VERSIONS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTVERSIONREQUEST = {"chart": string};
+export type CLUSTER_HELM_CHART_VERSIONS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTVERSIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO = {"data": CLUSTER_HELM_CHART_VERSIONS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO[],"message": string,"status": string};
 export type CLUSTER_HELM_CHART_VERSIONS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINFO = {"app_version": string,"description": string,"name": string,"version": string};
 export type CLUSTER_HELM_RELEASE_GET_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEGETREQUEST = {"getFormat": string,"namespace": string,"release": string};
+export type CLUSTER_HELM_RELEASE_GET_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEGETREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_RELEASE_GET_WORKLOADS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEGETWORKLOADSREQUEST = {"namespace": string,"release": string,"whitelist": CLUSTER_HELM_RELEASE_GET_WORKLOADS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY|undefined[]};
 export type CLUSTER_HELM_RELEASE_GET_WORKLOADS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string};
 export type CLUSTER_HELM_RELEASE_GET_WORKLOADS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
+export type CLUSTER_HELM_RELEASE_GET_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEGETWORKLOADSREQUEST_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"data": CLUSTER_HELM_RELEASE_GET_WORKLOADS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED[],"message": string,"status": string};
 export type CLUSTER_HELM_RELEASE_HISTORY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEHISTORYREQUEST = {"namespace": string,"release": string};
 export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_CHART = {"files": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_FILE|undefined[],"lock": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_LOCK|undefined,"metadata": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_METADATA|undefined,"schema": number[],"templates": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_FILE|undefined[],"values": Record<string, any>};
 export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_DEPENDENCY = {"alias": string,"condition": string,"enabled": boolean,"import-values": any[],"name": string,"repository": string,"tags": string[],"version": string};
@@ -17322,6 +18676,7 @@ export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_H
 export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_INFO = {"deleted": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_TIME_TIME,"description": string,"first_deployed": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_TIME_TIME,"last_deployed": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_TIME_TIME,"notes": string,"resources": Record<string, any[]>,"status": string};
 export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_RELEASE = {"chart": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_CHART|undefined,"config": Record<string, any>,"hooks": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_HOOK|undefined[],"info": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_INFO|undefined,"manifest": string,"name": string,"namespace": string,"version": number};
 export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_TIME_TIME = {"Time": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__TIME_TIME};
+export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEHISTORYREQUEST_HELM_SH_HELM_V3_PKG_RELEASE_RELEASE = {"data": CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_RELEASE|undefined[],"message": string,"status": string};
 export type CLUSTER_HELM_RELEASE_HISTORY_RESPONSE__TIME_TIME = {};
 export type CLUSTER_HELM_RELEASE_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASELISTREQUEST = {"namespace": string};
 export type CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_CHART = {"files": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_FILE|undefined[],"lock": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_LOCK|undefined,"metadata": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_METADATA|undefined,"schema": number[],"templates": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_FILE|undefined[],"values": Record<string, any>};
@@ -17335,18 +18690,27 @@ export type CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_HOOK
 export type CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_INFO = {"deleted": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_TIME_TIME,"description": string,"first_deployed": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_TIME_TIME,"last_deployed": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_TIME_TIME,"notes": string,"resources": Record<string, any[]>,"status": string};
 export type CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_RELEASE = {"chart": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_CHART_CHART|undefined,"config": Record<string, any>,"hooks": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_HOOK|undefined[],"info": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_INFO|undefined,"manifest": string,"name": string,"namespace": string,"version": number};
 export type CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_TIME_TIME = {"Time": CLUSTER_HELM_RELEASE_LIST_RESPONSE__TIME_TIME};
+export type CLUSTER_HELM_RELEASE_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASELISTREQUEST_HELM_SH_HELM_V3_PKG_RELEASE_RELEASE = {"data": CLUSTER_HELM_RELEASE_LIST_RESPONSE__HELM_SH_HELM_V3_PKG_RELEASE_RELEASE|undefined[],"message": string,"status": string};
 export type CLUSTER_HELM_RELEASE_LIST_RESPONSE__TIME_TIME = {};
 export type CLUSTER_HELM_RELEASE_ROLLBACK_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEROLLBACKREQUEST = {"namespace": string,"release": string,"revision": number};
+export type CLUSTER_HELM_RELEASE_ROLLBACK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEROLLBACKREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_RELEASE_STATUS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASESTATUSREQUEST = {"namespace": string,"release": string};
+export type CLUSTER_HELM_RELEASE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASESTATUSREQUEST_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASESTATUSINFO = {"data": CLUSTER_HELM_RELEASE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASESTATUSINFO|undefined,"message": string,"status": string};
 export type CLUSTER_HELM_RELEASE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASESTATUSINFO = {"chart": string,"lastDeployed": CLUSTER_HELM_RELEASE_STATUS_RESPONSE__TIME_TIME,"name": string,"namespace": string,"status": string,"version": number};
 export type CLUSTER_HELM_RELEASE_STATUS_RESPONSE__TIME_TIME = {};
 export type CLUSTER_HELM_RELEASE_UNINSTALL_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEUNINSTALLREQUEST = {"dryRun": boolean,"namespace": string,"release": string};
+export type CLUSTER_HELM_RELEASE_UNINSTALL_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMRELEASEUNINSTALLREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_RELEASE_UPGRADE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINSTALLUPGRADEREQUEST = {"chart": string,"dryRun": boolean,"namespace": string,"release": string,"values": string,"version": string};
+export type CLUSTER_HELM_RELEASE_UPGRADE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMCHARTINSTALLUPGRADEREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_REPO_ADD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOADDREQUEST = {"insecureSkipTLSverify": boolean,"name": string,"passCredentialsAll": boolean,"password": string,"url": string,"username": string};
+export type CLUSTER_HELM_REPO_ADD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOADDREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_REPO_LIST_REQUEST__ANON_STRUCT_0 = {};
+export type CLUSTER_HELM_REPO_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYWITHOUTPASSWORD = {"data": CLUSTER_HELM_REPO_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYWITHOUTPASSWORD|undefined[],"message": string,"status": string};
 export type CLUSTER_HELM_REPO_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYWITHOUTPASSWORD = {"insecure_skip_tls_verify": boolean,"name": string,"pass_credentials_all": boolean,"url": string};
 export type CLUSTER_HELM_REPO_PATCH_REQUEST__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOPATCHREQUEST = {"insecureSkipTLSverify": boolean,"name": string,"newName": string,"passCredentialsAll": boolean,"password": string,"url": string,"username": string};
+export type CLUSTER_HELM_REPO_PATCH_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_HELM_HELMREPOPATCHREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type CLUSTER_HELM_REPO_UPDATE_REQUEST__ANON_STRUCT_0 = {};
+export type CLUSTER_HELM_REPO_UPDATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYSTATUS = {"data": CLUSTER_HELM_REPO_UPDATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYSTATUS[],"message": string,"status": string};
 export type CLUSTER_HELM_REPO_UPDATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYSTATUS = {"entry": CLUSTER_HELM_REPO_UPDATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYWITHOUTPASSWORD|undefined,"message": string,"status": string};
 export type CLUSTER_HELM_REPO_UPDATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_HELM_HELMENTRYWITHOUTPASSWORD = {"insecure_skip_tls_verify": boolean,"name": string,"pass_credentials_all": boolean,"url": string};
 export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_CLUSTERLISTWORKLOADS = {"labelSelector": string,"namespace": string,"prefix": string};
@@ -17367,38 +18731,53 @@ export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__K8S_IO_APIMACHINERY_
 export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OWNERREFERENCE = {"apiVersion": string,"blockOwnerDeletion": boolean|undefined,"controller": boolean|undefined,"kind": string,"name": string,"uid": string};
 export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME = {"Time": CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__TIME_TIME};
 export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA = {"apiVersion": string,"kind": string};
+export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_SERVICES_CLUSTERLISTWORKLOADS_K8S_IO_API_CORE_V1_PERSISTENTVOLUMECLAIM = {"data": CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__K8S_IO_API_CORE_V1_PERSISTENTVOLUMECLAIM[],"message": string,"status": string};
 export type CLUSTER_LIST_PERSISTENT_VOLUME_CLAIMS_RESPONSE__TIME_TIME = {};
 export type CLUSTER_MACHINE_STATS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"nodes": string[]};
+export type CLUSTER_MACHINE_STATS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST17_MOGENIUS_K8S_MANAGER_SRC_STRUCTS_MACHINESTATS = {"data": CLUSTER_MACHINE_STATS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_MACHINESTATS[],"message": string,"status": string};
 export type CLUSTER_MACHINE_STATS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_MACHINESTATS = {"btfSupport": boolean};
 export type CLUSTER_UPDATE_LOCAL_TLS_SECRET_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_CLUSTERUPDATELOCALTLSSECRET = {"localTlsCrt": string,"localTlsKey": string};
 export type CREATE_GRANT_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"grantee": string,"name": string,"role": string,"targetName": string,"targetType": string};
+export type CREATE_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST29_STRING = {"data": string,"message": string,"status": string};
 export type CREATE_NEW_WORKLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEDATA = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string,"yamlData": string};
 export type CREATE_NEW_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
+export type CREATE_NEW_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEDATA_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"data": CREATE_NEW_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED|undefined,"message": string,"status": string};
 export type CREATE_USER_REQUEST__K8S_IO_API_RBAC_V1_SUBJECT = {"apiGroup": string,"kind": string,"name": string,"namespace": string};
 export type CREATE_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"email": string,"firstName": string,"lastName": string,"name": string,"subject": CREATE_USER_REQUEST__K8S_IO_API_RBAC_V1_SUBJECT|undefined};
+export type CREATE_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST24_STRING = {"data": string,"message": string,"status": string};
 export type CREATE_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"displayName": string,"name": string,"resources": CREATE_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_WORKSPACERESOURCEIDENTIFIER[]};
 export type CREATE_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_WORKSPACERESOURCEIDENTIFIER = {"id": string,"namespace": string,"type": string};
+export type CREATE_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST18_STRING = {"data": string,"message": string,"status": string};
 export type DELETE_GRANT_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"name": string};
+export type DELETE_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST32_STRING = {"data": string,"message": string,"status": string};
 export type DELETE_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"name": string};
+export type DELETE_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST27_STRING = {"data": string,"message": string,"status": string};
 export type DELETE_WORKLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM = {"group": string,"kind": string,"name": string,"namespace": string,"resourceName": string,"version": string};
-export type DELETE_WORKLOAD_RESPONSE__ANON_STRUCT_0 = {};
+export type DELETE_WORKLOAD_RESPONSE__ANON_STRUCT_1 = {};
+export type DELETE_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": DELETE_WORKLOAD_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type DELETE_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"name": string};
+export type DELETE_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST22_STRING = {"data": string,"message": string,"status": string};
 export type DESCRIBE_REQUEST__ANON_STRUCT_0 = {};
-export type DESCRIBE_RESPONSE__ANON_STRUCT_1 = {"buildType": string,"version": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_VERSION_VERSION};
-export type DESCRIBE_RESPONSE__ANON_STRUCT_3 = {};
-export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PATTERNCONFIG = {"deprecated": boolean,"deprecatedMessage": string,"needsUser": boolean,"requestSchema": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_SCHEMA|undefined,"responseSchema": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_SCHEMA|undefined};
-export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESPONSE = {"buildInfo": DESCRIBE_RESPONSE__ANON_STRUCT_1,"features": DESCRIBE_RESPONSE__ANON_STRUCT_3,"patterns": Record<string, DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PATTERNCONFIG>};
+export type DESCRIBE_RESPONSE__ANON_STRUCT_2 = {"buildType": string,"version": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_VERSION_VERSION};
+export type DESCRIBE_RESPONSE__ANON_STRUCT_4 = {};
+export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PATTERNCONFIG = {"deprecated": boolean,"deprecatedMessage": string,"legacyResponseLayout": boolean,"needsUser": boolean,"requestSchema": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_SCHEMA|undefined,"responseSchema": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_SCHEMA|undefined};
+export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESPONSE = {"buildInfo": DESCRIBE_RESPONSE__ANON_STRUCT_2,"features": DESCRIBE_RESPONSE__ANON_STRUCT_4,"patterns": Record<string, DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PATTERNCONFIG>};
+export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_CORE_RESPONSE2 = {"data": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESPONSE,"message": string,"status": string};
 export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_SCHEMA = {"structs": Record<string, DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_STRUCTLAYOUT>,"typeInfo": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_TYPEINFO|undefined};
 export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_STRUCTLAYOUT = {"name": string,"properties": Record<string, DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_TYPEINFO|undefined>};
 export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_TYPEINFO = {"elementType": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_TYPEINFO|undefined,"keyType": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_TYPEINFO|undefined,"pointer": boolean,"structRef": string,"type": string,"valueType": DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SCHEMA_TYPEINFO|undefined};
 export type DESCRIBE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_VERSION_VERSION = {"arch": string,"branch": string,"buildTimestamp": string,"gitCommitHash": string,"os": string,"version": string};
 export type DESCRIBE_WORKLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM = {"group": string,"kind": string,"name": string,"namespace": string,"resourceName": string,"version": string};
+export type DESCRIBE_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_STRING = {"data": string,"message": string,"status": string};
 export type DETACH_LABELED_NETWORK_POLICY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_DETACHLABELEDNETWORKPOLICYREQUEST = {"controllerName": string,"controllerType": string,"labeledNetworkPolicies": DETACH_LABELED_NETWORK_POLICY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO[],"namespaceName": string};
 export type DETACH_LABELED_NETWORK_POLICY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO = {"name": string,"port": number,"portType": string,"type": string};
+export type DETACH_LABELED_NETWORK_POLICY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_DETACHLABELEDNETWORKPOLICYREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type DISABLE_NETWORK_POLICY_MANAGER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_DISABLENETWORKPOLICYMANAGERREQUEST = {"namespaceName": string};
-export type DISABLE_NETWORK_POLICY_MANAGER_RESPONSE__ANON_STRUCT_0 = {};
+export type DISABLE_NETWORK_POLICY_MANAGER_RESPONSE__ANON_STRUCT_1 = {};
+export type DISABLE_NETWORK_POLICY_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_DISABLENETWORKPOLICYMANAGERREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": DISABLE_NETWORK_POLICY_MANAGER_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type ENFORCE_NETWORK_POLICY_MANAGER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_ENFORCENETWORKPOLICYMANAGERREQUEST = {"namespaceName": string};
-export type ENFORCE_NETWORK_POLICY_MANAGER_RESPONSE__ANON_STRUCT_0 = {};
+export type ENFORCE_NETWORK_POLICY_MANAGER_RESPONSE__ANON_STRUCT_1 = {};
+export type ENFORCE_NETWORK_POLICY_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_ENFORCENETWORKPOLICYMANAGERREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": ENFORCE_NETWORK_POLICY_MANAGER_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type EXTERNAL_SECRET_LIST_AVAILABLE_SECRETS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTSECRETSREQUEST = {"namePrefix": string};
 export type EXTERNAL_SECRET_STORE_CREATE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_CREATESECRETSSTOREREQUEST = {"displayName": string,"projectId": string,"role": string,"secretPath": string,"vaultServerUrl": string};
 export type EXTERNAL_SECRET_STORE_CREATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_CREATESECRETSSTORERESPONSE = {"errorMessage": string,"status": string};
@@ -17416,8 +18795,9 @@ export type FILES_DELETE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"file
 export type FILES_DELETE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEREQUESTDTO = {"path": string,"volumeName": string,"volumeNamespace": string};
 export type FILES_DOWNLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"file": FILES_DOWNLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEREQUESTDTO,"postTo": string};
 export type FILES_DOWNLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEREQUESTDTO = {"path": string,"volumeName": string,"volumeNamespace": string};
+export type FILES_DOWNLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_FILESDOWNLOADRESPONSE = {"error": string,"sizeInBytes": number};
 export type FILES_INFO_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEREQUESTDTO = {"path": string,"volumeName": string,"volumeNamespace": string};
-export type FILES_INFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEREQUESTDTO = {"path": string,"volumeName": string,"volumeNamespace": string};
+export type FILES_INFO_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEDTO = {"contentType": string,"createdAt": string,"extension": string,"hash": string,"mimeType": string,"mode": string,"modifiedAt": string,"name": string,"relativePath": string,"size": string,"sizeInBytes": number,"type": string,"uid_gid": string};
 export type FILES_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"folder": FILES_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEREQUESTDTO};
 export type FILES_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEREQUESTDTO = {"path": string,"volumeName": string,"volumeNamespace": string};
 export type FILES_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_PERSISTENTFILEDTO = {"contentType": string,"createdAt": string,"extension": string,"hash": string,"mimeType": string,"mode": string,"modifiedAt": string,"name": string,"relativePath": string,"size": string,"sizeInBytes": number,"type": string,"uid_gid": string};
@@ -17430,6 +18810,7 @@ export type GET_GRANT_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OBJECTMETA 
 export type GET_GRANT_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OWNERREFERENCE = {"apiVersion": string,"blockOwnerDeletion": boolean|undefined,"controller": boolean|undefined,"kind": string,"name": string,"uid": string};
 export type GET_GRANT_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME = {"Time": GET_GRANT_RESPONSE__TIME_TIME};
 export type GET_GRANT_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA = {"apiVersion": string,"kind": string};
+export type GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST30_MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT = {"data": GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT|undefined,"message": string,"status": string};
 export type GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT = {"TypeMeta": GET_GRANT_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA,"metadata": GET_GRANT_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OBJECTMETA,"spec": GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANTSPEC,"status": GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANTSTATUS};
 export type GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANTSPEC = {"grantee": string,"role": string,"targetName": string,"targetType": string};
 export type GET_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANTSTATUS = {};
@@ -17441,6 +18822,7 @@ export type GET_GRANTS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OBJECTMETA
 export type GET_GRANTS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OWNERREFERENCE = {"apiVersion": string,"blockOwnerDeletion": boolean|undefined,"controller": boolean|undefined,"kind": string,"name": string,"uid": string};
 export type GET_GRANTS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME = {"Time": GET_GRANTS_RESPONSE__TIME_TIME};
 export type GET_GRANTS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA = {"apiVersion": string,"kind": string};
+export type GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST28_MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT = {"data": GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT[],"message": string,"status": string};
 export type GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANT = {"TypeMeta": GET_GRANTS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA,"metadata": GET_GRANTS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OBJECTMETA,"spec": GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANTSPEC,"status": GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANTSTATUS};
 export type GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANTSPEC = {"grantee": string,"role": string,"targetName": string,"targetType": string};
 export type GET_GRANTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_GRANTSTATUS = {};
@@ -17449,9 +18831,11 @@ export type GET_LABELED_WORKLOAD_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_KUBERNET
 export type GET_LABELED_WORKLOAD_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string};
 export type GET_LABELED_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
 export type GET_LABELED_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST = {"Object": Record<string, any>,"items": GET_LABELED_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED[]};
+export type GET_LABELED_WORKLOAD_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETUNSTRUCTUREDLABELEDRESOURCELISTREQUEST_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST = {"data": GET_LABELED_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST,"message": string,"status": string};
 export type GET_NAMESPACE_WORKLOAD_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETUNSTRUCTUREDNAMESPACERESOURCELISTREQUEST = {"blacklist": GET_NAMESPACE_WORKLOAD_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY|undefined[],"namespace": string,"whitelist": GET_NAMESPACE_WORKLOAD_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY|undefined[]};
 export type GET_NAMESPACE_WORKLOAD_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string};
 export type GET_NAMESPACE_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
+export type GET_NAMESPACE_WORKLOAD_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETUNSTRUCTUREDNAMESPACERESOURCELISTREQUEST_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"data": GET_NAMESPACE_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED[],"message": string,"status": string};
 export type GET_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"name": string};
 export type GET_USER_RESPONSE__K8S_IO_API_RBAC_V1_SUBJECT = {"apiGroup": string,"kind": string,"name": string,"namespace": string};
 export type GET_USER_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_FIELDSV1 = {};
@@ -17460,6 +18844,7 @@ export type GET_USER_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OBJECTMETA =
 export type GET_USER_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OWNERREFERENCE = {"apiVersion": string,"blockOwnerDeletion": boolean|undefined,"controller": boolean|undefined,"kind": string,"name": string,"uid": string};
 export type GET_USER_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME = {"Time": GET_USER_RESPONSE__TIME_TIME};
 export type GET_USER_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA = {"apiVersion": string,"kind": string};
+export type GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST25_MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER = {"data": GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER|undefined,"message": string,"status": string};
 export type GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER = {"TypeMeta": GET_USER_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA,"metadata": GET_USER_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OBJECTMETA,"spec": GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USERSPEC,"status": GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USERSTATUS};
 export type GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USERSPEC = {"email": string,"firstName": string,"lastName": string,"subject": GET_USER_RESPONSE__K8S_IO_API_RBAC_V1_SUBJECT|undefined};
 export type GET_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USERSTATUS = {};
@@ -17472,16 +18857,20 @@ export type GET_USERS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OBJECTMETA 
 export type GET_USERS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OWNERREFERENCE = {"apiVersion": string,"blockOwnerDeletion": boolean|undefined,"controller": boolean|undefined,"kind": string,"name": string,"uid": string};
 export type GET_USERS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME = {"Time": GET_USERS_RESPONSE__TIME_TIME};
 export type GET_USERS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA = {"apiVersion": string,"kind": string};
+export type GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST23_MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER = {"data": GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER[],"message": string,"status": string};
 export type GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USER = {"TypeMeta": GET_USERS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA,"metadata": GET_USERS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OBJECTMETA,"spec": GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USERSPEC,"status": GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USERSTATUS};
 export type GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USERSPEC = {"email": string,"firstName": string,"lastName": string,"subject": GET_USERS_RESPONSE__K8S_IO_API_RBAC_V1_SUBJECT|undefined};
 export type GET_USERS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_USERSTATUS = {};
 export type GET_USERS_RESPONSE__TIME_TIME = {};
 export type GET_WORKLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM = {"group": string,"kind": string,"name": string,"namespace": string,"resourceName": string,"version": string};
 export type GET_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
+export type GET_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"data": GET_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED|undefined,"message": string,"status": string};
 export type GET_WORKLOAD_EXAMPLE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM = {"group": string,"kind": string,"name": string,"namespace": string,"resourceName": string,"version": string};
+export type GET_WORKLOAD_EXAMPLE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_STRING = {"data": string,"message": string,"status": string};
 export type GET_WORKLOAD_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string};
 export type GET_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
 export type GET_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST = {"Object": Record<string, any>,"items": GET_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED[]};
+export type GET_WORKLOAD_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST = {"data": GET_WORKLOAD_LIST_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTUREDLIST,"message": string,"status": string};
 export type GET_WORKLOAD_STATUS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETWORKLOADSTATUSHELMRELEASENAMEREQUEST = {"namespace": string,"release": string};
 export type GET_WORKLOAD_STATUS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETWORKLOADSTATUSREQUEST = {"helmReleases": GET_WORKLOAD_STATUS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETWORKLOADSTATUSHELMRELEASENAMEREQUEST[]|undefined,"ignoreDependentResources": boolean|undefined,"namespaces": string[]|undefined,"resourceEntity": GET_WORKLOAD_STATUS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY|undefined,"resourceNames": string[]|undefined};
 export type GET_WORKLOAD_STATUS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string};
@@ -17496,28 +18885,41 @@ export type GET_WORKLOAD_STATUS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_O
 export type GET_WORKLOAD_STATUS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_OWNERREFERENCE = {"apiVersion": string,"blockOwnerDeletion": boolean|undefined,"controller": boolean|undefined,"kind": string,"name": string,"uid": string};
 export type GET_WORKLOAD_STATUS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME = {"Time": GET_WORKLOAD_STATUS_RESPONSE__TIME_TIME};
 export type GET_WORKLOAD_STATUS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TYPEMETA = {"apiVersion": string,"kind": string};
+export type GET_WORKLOAD_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_KUBERNETES_GETWORKLOADSTATUSREQUEST_MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_WORKLOADSTATUSDTO = {"data": GET_WORKLOAD_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_WORKLOADSTATUSDTO[],"message": string,"status": string};
 export type GET_WORKLOAD_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_WORKLOADSTATUSDTO = {"items": GET_WORKLOAD_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_WORKLOADSTATUSITEMDTO[]};
 export type GET_WORKLOAD_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_WORKLOADSTATUSITEMDTO = {"creationTimestamp": GET_WORKLOAD_STATUS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME,"endpoints": any,"events": GET_WORKLOAD_STATUS_RESPONSE__K8S_IO_API_CORE_V1_EVENT[],"group": string,"kind": string,"name": string,"namespace": string,"ownerReferences": any,"replicas": number|undefined,"specClusterIP": string,"specType": string,"status": any,"uid": string};
 export type GET_WORKLOAD_STATUS_RESPONSE__TIME_TIME = {};
 export type GET_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"name": string};
 export type GET_WORKSPACE_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME = {"Time": GET_WORKSPACE_RESPONSE__TIME_TIME};
 export type GET_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT = {"creationTimestamp": GET_WORKSPACE_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME,"name": string,"resources": GET_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_WORKSPACERESOURCEIDENTIFIER[]};
+export type GET_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST19_MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT = {"data": GET_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT|undefined,"message": string,"status": string};
 export type GET_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_WORKSPACERESOURCEIDENTIFIER = {"id": string,"namespace": string,"type": string};
 export type GET_WORKSPACE_RESPONSE__TIME_TIME = {};
 export type GET_WORKSPACES_REQUEST__ANON_STRUCT_0 = {};
 export type GET_WORKSPACES_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME = {"Time": GET_WORKSPACES_RESPONSE__TIME_TIME};
 export type GET_WORKSPACES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT = {"creationTimestamp": GET_WORKSPACES_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_TIME,"name": string,"resources": GET_WORKSPACES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_WORKSPACERESOURCEIDENTIFIER[]};
+export type GET_WORKSPACES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT = {"data": GET_WORKSPACES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GETWORKSPACERESULT[],"message": string,"status": string};
 export type GET_WORKSPACES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_WORKSPACERESOURCEIDENTIFIER = {"id": string,"namespace": string,"type": string};
 export type GET_WORKSPACES_RESPONSE__TIME_TIME = {};
 export type GET_WORKSPACE_WORKLOADS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"blacklist": GET_WORKSPACE_WORKLOADS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY|undefined[],"namespaceWhitelist": string[],"whitelist": GET_WORKSPACE_WORKLOADS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY|undefined[],"workspaceName": string};
 export type GET_WORKSPACE_WORKLOADS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string};
 export type GET_WORKSPACE_WORKLOADS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
+export type GET_WORKSPACE_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST33_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"data": GET_WORKSPACE_WORKLOADS_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED[],"message": string,"status": string};
 export type INSTALL_CERT_MANAGER_REQUEST__ANON_STRUCT_0 = {};
+export type INSTALL_CERT_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type INSTALL_CLUSTER_ISSUER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"email": string};
+export type INSTALL_CLUSTER_ISSUER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST6_STRING = {"data": string,"message": string,"status": string};
 export type INSTALL_INGRESS_CONTROLLER_TRAEFIK_REQUEST__ANON_STRUCT_0 = {};
+export type INSTALL_INGRESS_CONTROLLER_TRAEFIK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type INSTALL_KEPLER_REQUEST__ANON_STRUCT_0 = {};
+export type INSTALL_KEPLER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type INSTALL_METALLB_REQUEST__ANON_STRUCT_0 = {};
+export type INSTALL_METALLB_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type INSTALL_METRICS_SERVER_REQUEST__ANON_STRUCT_0 = {};
+export type INSTALL_METRICS_SERVER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
+export type K8SNOTIFICATION_REQUEST__ANON_STRUCT_0 = {};
+export type K8SNOTIFICATION_RESPONSE__ANON_STRUCT_1 = {};
+export type K8SNOTIFICATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": K8SNOTIFICATION_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type LIST_ALL_NETWORK_POLICIES_REQUEST__ANON_STRUCT_0 = {};
 export type LIST_ALL_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_IPBLOCK = {"cidr": string,"except": string[]};
 export type LIST_ALL_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_NETWORKPOLICYEGRESSRULE = {"ports": LIST_ALL_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_NETWORKPOLICYPORT[],"to": LIST_ALL_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_NETWORKPOLICYPEER[]};
@@ -17531,8 +18933,10 @@ export type LIST_ALL_NETWORK_POLICIES_RESPONSE__K8S_IO_APIMACHINERY_PKG_UTIL_INT
 export type LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO = {"name": string|undefined,"namespaceName": string,"spec": LIST_ALL_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_NETWORKPOLICYSPEC};
 export type LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYCONTROLLER = {"controllerName": string,"controllerType": string,"networkPolicies": LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO[],"serviceId": string};
 export type LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE = {"controllers": LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYCONTROLLER[],"displayName": string,"id": string,"managedPolicies": LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO[],"name": string,"projectId": string,"unmanagedPolicies": LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO[]};
+export type LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE = {"data": LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE[],"message": string,"status": string};
 export type LIST_ALL_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO = {"name": string,"port": number,"portType": string,"type": string};
 export type LIST_ALL_WORKLOADS_REQUEST__ANON_STRUCT_0 = {};
+export type LIST_ALL_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY = {"data": LIST_ALL_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY[],"message": string,"status": string};
 export type LIST_ALL_WORKLOADS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEENTRY = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string};
 export type LIST_CONFLICTING_NETWORK_POLICIES_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONFLICTINGNETWORKPOLICIESREQUEST = {"namespaceName": string};
 export type LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_IPBLOCK = {"cidr": string,"except": string[]};
@@ -17545,11 +18949,18 @@ export type LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__K8S_IO_APIMACHINERY_PKG_
 export type LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_LABELSELECTORREQUIREMENT = {"key": string,"operator": string,"values": string[]};
 export type LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__K8S_IO_APIMACHINERY_PKG_UTIL_INTSTR_INTORSTRING = {"IntVal": number,"StrVal": string,"Type": number};
 export type LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO = {"name": string|undefined,"namespaceName": string,"spec": LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_NETWORKPOLICYSPEC};
+export type LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONFLICTINGNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO = {"data": LIST_CONFLICTING_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO[],"message": string,"status": string};
 export type LIST_CONTROLLER_NETWORK_POLICIES_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONTROLLERLABELEDNETWORKPOLICIESREQUEST = {"controllerName": string,"controllerType": string,"namespaceName": string};
 export type LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONTROLLERLABELEDNETWORKPOLICIESRESPONSE = {"controllerName": string,"controllerType": string,"labeledNetworkPolicies": LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO[],"namespaceName": string};
+export type LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONTROLLERLABELEDNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONTROLLERLABELEDNETWORKPOLICIESRESPONSE = {"data": LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTCONTROLLERLABELEDNETWORKPOLICIESRESPONSE,"message": string,"status": string};
 export type LIST_CONTROLLER_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO = {"name": string,"port": number,"portType": string,"type": string};
 export type LIST_CRONJOB_JOBS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"controllerName": string,"namespaceName": string,"projectId": string};
+export type LIST_CRONJOB_JOBS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_JOBINFO = {"durationInMs": number,"jobId": string,"jobName": string,"message": LIST_CRONJOB_JOBS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_STATUSMESSAGE|undefined,"podName": string,"schedule": LIST_CRONJOB_JOBS_RESPONSE__TIME_TIME,"status": string,"tileType": string};
+export type LIST_CRONJOB_JOBS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_LISTJOBINFORESPONSE = {"controllerName": string,"jobsInfo": LIST_CRONJOB_JOBS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_JOBINFO[],"namespaceName": string,"projectId": string};
+export type LIST_CRONJOB_JOBS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_STATUSMESSAGE = {"message": string,"reason": string};
+export type LIST_CRONJOB_JOBS_RESPONSE__TIME_TIME = {};
 export type LIST_LABELED_NETWORK_POLICY_PORTS_REQUEST__ANON_STRUCT_0 = {};
+export type LIST_LABELED_NETWORK_POLICY_PORTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO = {"data": LIST_LABELED_NETWORK_POLICY_PORTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO[],"message": string,"status": string};
 export type LIST_LABELED_NETWORK_POLICY_PORTS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO = {"name": string,"port": number,"portType": string,"type": string};
 export type LIST_NAMESPACE_NETWORK_POLICIES_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNAMESPACELABELEDNETWORKPOLICIESREQUEST = {"namespaceName": string};
 export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_IPBLOCK = {"cidr": string,"except": string[]};
@@ -17564,6 +18975,7 @@ export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__K8S_IO_APIMACHINERY_PKG_UT
 export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO = {"name": string|undefined,"namespaceName": string,"spec": LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_NETWORKPOLICYSPEC};
 export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYCONTROLLER = {"controllerName": string,"controllerType": string,"networkPolicies": LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO[],"serviceId": string};
 export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE = {"controllers": LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYCONTROLLER[],"displayName": string,"id": string,"managedPolicies": LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO[],"name": string,"projectId": string,"unmanagedPolicies": LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO[]};
+export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNAMESPACELABELEDNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE = {"data": LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNETWORKPOLICYNAMESPACE[],"message": string,"status": string};
 export type LIST_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SLABELEDNETWORKPOLICYDTO = {"name": string,"port": number,"portType": string,"type": string};
 export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNAMESPACELABELEDNETWORKPOLICIESREQUEST = {"namespaceName": string};
 export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_IPBLOCK = {"cidr": string,"except": string[]};
@@ -17577,12 +18989,25 @@ export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__K8S_IO_APIMACHINERY_P
 export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__K8S_IO_APIMACHINERY_PKG_UTIL_INTSTR_INTORSTRING = {"IntVal": number,"StrVal": string,"Type": number};
 export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO = {"name": string|undefined,"namespaceName": string,"spec": LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__K8S_IO_API_NETWORKING_V1_NETWORKPOLICYSPEC};
 export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTMANAGEDANDUNMANAGEDNETWORKPOLICYNAMESPACE = {"displayName": string,"id": string,"managedPolicies": LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO[],"name": string,"projectId": string,"unmanagedPolicies": LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_K8SNETWORKPOLICYDTO[]};
+export type LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTNAMESPACELABELEDNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTMANAGEDANDUNMANAGEDNETWORKPOLICYNAMESPACE = {"data": LIST_ONLY_NAMESPACE_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_LISTMANAGEDANDUNMANAGEDNETWORKPOLICYNAMESPACE[],"message": string,"status": string};
 export type LIVE_STREAM_NODES_CPU_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type LIVE_STREAM_NODES_CPU_RESPONSE__ANON_STRUCT_1 = {};
+export type LIVE_STREAM_NODES_CPU_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": LIVE_STREAM_NODES_CPU_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type LIVE_STREAM_NODES_MEMORY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type LIVE_STREAM_NODES_MEMORY_RESPONSE__ANON_STRUCT_1 = {};
+export type LIVE_STREAM_NODES_MEMORY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": LIVE_STREAM_NODES_MEMORY_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type LIVE_STREAM_NODES_TRAFFIC_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type LIVE_STREAM_NODES_TRAFFIC_RESPONSE__ANON_STRUCT_1 = {};
+export type LIVE_STREAM_NODES_TRAFFIC_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": LIVE_STREAM_NODES_TRAFFIC_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type LIVE_STREAM_POD_CPU_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type LIVE_STREAM_POD_CPU_RESPONSE__ANON_STRUCT_1 = {};
+export type LIVE_STREAM_POD_CPU_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": LIVE_STREAM_POD_CPU_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type LIVE_STREAM_POD_MEMORY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type LIVE_STREAM_POD_MEMORY_RESPONSE__ANON_STRUCT_1 = {};
+export type LIVE_STREAM_POD_MEMORY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": LIVE_STREAM_POD_MEMORY_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type LIVE_STREAM_POD_TRAFFIC_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type LIVE_STREAM_POD_TRAFFIC_RESPONSE__ANON_STRUCT_1 = {};
+export type LIVE_STREAM_POD_TRAFFIC_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": LIVE_STREAM_POD_TRAFFIC_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type LIVE_STREAM_WORKSPACE_CPU_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
 export type LIVE_STREAM_WORKSPACE_MEMORY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
 export type LIVE_STREAM_WORKSPACE_TRAFFIC_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
@@ -17593,7 +19018,6 @@ export type METRICS_DEPLOYMENT_AVERAGE_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGE
 export type METRICS_DEPLOYMENT_AVERAGE_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_PODMETRICS = {"containers": METRICS_DEPLOYMENT_AVERAGE_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_CONTAINERMETRICS[],"name": string};
 export type METRICS_DEPLOYMENT_AVERAGE_UTILIZATION_RESPONSE__TIME_TIME = {};
 export type NAMESPACE_BACKUP_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NAMESPACEBACKUPREQUEST = {"namespaceName": string};
-export type NAMESPACE_BACKUP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_NAMESPACEBACKUPRESPONSE = {"data": string,"messages": string[],"namespaceName": string};
 export type NAMESPACE_CREATE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SNAMESPACEDTO = {"Name": string,"displayName": string,"id": string};
 export type NAMESPACE_CREATE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SPROJECTDTO = {"clusterDisplayName": string,"clusterId": string,"clusterMfaId": string,"containerRegistryPat": string|undefined,"containerRegistryPath": string|undefined,"containerRegistryUrl": string|undefined,"containerRegistryUser": string|undefined,"displayName": string,"gitAccessToken": string|undefined,"gitConnectionType": string|undefined,"gitUserId": string|undefined,"id": string,"name": string};
 export type NAMESPACE_CREATE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NAMESPACECREATEREQUEST = {"namespace": NAMESPACE_CREATE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SNAMESPACEDTO,"project": NAMESPACE_CREATE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SPROJECTDTO};
@@ -17606,22 +19030,32 @@ export type NAMESPACE_DELETE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NAMESPAC
 export type NAMESPACE_DELETE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_COMMAND = {"command": string,"finished": NAMESPACE_DELETE_RESPONSE__TIME_TIME,"id": string,"message": string,"started": NAMESPACE_DELETE_RESPONSE__TIME_TIME,"state": string,"title": string};
 export type NAMESPACE_DELETE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_JOB = {"commands": NAMESPACE_DELETE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_COMMAND|undefined[],"containerName": string,"controllerName": string,"finished": NAMESPACE_DELETE_RESPONSE__TIME_TIME,"id": string,"message": string,"namespaceName": string,"projectId": string,"started": NAMESPACE_DELETE_RESPONSE__TIME_TIME,"state": string,"title": string};
 export type NAMESPACE_DELETE_RESPONSE__TIME_TIME = {};
+export type PRINT_CURRENT_CONFIG_REQUEST__ANON_STRUCT_0 = {};
 export type PROMETHEUS_CHARTS_ADD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS = {"controller": string,"namespace": string,"query": string,"queryName": string,"step": number};
+export type PROMETHEUS_CHARTS_ADD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS_STRING = {"data": string|undefined,"message": string,"status": string};
 export type PROMETHEUS_CHARTS_GET_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS = {"controller": string,"namespace": string,"query": string,"queryName": string,"step": number};
 export type PROMETHEUS_CHARTS_GET_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT = {"createdAt": PROMETHEUS_CHARTS_GET_RESPONSE__TIME_TIME,"query": string,"step": number};
+export type PROMETHEUS_CHARTS_GET_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS_MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT = {"data": PROMETHEUS_CHARTS_GET_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT|undefined,"message": string,"status": string};
 export type PROMETHEUS_CHARTS_GET_RESPONSE__TIME_TIME = {};
 export type PROMETHEUS_CHARTS_LIST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDISLIST = {"controller": string,"namespace": string};
 export type PROMETHEUS_CHARTS_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT = {"createdAt": PROMETHEUS_CHARTS_LIST_RESPONSE__TIME_TIME,"query": string,"step": number};
+export type PROMETHEUS_CHARTS_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDISLIST_MAPSTRINGMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT = {"data": Record<string, PROMETHEUS_CHARTS_LIST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSSTOREOBJECT>,"message": string,"status": string};
 export type PROMETHEUS_CHARTS_LIST_RESPONSE__TIME_TIME = {};
 export type PROMETHEUS_CHARTS_REMOVE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS = {"controller": string,"namespace": string,"query": string,"queryName": string,"step": number};
+export type PROMETHEUS_CHARTS_REMOVE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUESTREDIS_STRING = {"data": string|undefined,"message": string,"status": string};
 export type PROMETHEUS_IS_REACHABLE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST = {"prometheusPass": string,"prometheusToken": string,"prometheusUrl": string,"prometheusUser": string,"query": string,"step": number,"timeOffsetSeconds": number};
+export type PROMETHEUS_IS_REACHABLE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST_BOOL = {"data": boolean,"message": string,"status": string};
 export type PROMETHEUS_QUERY_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST = {"prometheusPass": string,"prometheusToken": string,"prometheusUrl": string,"prometheusUser": string,"query": string,"step": number,"timeOffsetSeconds": number};
-export type PROMETHEUS_QUERY_RESPONSE__ANON_STRUCT_1 = {"result": any[],"resultType": string};
-export type PROMETHEUS_QUERY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSQUERYRESPONSE = {"data": PROMETHEUS_QUERY_RESPONSE__ANON_STRUCT_1,"error": string,"errorType": string,"status": string};
+export type PROMETHEUS_QUERY_RESPONSE__ANON_STRUCT_2 = {"result": any[],"resultType": string};
+export type PROMETHEUS_QUERY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSQUERYRESPONSE = {"data": PROMETHEUS_QUERY_RESPONSE__ANON_STRUCT_2,"error": string,"errorType": string,"status": string};
+export type PROMETHEUS_QUERY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSQUERYRESPONSE = {"data": PROMETHEUS_QUERY_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSQUERYRESPONSE|undefined,"message": string,"status": string};
 export type PROMETHEUS_VALUES_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST = {"prometheusPass": string,"prometheusToken": string,"prometheusUrl": string,"prometheusUser": string,"query": string,"step": number,"timeOffsetSeconds": number};
+export type PROMETHEUS_VALUES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_PROMETHEUSREQUEST_STRING = {"data": string[],"message": string,"status": string};
 export type REMOVE_CONFLICTING_NETWORK_POLICIES_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_REMOVECONFLICTINGNETWORKPOLICIESREQUEST = {"namespaceName": string};
+export type REMOVE_CONFLICTING_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_REMOVECONFLICTINGNETWORKPOLICIESREQUEST_STRING = {"data": string,"message": string,"status": string};
 export type REMOVE_UNMANAGED_NETWORK_POLICIES_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_REMOVEUNMANAGEDNETWORKPOLICIESREQUEST = {"namespaceName": string,"policies": string[]};
-export type REMOVE_UNMANAGED_NETWORK_POLICIES_RESPONSE__ANON_STRUCT_0 = {};
+export type REMOVE_UNMANAGED_NETWORK_POLICIES_RESPONSE__ANON_STRUCT_1 = {};
+export type REMOVE_UNMANAGED_NETWORK_POLICIES_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CONTROLLERS_REMOVEUNMANAGEDNETWORKPOLICIESREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": REMOVE_UNMANAGED_NETWORK_POLICIES_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type SERVICE_CREATE_REQUEST__K8S_IO_API_AUTOSCALING_V2_CONTAINERRESOURCEMETRICSOURCE = {"container": string,"name": string,"target": SERVICE_CREATE_REQUEST__K8S_IO_API_AUTOSCALING_V2_METRICTARGET};
 export type SERVICE_CREATE_REQUEST__K8S_IO_API_AUTOSCALING_V2_CROSSVERSIONOBJECTREFERENCE = {"apiVersion": string,"kind": string,"name": string};
 export type SERVICE_CREATE_REQUEST__K8S_IO_API_AUTOSCALING_V2_EXTERNALMETRICSOURCE = {"metric": SERVICE_CREATE_REQUEST__K8S_IO_API_AUTOSCALING_V2_METRICIDENTIFIER,"target": SERVICE_CREATE_REQUEST__K8S_IO_API_AUTOSCALING_V2_METRICTARGET};
@@ -17700,8 +19134,12 @@ export type SERVICE_DELETE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_JOB = {"co
 export type SERVICE_DELETE_RESPONSE__TIME_TIME = {};
 export type SERVICE_EXEC_SH_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_PODCMDCONNECTIONREQUEST = {"container": string,"controller": string,"logTail": string,"namespace": string,"pod": string,"wsConnectionRequest": SERVICE_EXEC_SH_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST};
 export type SERVICE_EXEC_SH_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type SERVICE_EXEC_SH_CONNECTION_REQUEST_RESPONSE__ANON_STRUCT_1 = {};
+export type SERVICE_EXEC_SH_CONNECTION_REQUEST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_PODCMDCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": SERVICE_EXEC_SH_CONNECTION_REQUEST_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type SERVICE_LOG_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_PODCMDCONNECTIONREQUEST = {"container": string,"controller": string,"logTail": string,"namespace": string,"pod": string,"wsConnectionRequest": SERVICE_LOG_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST};
 export type SERVICE_LOG_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type SERVICE_LOG_STREAM_CONNECTION_REQUEST_RESPONSE__ANON_STRUCT_1 = {};
+export type SERVICE_LOG_STREAM_CONNECTION_REQUEST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_PODCMDCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": SERVICE_LOG_STREAM_CONNECTION_REQUEST_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type SERVICE_PODS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_SERVICEPODSREQUEST = {"controllerName": string,"namespace": string};
 export type SERVICE_PODS_RESPONSE__K8S_IO_API_CORE_V1_AWSELASTICBLOCKSTOREVOLUMESOURCE = {"fsType": string,"partition": number,"readOnly": boolean,"volumeID": string};
 export type SERVICE_PODS_RESPONSE__K8S_IO_API_CORE_V1_AFFINITY = {"nodeAffinity": SERVICE_PODS_RESPONSE__K8S_IO_API_CORE_V1_NODEAFFINITY|undefined,"podAffinity": SERVICE_PODS_RESPONSE__K8S_IO_API_CORE_V1_PODAFFINITY|undefined,"podAntiAffinity": SERVICE_PODS_RESPONSE__K8S_IO_API_CORE_V1_PODANTIAFFINITY|undefined};
@@ -17834,6 +19272,8 @@ export type SERVICE_PODS_RESPONSE__K8S_IO_APIMACHINERY_PKG_UTIL_INTSTR_INTORSTRI
 export type SERVICE_PODS_RESPONSE__TIME_TIME = {};
 export type SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_PODEVENTCONNECTIONREQUEST = {"controller": string,"namespace": string,"wsConnectionRequest": SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST};
 export type SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_REQUEST__MOGENIUS_K8S_MANAGER_SRC_XTERM_WSCONNECTIONREQUEST = {"channelId": string,"cmdType": string,"nodeName": string,"podName": string,"websocketHost": string,"websocketScheme": string,"workspace": string};
+export type SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_RESPONSE__ANON_STRUCT_1 = {};
+export type SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_XTERM_PODEVENTCONNECTIONREQUEST_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": SERVICE_POD_EVENT_STREAM_CONNECTION_REQUEST_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type SERVICE_RESOURCE_STATUS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_SERVICERESOURCESTATUSREQUEST = {"name": string,"namespace": string,"resource": string,"statusOnly": boolean};
 export type SERVICE_RESOURCE_STATUS_RESPONSE__K8S_IO_API_CORE_V1_AWSELASTICBLOCKSTOREVOLUMESOURCE = {"fsType": string,"partition": number,"readOnly": boolean,"volumeID": string};
 export type SERVICE_RESOURCE_STATUS_RESPONSE__K8S_IO_API_CORE_V1_AFFINITY = {"nodeAffinity": SERVICE_RESOURCE_STATUS_RESPONSE__K8S_IO_API_CORE_V1_NODEAFFINITY|undefined,"podAffinity": SERVICE_RESOURCE_STATUS_RESPONSE__K8S_IO_API_CORE_V1_PODAFFINITY|undefined,"podAntiAffinity": SERVICE_RESOURCE_STATUS_RESPONSE__K8S_IO_API_CORE_V1_PODANTIAFFINITY|undefined};
@@ -18123,9 +19563,6 @@ export type SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SPRO
 export type SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SSERVICEDTO = {"containers": SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SCONTAINERDTO[],"controller": string,"controllerName": string,"cronJobSettings": SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SCRONJOBSETTINGSDTO|undefined,"deploymentStrategy": string,"displayName": string,"hpaSettings": SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SHPASETTINGSDTO|undefined,"id": string,"ports": SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SPORTSDTO[],"replicaCount": number};
 export type SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SSERVICESETTINGSDTO = {"ephemeralStorageMB": number,"imagePullPolicy": string,"limitCpuCores": number,"limitMemoryMB": number};
 export type SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_SERVICEUPDATEREQUEST = {"namespace": SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SNAMESPACEDTO,"project": SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SPROJECTDTO,"service": SERVICE_UPDATE_SERVICE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SSERVICEDTO};
-export type SERVICE_UPDATE_SERVICE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_COMMAND = {"command": string,"finished": SERVICE_UPDATE_SERVICE_RESPONSE__TIME_TIME,"id": string,"message": string,"started": SERVICE_UPDATE_SERVICE_RESPONSE__TIME_TIME,"state": string,"title": string};
-export type SERVICE_UPDATE_SERVICE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_JOB = {"commands": SERVICE_UPDATE_SERVICE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_COMMAND|undefined[],"containerName": string,"controllerName": string,"finished": SERVICE_UPDATE_SERVICE_RESPONSE__TIME_TIME,"id": string,"message": string,"namespaceName": string,"projectId": string,"started": SERVICE_UPDATE_SERVICE_RESPONSE__TIME_TIME,"state": string,"title": string};
-export type SERVICE_UPDATE_SERVICE_RESPONSE__TIME_TIME = {};
 export type STATS_PODSTAT_ALL_FOR_CONTROLLER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"kind": string,"name": string,"namespace": string,"timeOffsetMinutes": number};
 export type STATS_PODSTAT_ALL_FOR_CONTROLLER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_PODSTATS = {"containerName": string,"cpu": number,"cpuLimit": number,"createdAt": string,"ephemeralStorage": number,"ephemeralStorageLimit": number,"memory": number,"memoryLimit": number,"namespace": string,"podName": string,"startTime": string};
 export type STATS_PODSTAT_LAST_FOR_CONTROLLER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_DTOS_K8SCONTROLLER = {"kind": string,"name": string,"namespace": string};
@@ -18143,10 +19580,13 @@ export type STATS_TRAFFIC_SUM_FOR_NAMESPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_N
 export type STATS_TRAFFIC_SUM_FOR_NAMESPACE_RESPONSE__TIME_TIME = {};
 export type STATS_WORKSPACE_CPU_UTILIZATION_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"timeOffsetMinutes": number,"workspaceName": string};
 export type STATS_WORKSPACE_CPU_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY = {"time": string,"value": number};
+export type STATS_WORKSPACE_CPU_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST9_MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY = {"data": STATS_WORKSPACE_CPU_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY[],"message": string,"status": string};
 export type STATS_WORKSPACE_MEMORY_UTILIZATION_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"timeOffsetMinutes": number,"workspaceName": string};
 export type STATS_WORKSPACE_MEMORY_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY = {"time": string,"value": number};
+export type STATS_WORKSPACE_MEMORY_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST9_MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY = {"data": STATS_WORKSPACE_MEMORY_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY[],"message": string,"status": string};
 export type STATS_WORKSPACE_TRAFFIC_UTILIZATION_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"timeOffsetMinutes": number,"workspaceName": string};
 export type STATS_WORKSPACE_TRAFFIC_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY = {"time": string,"value": number};
+export type STATS_WORKSPACE_TRAFFIC_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST9_MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY = {"data": STATS_WORKSPACE_TRAFFIC_UTILIZATION_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_GENERICCHARTENTRY[],"message": string,"status": string};
 export type STORAGE_CREATE_VOLUME_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NFSVOLUMEREQUEST = {"namespaceName": string,"sizeInGb": number,"volumeName": string};
 export type STORAGE_CREATE_VOLUME_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_DEFAULTRESPONSE = {"error": string,"success": boolean};
 export type STORAGE_DELETE_VOLUME_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NFSVOLUMEREQUEST = {"namespaceName": string,"sizeInGb": number,"volumeName": string};
@@ -18158,37 +19598,56 @@ export type STORAGE_STATS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NFSVOLUMES
 export type STORAGE_STATUS_REQUEST__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NFSSTATUSREQUEST = {"name": string,"namespace": string,"type": string};
 export type STORAGE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_NFSSTATUSRESPONSE = {"freeBytes": number,"messages": STORAGE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_VOLUMESTATUSMESSAGE[],"namespaceName": string,"status": string,"totalBytes": number,"usedByPods": string[],"usedBytes": number,"volumeName": string};
 export type STORAGE_STATUS_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_VOLUMESTATUSMESSAGE = {"message": string,"type": string};
+export type SYSTEM_CHECK_REQUEST__ANON_STRUCT_0 = {};
 export type SYSTEM_CHECK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_SYSTEMCHECKENTRY = {"checkName": string,"description": string,"errorMessage": string|undefined,"helmStatus": string,"installPattern": string,"isRequired": boolean,"isRunning": boolean,"processTimeInMs": number,"solutionMessage": string,"successMessage": string,"uninstallPattern": string,"upgradePattern": string,"versionAvailable": string,"versionInstalled": string,"wantsToBeInstalled": boolean};
 export type SYSTEM_CHECK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_SYSTEMCHECKRESPONSE = {"entries": SYSTEM_CHECK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_SERVICES_SYSTEMCHECKENTRY[],"terminalString": string};
 export type TRIGGER_WORKLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM = {"group": string,"kind": string,"name": string,"namespace": string,"resourceName": string,"version": string};
 export type TRIGGER_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
+export type TRIGGER_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEITEM_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"data": TRIGGER_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED|undefined,"message": string,"status": string};
 export type UNINSTALL_CERT_MANAGER_REQUEST__ANON_STRUCT_0 = {};
+export type UNINSTALL_CERT_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UNINSTALL_CLUSTER_ISSUER_REQUEST__ANON_STRUCT_0 = {};
+export type UNINSTALL_CLUSTER_ISSUER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UNINSTALL_INGRESS_CONTROLLER_TRAEFIK_REQUEST__ANON_STRUCT_0 = {};
+export type UNINSTALL_INGRESS_CONTROLLER_TRAEFIK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UNINSTALL_KEPLER_REQUEST__ANON_STRUCT_0 = {};
+export type UNINSTALL_KEPLER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UNINSTALL_METALLB_REQUEST__ANON_STRUCT_0 = {};
+export type UNINSTALL_METALLB_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UNINSTALL_METRICS_SERVER_REQUEST__ANON_STRUCT_0 = {};
+export type UNINSTALL_METRICS_SERVER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UPDATE_GRANT_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"grantee": string,"name": string,"role": string,"targetName": string,"targetType": string};
+export type UPDATE_GRANT_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST31_STRING = {"data": string,"message": string,"status": string};
 export type UPDATE_NETWORK_POLICIES_TEMPLATE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_KUBERNETES_NETWORKPOLICY = {"Name": string,"Port": number,"Protocol": string,"Type": string};
-export type UPDATE_NETWORK_POLICIES_TEMPLATE_RESPONSE__ANON_STRUCT_0 = {};
+export type UPDATE_NETWORK_POLICIES_TEMPLATE_RESPONSE__ANON_STRUCT_1 = {};
+export type UPDATE_NETWORK_POLICIES_TEMPLATE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_KUBERNETES_NETWORKPOLICY_MOGENIUS_K8S_MANAGER_SRC_CORE_VOID = {"data": UPDATE_NETWORK_POLICIES_TEMPLATE_RESPONSE__ANON_STRUCT_1|undefined,"message": string,"status": string};
 export type UPDATE_USER_REQUEST__K8S_IO_API_RBAC_V1_SUBJECT = {"apiGroup": string,"kind": string,"name": string,"namespace": string};
 export type UPDATE_USER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"email": string,"firstName": string,"lastName": string,"name": string,"subject": UPDATE_USER_REQUEST__K8S_IO_API_RBAC_V1_SUBJECT|undefined};
+export type UPDATE_USER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST26_STRING = {"data": string,"message": string,"status": string};
 export type UPDATE_WORKLOAD_REQUEST__MOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEDATA = {"group": string,"kind": string,"name": string,"namespace": string|undefined,"version": string,"yamlData": string};
 export type UPDATE_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"Object": Record<string, any>};
+export type UPDATE_WORKLOAD_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_UTILS_RESOURCEDATA_K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED = {"data": UPDATE_WORKLOAD_RESPONSE__K8S_IO_APIMACHINERY_PKG_APIS_META_V1_UNSTRUCTURED_UNSTRUCTURED|undefined,"message": string,"status": string};
 export type UPDATE_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"displayName": string,"name": string,"resources": UPDATE_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_WORKSPACERESOURCEIDENTIFIER[]};
 export type UPDATE_WORKSPACE_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CRDS_V1ALPHA1_WORKSPACERESOURCEIDENTIFIER = {"id": string,"namespace": string,"type": string};
+export type UPDATE_WORKSPACE_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST21_STRING = {"data": string,"message": string,"status": string};
 export type UPGRADEK8SMANAGER_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"command": string};
 export type UPGRADEK8SMANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_COMMAND = {"command": string,"finished": UPGRADEK8SMANAGER_RESPONSE__TIME_TIME,"id": string,"message": string,"started": UPGRADEK8SMANAGER_RESPONSE__TIME_TIME,"state": string,"title": string};
 export type UPGRADEK8SMANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_JOB = {"commands": UPGRADEK8SMANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_STRUCTS_COMMAND|undefined[],"containerName": string,"controllerName": string,"finished": UPGRADEK8SMANAGER_RESPONSE__TIME_TIME,"id": string,"message": string,"namespaceName": string,"projectId": string,"started": UPGRADEK8SMANAGER_RESPONSE__TIME_TIME,"state": string,"title": string};
 export type UPGRADEK8SMANAGER_RESPONSE__TIME_TIME = {};
 export type UPGRADE_CERT_MANAGER_REQUEST__ANON_STRUCT_0 = {};
+export type UPGRADE_CERT_MANAGER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UPGRADE_INGRESS_CONTROLLER_TRAEFIK_REQUEST__ANON_STRUCT_0 = {};
+export type UPGRADE_INGRESS_CONTROLLER_TRAEFIK_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UPGRADE_KEPLER_REQUEST__ANON_STRUCT_0 = {};
+export type UPGRADE_KEPLER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UPGRADE_METALLB_REQUEST__ANON_STRUCT_0 = {};
+export type UPGRADE_METALLB_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type UPGRADE_METRICS_SERVER_REQUEST__ANON_STRUCT_0 = {};
+export type UPGRADE_METRICS_SERVER_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_VOID_STRING = {"data": string,"message": string,"status": string};
 export type WORKSPACE_CLEAN_UP_REQUEST__MOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST = {"configMaps": boolean,"dryRun": boolean,"ingresses": boolean,"jobs": boolean,"name": string,"pods": boolean,"replicaSets": boolean,"secrets": boolean,"services": boolean};
 export type WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULT = {"configMaps": WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULTENTRY[],"ingresses": WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULTENTRY[],"jobs": WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULTENTRY[],"pods": WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULTENTRY[],"replicaSets": WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULTENTRY[],"secrets": WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULTENTRY[],"services": WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULTENTRY[]};
 export type WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULTENTRY = {"name": string,"namespace": string,"reason": string};
+export type WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_RESULTMOGENIUS_K8S_MANAGER_SRC_CORE_REQUEST20_MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULT = {"data": WORKSPACE_CLEAN_UP_RESPONSE__MOGENIUS_K8S_MANAGER_SRC_CORE_CLEANUPRESULT,"message": string,"status": string};
 
 //===============================================================
 //==================== Pattern Type Mapping =====================

--- a/generated/spec.yaml
+++ b/generated/spec.yaml
@@ -1,12 +1,39 @@
 ClusterForceDisconnect:
+    legacyResponseLayout: true
+    requestSchema:
+        structs:
+            ANON_STRUCT_0:
+                properties: {}
+        typeInfo:
+            pointer: true
+            structRef: ANON_STRUCT_0
+            type: struct
     responseSchema:
         typeInfo:
             type: bool
 ClusterForceReconnect:
+    legacyResponseLayout: true
+    requestSchema:
+        structs:
+            ANON_STRUCT_0:
+                properties: {}
+        typeInfo:
+            pointer: true
+            structRef: ANON_STRUCT_0
+            type: struct
     responseSchema:
         typeInfo:
             type: bool
 ClusterResourceInfo:
+    legacyResponseLayout: true
+    requestSchema:
+        structs:
+            ANON_STRUCT_0:
+                properties: {}
+        typeInfo:
+            pointer: true
+            structRef: ANON_STRUCT_0
+            type: struct
     responseSchema:
         structs:
             mogenius-k8s-manager/src/core.Response:
@@ -181,8 +208,35 @@ ClusterResourceInfo:
         typeInfo:
             structRef: mogenius-k8s-manager/src/core.Response
             type: struct
-K8sNotification: {}
+K8sNotification:
+    requestSchema:
+        structs:
+            ANON_STRUCT_0:
+                properties: {}
+        typeInfo:
+            pointer: true
+            structRef: ANON_STRUCT_0
+            type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Void]
+            type: struct
 SERVICE_PODS:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.ServicePodsRequest:
@@ -2342,6 +2396,15 @@ SERVICE_PODS:
                 type: struct
             type: array
 SYSTEM_CHECK:
+    legacyResponseLayout: true
+    requestSchema:
+        structs:
+            ANON_STRUCT_0:
+                properties: {}
+        typeInfo:
+            pointer: true
+            structRef: ANON_STRUCT_0
+            type: struct
     responseSchema:
         structs:
             mogenius-k8s-manager/src/services.SystemCheckEntry:
@@ -2392,6 +2455,7 @@ SYSTEM_CHECK:
             structRef: mogenius-k8s-manager/src/services.SystemCheckResponse
             type: struct
 UpgradeK8sManager:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -2493,25 +2557,33 @@ attach/labeled_network_policy:
             structRef: mogenius-k8s-manager/src/controllers.AttachLabeledNetworkPolicyRequest
             type: struct
     responseSchema:
-        typeInfo:
-            type: string
-cluster/backup:
-    responseSchema:
         structs:
-            mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse:
-                name: mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.AttachLabeledNetworkPolicyRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.AttachLabeledNetworkPolicyRequest,string]
                 properties:
                     data:
                         type: string
-                    messages:
-                        elementType:
-                            type: string
-                        type: array
-                    namespaceName:
+                    message:
+                        type: string
+                    status:
                         type: string
         typeInfo:
-            structRef: mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.AttachLabeledNetworkPolicyRequest,string]
             type: struct
+cluster/backup:
+    legacyResponseLayout: true
+    requestSchema:
+        structs:
+            ANON_STRUCT_0:
+                properties: {}
+        typeInfo:
+            pointer: true
+            structRef: ANON_STRUCT_0
+            type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 cluster/clear-valkey-cache:
     requestSchema:
         structs:
@@ -2528,8 +2600,19 @@ cluster/clear-valkey-cache:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·5,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·5,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·5,string]
+            type: struct
 cluster/component-log-stream-connection-request:
     requestSchema:
         structs:
@@ -2570,6 +2653,24 @@ cluster/component-log-stream-connection-request:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.ComponentLogConnectionRequest
             type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.ComponentLogConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.ComponentLogConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.ComponentLogConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            type: struct
 cluster/helm-chart-install:
     requestSchema:
         structs:
@@ -2592,8 +2693,19 @@ cluster/helm-chart-install:
             structRef: mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]
+            type: struct
 cluster/helm-chart-install-oci:
     requestSchema:
         structs:
@@ -2622,8 +2734,19 @@ cluster/helm-chart-install-oci:
             structRef: mogenius-k8s-manager/src/helm.HelmChartOciInstallUpgradeRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartOciInstallUpgradeRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartOciInstallUpgradeRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartOciInstallUpgradeRequest,string]
+            type: struct
 cluster/helm-chart-remove:
     requestSchema:
         structs:
@@ -2636,8 +2759,19 @@ cluster/helm-chart-remove:
             structRef: mogenius-k8s-manager/src/helm.HelmRepoRemoveRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoRemoveRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoRemoveRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoRemoveRequest,string]
+            type: struct
 cluster/helm-chart-search:
     requestSchema:
         structs:
@@ -2651,6 +2785,18 @@ cluster/helm-chart-search:
             type: struct
     responseSchema:
         structs:
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartSearchRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartSearchRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/helm.HelmChartInfo
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/helm.HelmChartInfo:
                 name: mogenius-k8s-manager/src/helm.HelmChartInfo
                 properties:
@@ -2663,10 +2809,8 @@ cluster/helm-chart-search:
                     version:
                         type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/helm.HelmChartInfo
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartSearchRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+            type: struct
 cluster/helm-chart-show:
     requestSchema:
         structs:
@@ -2681,8 +2825,19 @@ cluster/helm-chart-show:
             structRef: mogenius-k8s-manager/src/helm.HelmChartShowRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartShowRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartShowRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartShowRequest,string]
+            type: struct
 cluster/helm-chart-versions:
     requestSchema:
         structs:
@@ -2696,6 +2851,18 @@ cluster/helm-chart-versions:
             type: struct
     responseSchema:
         structs:
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartVersionRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartVersionRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/helm.HelmChartInfo
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/helm.HelmChartInfo:
                 name: mogenius-k8s-manager/src/helm.HelmChartInfo
                 properties:
@@ -2708,10 +2875,8 @@ cluster/helm-chart-versions:
                     version:
                         type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/helm.HelmChartInfo
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartVersionRequest,[]mogenius-k8s-manager/src/helm.HelmChartInfo]
+            type: struct
 cluster/helm-release-get:
     requestSchema:
         structs:
@@ -2728,8 +2893,19 @@ cluster/helm-release-get:
             structRef: mogenius-k8s-manager/src/helm.HelmReleaseGetRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetRequest,string]
+            type: struct
 cluster/helm-release-get-workloads:
     requestSchema:
         structs:
@@ -2775,11 +2951,21 @@ cluster/helm-release-get-workloads:
                         valueType:
                             pointer: true
                             type: any
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetWorkloadsRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetWorkloadsRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+                properties:
+                    data:
+                        elementType:
+                            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseGetWorkloadsRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            type: struct
 cluster/helm-release-history:
     requestSchema:
         structs:
@@ -3042,15 +3228,25 @@ cluster/helm-release-history:
                     Time:
                         structRef: time.Time
                         type: struct
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseHistoryRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseHistoryRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+                properties:
+                    data:
+                        elementType:
+                            pointer: true
+                            structRef: helm.sh/helm/v3/pkg/release.Release
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             time.Time:
                 name: time.Time
                 properties: {}
         typeInfo:
-            elementType:
-                pointer: true
-                structRef: helm.sh/helm/v3/pkg/release.Release
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseHistoryRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+            type: struct
 cluster/helm-release-list:
     requestSchema:
         structs:
@@ -3311,15 +3507,25 @@ cluster/helm-release-list:
                     Time:
                         structRef: time.Time
                         type: struct
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseListRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseListRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+                properties:
+                    data:
+                        elementType:
+                            pointer: true
+                            structRef: helm.sh/helm/v3/pkg/release.Release
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             time.Time:
                 name: time.Time
                 properties: {}
         typeInfo:
-            elementType:
-                pointer: true
-                structRef: helm.sh/helm/v3/pkg/release.Release
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseListRequest,[]*helm.sh/helm/v3/pkg/release.Release]
+            type: struct
 cluster/helm-release-rollback:
     requestSchema:
         structs:
@@ -3336,8 +3542,19 @@ cluster/helm-release-rollback:
             structRef: mogenius-k8s-manager/src/helm.HelmReleaseRollbackRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseRollbackRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseRollbackRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseRollbackRequest,string]
+            type: struct
 cluster/helm-release-status:
     requestSchema:
         structs:
@@ -3353,6 +3570,17 @@ cluster/helm-release-status:
             type: struct
     responseSchema:
         structs:
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseStatusRequest,*mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseStatusRequest,*mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo:
                 name: mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo
                 properties:
@@ -3373,8 +3601,7 @@ cluster/helm-release-status:
                 name: time.Time
                 properties: {}
         typeInfo:
-            pointer: true
-            structRef: mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseStatusRequest,*mogenius-k8s-manager/src/helm.HelmReleaseStatusInfo]
             type: struct
 cluster/helm-release-uninstall:
     requestSchema:
@@ -3392,8 +3619,19 @@ cluster/helm-release-uninstall:
             structRef: mogenius-k8s-manager/src/helm.HelmReleaseUninstallRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseUninstallRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseUninstallRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmReleaseUninstallRequest,string]
+            type: struct
 cluster/helm-release-upgrade:
     requestSchema:
         structs:
@@ -3416,8 +3654,19 @@ cluster/helm-release-upgrade:
             structRef: mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmChartInstallUpgradeRequest,string]
+            type: struct
 cluster/helm-repo-add:
     requestSchema:
         structs:
@@ -3440,8 +3689,19 @@ cluster/helm-repo-add:
             structRef: mogenius-k8s-manager/src/helm.HelmRepoAddRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoAddRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoAddRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoAddRequest,string]
+            type: struct
 cluster/helm-repo-list:
     requestSchema:
         structs:
@@ -3453,6 +3713,19 @@ cluster/helm-repo-list:
             type: struct
     responseSchema:
         structs:
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]*mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]*mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword]
+                properties:
+                    data:
+                        elementType:
+                            pointer: true
+                            structRef: mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword:
                 name: mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword
                 properties:
@@ -3465,11 +3738,8 @@ cluster/helm-repo-list:
                     url:
                         type: string
         typeInfo:
-            elementType:
-                pointer: true
-                structRef: mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]*mogenius-k8s-manager/src/helm.HelmEntryWithoutPassword]
+            type: struct
 cluster/helm-repo-patch:
     requestSchema:
         structs:
@@ -3494,8 +3764,19 @@ cluster/helm-repo-patch:
             structRef: mogenius-k8s-manager/src/helm.HelmRepoPatchRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoPatchRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoPatchRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/helm.HelmRepoPatchRequest,string]
+            type: struct
 cluster/helm-repo-update:
     requestSchema:
         structs:
@@ -3507,6 +3788,18 @@ cluster/helm-repo-update:
             type: struct
     responseSchema:
         structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/helm.HelmEntryStatus]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/helm.HelmEntryStatus]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/helm.HelmEntryStatus
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/helm.HelmEntryStatus:
                 name: mogenius-k8s-manager/src/helm.HelmEntryStatus
                 properties:
@@ -3530,10 +3823,8 @@ cluster/helm-repo-update:
                     url:
                         type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/helm.HelmEntryStatus
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/helm.HelmEntryStatus]
+            type: struct
 cluster/list-persistent-volume-claims:
     requestSchema:
         structs:
@@ -3841,14 +4132,24 @@ cluster/list-persistent-volume-claims:
                         type: string
                     kind:
                         type: string
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/services.ClusterListWorkloads,[]k8s.io/api/core/v1.PersistentVolumeClaim]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/services.ClusterListWorkloads,[]k8s.io/api/core/v1.PersistentVolumeClaim]
+                properties:
+                    data:
+                        elementType:
+                            structRef: k8s.io/api/core/v1.PersistentVolumeClaim
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             time.Time:
                 name: time.Time
                 properties: {}
         typeInfo:
-            elementType:
-                structRef: k8s.io/api/core/v1.PersistentVolumeClaim
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/services.ClusterListWorkloads,[]k8s.io/api/core/v1.PersistentVolumeClaim]
+            type: struct
 cluster/machine-stats:
     requestSchema:
         structs:
@@ -3864,17 +4165,28 @@ cluster/machine-stats:
             type: struct
     responseSchema:
         structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·17,[]mogenius-k8s-manager/src/structs.MachineStats]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·17,[]mogenius-k8s-manager/src/structs.MachineStats]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/structs.MachineStats
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/structs.MachineStats:
                 name: mogenius-k8s-manager/src/structs.MachineStats
                 properties:
                     btfSupport:
                         type: bool
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/structs.MachineStats
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·17,[]mogenius-k8s-manager/src/structs.MachineStats]
+            type: struct
 cluster/update-local-tls-secret:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.ClusterUpdateLocalTlsSecret:
@@ -3887,6 +4199,10 @@ cluster/update-local-tls-secret:
         typeInfo:
             structRef: mogenius-k8s-manager/src/services.ClusterUpdateLocalTlsSecret
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 create/grant:
     requestSchema:
         structs:
@@ -3907,8 +4223,19 @@ create/grant:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·29,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·29,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·29,string]
+            type: struct
 create/new-workload:
     requestSchema:
         structs:
@@ -3943,9 +4270,19 @@ create/new-workload:
                         valueType:
                             pointer: true
                             type: any
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
             type: struct
 create/user:
     requestSchema:
@@ -3980,8 +4317,19 @@ create/user:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·24,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·24,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·24,string]
+            type: struct
 create/workspace:
     requestSchema:
         structs:
@@ -4010,8 +4358,19 @@ create/workspace:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·18,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·18,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·18,string]
+            type: struct
 delete/grant:
     requestSchema:
         structs:
@@ -4024,8 +4383,19 @@ delete/grant:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·32,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·32,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·32,string]
+            type: struct
 delete/user:
     requestSchema:
         structs:
@@ -4038,8 +4408,19 @@ delete/user:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·27,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·27,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·27,string]
+            type: struct
 delete/workload:
     requestSchema:
         structs:
@@ -4063,11 +4444,21 @@ delete/workload:
             type: struct
     responseSchema:
         structs:
-            ANON_STRUCT_0:
+            ANON_STRUCT_1:
                 properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: ANON_STRUCT_0
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,mogenius-k8s-manager/src/core.Void]
             type: struct
 delete/workspace:
     requestSchema:
@@ -4081,8 +4472,19 @@ delete/workspace:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·22,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·22,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·22,string]
+            type: struct
 describe:
     requestSchema:
         structs:
@@ -4094,14 +4496,14 @@ describe:
             type: struct
     responseSchema:
         structs:
-            ANON_STRUCT_1:
+            ANON_STRUCT_2:
                 properties:
                     buildType:
                         type: string
                     version:
                         structRef: mogenius-k8s-manager/src/version.Version
                         type: struct
-            ANON_STRUCT_3:
+            ANON_STRUCT_4:
                 properties: {}
             mogenius-k8s-manager/src/core.PatternConfig:
                 name: mogenius-k8s-manager/src/core.PatternConfig
@@ -4110,6 +4512,8 @@ describe:
                         type: bool
                     deprecatedMessage:
                         type: string
+                    legacyResponseLayout:
+                        type: bool
                     needsUser:
                         type: bool
                     requestSchema:
@@ -4124,10 +4528,10 @@ describe:
                 name: mogenius-k8s-manager/src/core.Response
                 properties:
                     buildInfo:
-                        structRef: ANON_STRUCT_1
+                        structRef: ANON_STRUCT_2
                         type: struct
                     features:
-                        structRef: ANON_STRUCT_3
+                        structRef: ANON_STRUCT_4
                         type: struct
                     patterns:
                         keyType:
@@ -4136,6 +4540,16 @@ describe:
                         valueType:
                             structRef: mogenius-k8s-manager/src/core.PatternConfig
                             type: struct
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Response·2]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Response·2]
+                properties:
+                    data:
+                        structRef: mogenius-k8s-manager/src/core.Response
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/schema.Schema:
                 name: mogenius-k8s-manager/src/schema.Schema
                 properties:
@@ -4200,7 +4614,7 @@ describe:
                     version:
                         type: string
         typeInfo:
-            structRef: mogenius-k8s-manager/src/core.Response
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,mogenius-k8s-manager/src/core.Response·2]
             type: struct
 describe/workload:
     requestSchema:
@@ -4224,8 +4638,19 @@ describe/workload:
             structRef: mogenius-k8s-manager/src/utils.ResourceItem
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]
+            type: struct
 detach/labeled_network_policy:
     requestSchema:
         structs:
@@ -4258,8 +4683,19 @@ detach/labeled_network_policy:
             structRef: mogenius-k8s-manager/src/controllers.DetachLabeledNetworkPolicyRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DetachLabeledNetworkPolicyRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DetachLabeledNetworkPolicyRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DetachLabeledNetworkPolicyRequest,string]
+            type: struct
 disable/network_policy_manager:
     requestSchema:
         structs:
@@ -4273,11 +4709,21 @@ disable/network_policy_manager:
             type: struct
     responseSchema:
         structs:
-            ANON_STRUCT_0:
+            ANON_STRUCT_1:
                 properties: {}
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DisableNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DisableNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: ANON_STRUCT_0
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.DisableNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
             type: struct
 enforce/network_policy_manager:
     requestSchema:
@@ -4292,13 +4738,24 @@ enforce/network_policy_manager:
             type: struct
     responseSchema:
         structs:
-            ANON_STRUCT_0:
+            ANON_STRUCT_1:
                 properties: {}
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.EnforceNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.EnforceNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: ANON_STRUCT_0
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.EnforceNetworkPolicyManagerRequest,mogenius-k8s-manager/src/core.Void]
             type: struct
 external-secret-store/create:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/controllers.CreateSecretsStoreRequest:
@@ -4330,6 +4787,7 @@ external-secret-store/create:
             structRef: mogenius-k8s-manager/src/controllers.CreateSecretsStoreResponse
             type: struct
 external-secret-store/delete:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/controllers.DeleteSecretsStoreRequest:
@@ -4353,6 +4811,7 @@ external-secret-store/delete:
             structRef: mogenius-k8s-manager/src/controllers.DeleteSecretsStoreResponse
             type: struct
 external-secret-store/list:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/controllers.ListSecretStoresRequest:
@@ -4398,6 +4857,7 @@ external-secret-store/list:
                 type: struct
             type: array
 external-secret/list-available-secrets:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/controllers.ListSecretsRequest:
@@ -4414,6 +4874,7 @@ external-secret/list-available-secrets:
                 type: string
             type: array
 files/chmod:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -4436,7 +4897,12 @@ files/chmod:
         typeInfo:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 files/chown:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -4461,7 +4927,12 @@ files/chown:
         typeInfo:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 files/create-folder:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -4482,7 +4953,12 @@ files/create-folder:
         typeInfo:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 files/delete:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -4503,7 +4979,12 @@ files/delete:
         typeInfo:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 files/download:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -4526,7 +5007,20 @@ files/download:
         typeInfo:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
+    responseSchema:
+        structs:
+            mogenius-k8s-manager/src/services.FilesDownloadResponse:
+                name: mogenius-k8s-manager/src/services.FilesDownloadResponse
+                properties:
+                    error:
+                        type: string
+                    sizeInBytes:
+                        type: int
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/services.FilesDownloadResponse
+            type: struct
 files/info:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/dtos.PersistentFileRequestDto:
@@ -4543,19 +5037,40 @@ files/info:
             type: struct
     responseSchema:
         structs:
-            mogenius-k8s-manager/src/dtos.PersistentFileRequestDto:
-                name: mogenius-k8s-manager/src/dtos.PersistentFileRequestDto
+            mogenius-k8s-manager/src/dtos.PersistentFileDto:
+                name: mogenius-k8s-manager/src/dtos.PersistentFileDto
                 properties:
-                    path:
+                    contentType:
                         type: string
-                    volumeName:
+                    createdAt:
                         type: string
-                    volumeNamespace:
+                    extension:
+                        type: string
+                    hash:
+                        type: string
+                    mimeType:
+                        type: string
+                    mode:
+                        type: string
+                    modifiedAt:
+                        type: string
+                    name:
+                        type: string
+                    relativePath:
+                        type: string
+                    size:
+                        type: string
+                    sizeInBytes:
+                        type: int
+                    type:
+                        type: string
+                    uid_gid:
                         type: string
         typeInfo:
-            structRef: mogenius-k8s-manager/src/dtos.PersistentFileRequestDto
+            structRef: mogenius-k8s-manager/src/dtos.PersistentFileDto
             type: struct
 files/list:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -4613,6 +5128,7 @@ files/list:
                 type: struct
             type: array
 files/rename:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -4635,6 +5151,10 @@ files/rename:
         typeInfo:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 get/grant:
     requestSchema:
         structs:
@@ -4755,6 +5275,17 @@ get/grant:
                         type: string
                     kind:
                         type: string
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·30,*mogenius-k8s-manager/src/crds/v1alpha1.Grant]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·30,*mogenius-k8s-manager/src/crds/v1alpha1.Grant]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: mogenius-k8s-manager/src/crds/v1alpha1.Grant
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/crds/v1alpha1.Grant:
                 name: mogenius-k8s-manager/src/crds/v1alpha1.Grant
                 properties:
@@ -4788,8 +5319,7 @@ get/grant:
                 name: time.Time
                 properties: {}
         typeInfo:
-            pointer: true
-            structRef: mogenius-k8s-manager/src/crds/v1alpha1.Grant
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·30,*mogenius-k8s-manager/src/crds/v1alpha1.Grant]
             type: struct
 get/grants:
     requestSchema:
@@ -4915,6 +5445,18 @@ get/grants:
                         type: string
                     kind:
                         type: string
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·28,[]mogenius-k8s-manager/src/crds/v1alpha1.Grant]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·28,[]mogenius-k8s-manager/src/crds/v1alpha1.Grant]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/crds/v1alpha1.Grant
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/crds/v1alpha1.Grant:
                 name: mogenius-k8s-manager/src/crds/v1alpha1.Grant
                 properties:
@@ -4948,10 +5490,8 @@ get/grants:
                 name: time.Time
                 properties: {}
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/crds/v1alpha1.Grant
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·28,[]mogenius-k8s-manager/src/crds/v1alpha1.Grant]
+            type: struct
 get/labeled-workload-list:
     requestSchema:
         structs:
@@ -5016,8 +5556,18 @@ get/labeled-workload-list:
                             structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
                             type: struct
                         type: array
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredLabeledResourceListRequest,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredLabeledResourceListRequest,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
+                properties:
+                    data:
+                        structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredLabeledResourceListRequest,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
             type: struct
 get/namespace-workload-list:
     requestSchema:
@@ -5068,11 +5618,21 @@ get/namespace-workload-list:
                         valueType:
                             pointer: true
                             type: any
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredNamespaceResourceListRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredNamespaceResourceListRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+                properties:
+                    data:
+                        elementType:
+                            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetUnstructuredNamespaceResourceListRequest,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            type: struct
 get/user:
     requestSchema:
         structs:
@@ -5204,6 +5764,17 @@ get/user:
                         type: string
                     kind:
                         type: string
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·25,*mogenius-k8s-manager/src/crds/v1alpha1.User]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·25,*mogenius-k8s-manager/src/crds/v1alpha1.User]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: mogenius-k8s-manager/src/crds/v1alpha1.User
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/crds/v1alpha1.User:
                 name: mogenius-k8s-manager/src/crds/v1alpha1.User
                 properties:
@@ -5239,8 +5810,7 @@ get/user:
                 name: time.Time
                 properties: {}
         typeInfo:
-            pointer: true
-            structRef: mogenius-k8s-manager/src/crds/v1alpha1.User
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·25,*mogenius-k8s-manager/src/crds/v1alpha1.User]
             type: struct
 get/users:
     requestSchema:
@@ -5374,6 +5944,18 @@ get/users:
                         type: string
                     kind:
                         type: string
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·23,[]mogenius-k8s-manager/src/crds/v1alpha1.User]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·23,[]mogenius-k8s-manager/src/crds/v1alpha1.User]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/crds/v1alpha1.User
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/crds/v1alpha1.User:
                 name: mogenius-k8s-manager/src/crds/v1alpha1.User
                 properties:
@@ -5409,10 +5991,8 @@ get/users:
                 name: time.Time
                 properties: {}
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/crds/v1alpha1.User
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·23,[]mogenius-k8s-manager/src/crds/v1alpha1.User]
+            type: struct
 get/workload:
     requestSchema:
         structs:
@@ -5446,9 +6026,19 @@ get/workload:
                         valueType:
                             pointer: true
                             type: any
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
             type: struct
 get/workload-example:
     requestSchema:
@@ -5472,8 +6062,19 @@ get/workload-example:
             structRef: mogenius-k8s-manager/src/utils.ResourceItem
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,string]
+            type: struct
 get/workload-list:
     requestSchema:
         structs:
@@ -5521,8 +6122,18 @@ get/workload-list:
                             structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
                             type: struct
                         type: array
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceEntry,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceEntry,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
+                properties:
+                    data:
+                        structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceEntry,k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList]
             type: struct
 get/workload-status:
     requestSchema:
@@ -5770,6 +6381,18 @@ get/workload-status:
                         type: string
                     kind:
                         type: string
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetWorkloadStatusRequest,[]mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetWorkloadStatusRequest,[]mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto:
                 name: mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto
                 properties:
@@ -5819,10 +6442,8 @@ get/workload-status:
                 name: time.Time
                 properties: {}
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/kubernetes.GetWorkloadStatusRequest,[]mogenius-k8s-manager/src/kubernetes.WorkloadStatusDto]
+            type: struct
 get/workspace:
     requestSchema:
         structs:
@@ -5855,6 +6476,17 @@ get/workspace:
                             structRef: mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier
                             type: struct
                         type: array
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·19,*mogenius-k8s-manager/src/core.GetWorkspaceResult]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·19,*mogenius-k8s-manager/src/core.GetWorkspaceResult]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: mogenius-k8s-manager/src/core.GetWorkspaceResult
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier:
                 name: mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier
                 properties:
@@ -5868,8 +6500,7 @@ get/workspace:
                 name: time.Time
                 properties: {}
         typeInfo:
-            pointer: true
-            structRef: mogenius-k8s-manager/src/core.GetWorkspaceResult
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·19,*mogenius-k8s-manager/src/core.GetWorkspaceResult]
             type: struct
 get/workspace-workloads:
     requestSchema:
@@ -5924,11 +6555,21 @@ get/workspace-workloads:
                         valueType:
                             pointer: true
                             type: any
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·33,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·33,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+                properties:
+                    data:
+                        elementType:
+                            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·33,[]k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            type: struct
 get/workspaces:
     requestSchema:
         structs:
@@ -5959,6 +6600,18 @@ get/workspaces:
                             structRef: mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier
                             type: struct
                         type: array
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/core.GetWorkspaceResult]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/core.GetWorkspaceResult]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/core.GetWorkspaceResult
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier:
                 name: mogenius-k8s-manager/src/crds/v1alpha1.WorkspaceResourceIdentifier
                 properties:
@@ -5972,10 +6625,8 @@ get/workspaces:
                 name: time.Time
                 properties: {}
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/core.GetWorkspaceResult
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/core.GetWorkspaceResult]
+            type: struct
 install-cert-manager:
     requestSchema:
         structs:
@@ -5986,8 +6637,19 @@ install-cert-manager:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 install-cluster-issuer:
     requestSchema:
         structs:
@@ -6000,8 +6662,19 @@ install-cluster-issuer:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·6,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·6,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·6,string]
+            type: struct
 install-ingress-controller-traefik:
     requestSchema:
         structs:
@@ -6012,8 +6685,19 @@ install-ingress-controller-traefik:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 install-kepler:
     requestSchema:
         structs:
@@ -6024,8 +6708,19 @@ install-kepler:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 install-metallb:
     requestSchema:
         structs:
@@ -6036,8 +6731,19 @@ install-metallb:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 install-metrics-server:
     requestSchema:
         structs:
@@ -6048,8 +6754,19 @@ install-metrics-server:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 list/all-workloads:
     requestSchema:
         structs:
@@ -6061,6 +6778,18 @@ list/all-workloads:
             type: struct
     responseSchema:
         structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/utils.ResourceEntry]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/utils.ResourceEntry]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/utils.ResourceEntry
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/utils.ResourceEntry:
                 name: mogenius-k8s-manager/src/utils.ResourceEntry
                 properties:
@@ -6076,10 +6805,8 @@ list/all-workloads:
                     version:
                         type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/utils.ResourceEntry
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/utils.ResourceEntry]
+            type: struct
 list/all_network_policies:
     requestSchema:
         structs:
@@ -6259,6 +6986,18 @@ list/all_network_policies:
                             structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
                             type: struct
                         type: array
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto:
                 name: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
                 properties:
@@ -6271,10 +7010,8 @@ list/all_network_policies:
                     type:
                         type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+            type: struct
 list/conflicting_network_policies:
     requestSchema:
         structs:
@@ -6416,11 +7153,21 @@ list/conflicting_network_policies:
                     spec:
                         structRef: k8s.io/api/networking/v1.NetworkPolicySpec
                         type: struct
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListConflictingNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListConflictingNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListConflictingNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto]
+            type: struct
 list/controller_network_policies:
     requestSchema:
         structs:
@@ -6452,6 +7199,16 @@ list/controller_network_policies:
                         type: array
                     namespaceName:
                         type: string
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesRequest,mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesRequest,mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse]
+                properties:
+                    data:
+                        structRef: mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto:
                 name: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
                 properties:
@@ -6464,9 +7221,10 @@ list/controller_network_policies:
                     type:
                         type: string
         typeInfo:
-            structRef: mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesRequest,mogenius-k8s-manager/src/controllers.ListControllerLabeledNetworkPoliciesResponse]
             type: struct
 list/cronjob-jobs:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -6481,6 +7239,57 @@ list/cronjob-jobs:
         typeInfo:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
+    responseSchema:
+        structs:
+            mogenius-k8s-manager/src/kubernetes.JobInfo:
+                name: mogenius-k8s-manager/src/kubernetes.JobInfo
+                properties:
+                    durationInMs:
+                        type: int
+                    jobId:
+                        type: string
+                    jobName:
+                        type: string
+                    message:
+                        pointer: true
+                        structRef: mogenius-k8s-manager/src/kubernetes.StatusMessage
+                        type: struct
+                    podName:
+                        type: string
+                    schedule:
+                        structRef: time.Time
+                        type: struct
+                    status:
+                        type: string
+                    tileType:
+                        type: string
+            mogenius-k8s-manager/src/kubernetes.ListJobInfoResponse:
+                name: mogenius-k8s-manager/src/kubernetes.ListJobInfoResponse
+                properties:
+                    controllerName:
+                        type: string
+                    jobsInfo:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/kubernetes.JobInfo
+                            type: struct
+                        type: array
+                    namespaceName:
+                        type: string
+                    projectId:
+                        type: string
+            mogenius-k8s-manager/src/kubernetes.StatusMessage:
+                name: mogenius-k8s-manager/src/kubernetes.StatusMessage
+                properties:
+                    message:
+                        type: string
+                    reason:
+                        type: string
+            time.Time:
+                name: time.Time
+                properties: {}
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/kubernetes.ListJobInfoResponse
+            type: struct
 list/labeled_network_policy_ports:
     requestSchema:
         structs:
@@ -6492,6 +7301,18 @@ list/labeled_network_policy_ports:
             type: struct
     responseSchema:
         structs:
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto:
                 name: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
                 properties:
@@ -6504,10 +7325,8 @@ list/labeled_network_policy_ports:
                     type:
                         type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,[]mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto]
+            type: struct
 list/namespace_network_policies:
     requestSchema:
         structs:
@@ -6689,6 +7508,18 @@ list/namespace_network_policies:
                             structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
                             type: struct
                         type: array
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
             mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto:
                 name: mogenius-k8s-manager/src/dtos.K8sLabeledNetworkPolicyDto
                 properties:
@@ -6701,10 +7532,8 @@ list/namespace_network_policies:
                     type:
                         type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListNetworkPolicyNamespace]
+            type: struct
 list/only_namespace_network_policies:
     requestSchema:
         structs:
@@ -6867,11 +7696,21 @@ list/only_namespace_network_policies:
                             structRef: mogenius-k8s-manager/src/controllers.K8sNetworkPolicyDto
                             type: struct
                         type: array
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.ListNamespaceLabeledNetworkPoliciesRequest,[]mogenius-k8s-manager/src/controllers.ListManagedAndUnmanagedNetworkPolicyNamespace]
+            type: struct
 live-stream/nodes-cpu:
     requestSchema:
         structs:
@@ -6894,6 +7733,24 @@ live-stream/nodes-cpu:
                         type: string
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
+            type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
             type: struct
 live-stream/nodes-memory:
     requestSchema:
@@ -6918,6 +7775,24 @@ live-stream/nodes-memory:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
             type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            type: struct
 live-stream/nodes-traffic:
     requestSchema:
         structs:
@@ -6940,6 +7815,24 @@ live-stream/nodes-traffic:
                         type: string
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
+            type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
             type: struct
 live-stream/pod-cpu:
     requestSchema:
@@ -6964,6 +7857,24 @@ live-stream/pod-cpu:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
             type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            type: struct
 live-stream/pod-memory:
     requestSchema:
         structs:
@@ -6986,6 +7897,24 @@ live-stream/pod-memory:
                         type: string
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
+            type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
             type: struct
 live-stream/pod-traffic:
     requestSchema:
@@ -7010,7 +7939,26 @@ live-stream/pod-traffic:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
             type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.WsConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            type: struct
 live-stream/workspace-cpu:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/xterm.WsConnectionRequest:
@@ -7033,7 +7981,12 @@ live-stream/workspace-cpu:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 live-stream/workspace-memory:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/xterm.WsConnectionRequest:
@@ -7056,7 +8009,12 @@ live-stream/workspace-memory:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 live-stream/workspace-traffic:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/xterm.WsConnectionRequest:
@@ -7079,7 +8037,12 @@ live-stream/workspace-traffic:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.WsConnectionRequest
             type: struct
+    responseSchema:
+        typeInfo:
+            pointer: true
+            type: any
 metrics/deployment/average-utilization:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/dtos.K8sController:
@@ -7156,6 +8119,7 @@ metrics/deployment/average-utilization:
             structRef: mogenius-k8s-manager/src/kubernetes.Metrics
             type: struct
 namespace/backup:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.NamespaceBackupRequest:
@@ -7167,22 +8131,11 @@ namespace/backup:
             structRef: mogenius-k8s-manager/src/services.NamespaceBackupRequest
             type: struct
     responseSchema:
-        structs:
-            mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse:
-                name: mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse
-                properties:
-                    data:
-                        type: string
-                    messages:
-                        elementType:
-                            type: string
-                        type: array
-                    namespaceName:
-                        type: string
         typeInfo:
-            structRef: mogenius-k8s-manager/src/kubernetes.NamespaceBackupResponse
-            type: struct
+            pointer: true
+            type: any
 namespace/create:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/dtos.K8sNamespaceDto:
@@ -7302,6 +8255,7 @@ namespace/create:
             structRef: mogenius-k8s-manager/src/structs.Job
             type: struct
 namespace/delete:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/dtos.K8sNamespaceDto:
@@ -7421,6 +8375,15 @@ namespace/delete:
             structRef: mogenius-k8s-manager/src/structs.Job
             type: struct
 print-current-config:
+    legacyResponseLayout: true
+    requestSchema:
+        structs:
+            ANON_STRUCT_0:
+                properties: {}
+        typeInfo:
+            pointer: true
+            structRef: ANON_STRUCT_0
+            type: struct
     responseSchema:
         typeInfo:
             type: string
@@ -7444,9 +8407,20 @@ prometheus/charts/add:
             structRef: mogenius-k8s-manager/src/core.PrometheusRequestRedis
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]
+                properties:
+                    data:
+                        pointer: true
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]
+            type: struct
 prometheus/charts/get:
     requestSchema:
         structs:
@@ -7478,12 +8452,22 @@ prometheus/charts/get:
                         type: string
                     step:
                         type: int
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*mogenius-k8s-manager/src/core.PrometheusStoreObject]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*mogenius-k8s-manager/src/core.PrometheusStoreObject]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: mogenius-k8s-manager/src/core.PrometheusStoreObject
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
             time.Time:
                 name: time.Time
                 properties: {}
         typeInfo:
-            pointer: true
-            structRef: mogenius-k8s-manager/src/core.PrometheusStoreObject
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*mogenius-k8s-manager/src/core.PrometheusStoreObject]
             type: struct
 prometheus/charts/list:
     requestSchema:
@@ -7510,16 +8494,26 @@ prometheus/charts/list:
                         type: string
                     step:
                         type: int
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedisList,map[string]mogenius-k8s-manager/src/core.PrometheusStoreObject]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedisList,map[string]mogenius-k8s-manager/src/core.PrometheusStoreObject]
+                properties:
+                    data:
+                        keyType:
+                            type: string
+                        type: map
+                        valueType:
+                            structRef: mogenius-k8s-manager/src/core.PrometheusStoreObject
+                            type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
             time.Time:
                 name: time.Time
                 properties: {}
         typeInfo:
-            keyType:
-                type: string
-            type: map
-            valueType:
-                structRef: mogenius-k8s-manager/src/core.PrometheusStoreObject
-                type: struct
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedisList,map[string]mogenius-k8s-manager/src/core.PrometheusStoreObject]
+            type: struct
 prometheus/charts/remove:
     requestSchema:
         structs:
@@ -7540,9 +8534,20 @@ prometheus/charts/remove:
             structRef: mogenius-k8s-manager/src/core.PrometheusRequestRedis
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]
+                properties:
+                    data:
+                        pointer: true
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequestRedis,*string]
+            type: struct
 prometheus/is-reachable:
     requestSchema:
         structs:
@@ -7567,8 +8572,19 @@ prometheus/is-reachable:
             structRef: mogenius-k8s-manager/src/core.PrometheusRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,bool]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,bool]
+                properties:
+                    data:
+                        type: bool
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: bool
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,bool]
+            type: struct
 prometheus/query:
     requestSchema:
         structs:
@@ -7594,7 +8610,7 @@ prometheus/query:
             type: struct
     responseSchema:
         structs:
-            ANON_STRUCT_1:
+            ANON_STRUCT_2:
                 properties:
                     result:
                         elementType:
@@ -7607,7 +8623,7 @@ prometheus/query:
                 name: mogenius-k8s-manager/src/core.PrometheusQueryResponse
                 properties:
                     data:
-                        structRef: ANON_STRUCT_1
+                        structRef: ANON_STRUCT_2
                         type: struct
                     error:
                         type: string
@@ -7615,9 +8631,19 @@ prometheus/query:
                         type: string
                     status:
                         type: string
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,*mogenius-k8s-manager/src/core.PrometheusQueryResponse]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,*mogenius-k8s-manager/src/core.PrometheusQueryResponse]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: mogenius-k8s-manager/src/core.PrometheusQueryResponse
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: mogenius-k8s-manager/src/core.PrometheusQueryResponse
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,*mogenius-k8s-manager/src/core.PrometheusQueryResponse]
             type: struct
 prometheus/values:
     requestSchema:
@@ -7643,10 +8669,21 @@ prometheus/values:
             structRef: mogenius-k8s-manager/src/core.PrometheusRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,[]string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,[]string]
+                properties:
+                    data:
+                        elementType:
+                            type: string
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                type: string
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.PrometheusRequest,[]string]
+            type: struct
 remove/conflicting_network_policies:
     requestSchema:
         structs:
@@ -7659,8 +8696,19 @@ remove/conflicting_network_policies:
             structRef: mogenius-k8s-manager/src/controllers.RemoveConflictingNetworkPoliciesRequest
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveConflictingNetworkPoliciesRequest,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveConflictingNetworkPoliciesRequest,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveConflictingNetworkPoliciesRequest,string]
+            type: struct
 remove/unmanaged_network_policies:
     requestSchema:
         structs:
@@ -7678,13 +8726,24 @@ remove/unmanaged_network_policies:
             type: struct
     responseSchema:
         structs:
-            ANON_STRUCT_0:
+            ANON_STRUCT_1:
                 properties: {}
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveUnmanagedNetworkPoliciesRequest,mogenius-k8s-manager/src/core.Void]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveUnmanagedNetworkPoliciesRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: ANON_STRUCT_0
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/controllers.RemoveUnmanagedNetworkPoliciesRequest,mogenius-k8s-manager/src/core.Void]
             type: struct
 service/create:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             k8s.io/api/autoscaling/v2.ContainerResourceMetricSource:
@@ -8284,6 +9343,7 @@ service/create:
             structRef: mogenius-k8s-manager/src/structs.Job
             type: struct
 service/delete:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             k8s.io/api/autoscaling/v2.ContainerResourceMetricSource:
@@ -8921,6 +9981,24 @@ service/exec-sh-connection-request:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest
             type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            type: struct
 service/log-stream-connection-request:
     requestSchema:
         structs:
@@ -8960,6 +10038,24 @@ service/log-stream-connection-request:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest
             type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodCmdConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            type: struct
 service/pod-event-stream-connection-request:
     requestSchema:
         structs:
@@ -8993,7 +10089,26 @@ service/pod-event-stream-connection-request:
         typeInfo:
             structRef: mogenius-k8s-manager/src/xterm.PodEventConnectionRequest
             type: struct
+    responseSchema:
+        structs:
+            ANON_STRUCT_1:
+                properties: {}
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodEventConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodEventConnectionRequest,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
+        typeInfo:
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/xterm.PodEventConnectionRequest,mogenius-k8s-manager/src/core.Void]
+            type: struct
 service/resource-status:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.ServiceResourceStatusRequest:
@@ -11156,6 +12271,7 @@ service/resource-status:
             structRef: k8s.io/api/core/v1.Pod
             type: struct
 service/restart:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             k8s.io/api/autoscaling/v2.ContainerResourceMetricSource:
@@ -11755,6 +12871,7 @@ service/restart:
             structRef: mogenius-k8s-manager/src/structs.Job
             type: struct
 service/start:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             k8s.io/api/autoscaling/v2.ContainerResourceMetricSource:
@@ -12354,6 +13471,7 @@ service/start:
             structRef: mogenius-k8s-manager/src/structs.Job
             type: struct
 service/status:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.ServiceStatusRequest:
@@ -12454,6 +13572,7 @@ service/status:
             structRef: mogenius-k8s-manager/src/services.ServiceStatusResponse
             type: struct
 service/stop:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             k8s.io/api/autoscaling/v2.ContainerResourceMetricSource:
@@ -13016,6 +14135,7 @@ service/stop:
             structRef: mogenius-k8s-manager/src/structs.Job
             type: struct
 service/trigger-job:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.ServiceTriggerJobRequest:
@@ -13096,6 +14216,7 @@ service/trigger-job:
             structRef: mogenius-k8s-manager/src/structs.Job
             type: struct
 service/update-service:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             k8s.io/api/autoscaling/v2.ContainerResourceMetricSource:
@@ -13636,65 +14757,11 @@ service/update-service:
             structRef: mogenius-k8s-manager/src/services.ServiceUpdateRequest
             type: struct
     responseSchema:
-        structs:
-            mogenius-k8s-manager/src/structs.Command:
-                name: mogenius-k8s-manager/src/structs.Command
-                properties:
-                    command:
-                        type: string
-                    finished:
-                        structRef: time.Time
-                        type: struct
-                    id:
-                        type: string
-                    message:
-                        type: string
-                    started:
-                        structRef: time.Time
-                        type: struct
-                    state:
-                        type: string
-                    title:
-                        type: string
-            mogenius-k8s-manager/src/structs.Job:
-                name: mogenius-k8s-manager/src/structs.Job
-                properties:
-                    commands:
-                        elementType:
-                            pointer: true
-                            structRef: mogenius-k8s-manager/src/structs.Command
-                            type: struct
-                        type: array
-                    containerName:
-                        type: string
-                    controllerName:
-                        type: string
-                    finished:
-                        structRef: time.Time
-                        type: struct
-                    id:
-                        type: string
-                    message:
-                        type: string
-                    namespaceName:
-                        type: string
-                    projectId:
-                        type: string
-                    started:
-                        structRef: time.Time
-                        type: struct
-                    state:
-                        type: string
-                    title:
-                        type: string
-            time.Time:
-                name: time.Time
-                properties: {}
         typeInfo:
             pointer: true
-            structRef: mogenius-k8s-manager/src/structs.Job
-            type: struct
+            type: any
 stats/podstat/all-for-controller:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -13745,6 +14812,7 @@ stats/podstat/all-for-controller:
             pointer: true
             type: array
 stats/podstat/last-for-controller:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/dtos.K8sController:
@@ -13791,6 +14859,7 @@ stats/podstat/last-for-controller:
             structRef: mogenius-k8s-manager/src/structs.PodStats
             type: struct
 stats/traffic/all-for-controller:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -13848,6 +14917,7 @@ stats/traffic/all-for-controller:
             pointer: true
             type: array
 stats/traffic/for-controller-socket-connections:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/dtos.K8sController:
@@ -13880,6 +14950,7 @@ stats/traffic/for-controller-socket-connections:
             structRef: mogenius-k8s-manager/src/structs.SocketConnections
             type: struct
 stats/traffic/sum-for-controller:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/dtos.K8sController:
@@ -13933,6 +15004,7 @@ stats/traffic/sum-for-controller:
             structRef: mogenius-k8s-manager/src/networkmonitor.PodNetworkStats
             type: struct
 stats/traffic/sum-for-namespace:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/core.Request:
@@ -14004,11 +15076,21 @@ stats/workspace-cpu-utilization:
                         type: string
                     value:
                         type: float
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/core.GenericChartEntry
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/core.GenericChartEntry
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+            type: struct
 stats/workspace-memory-utilization:
     requestSchema:
         structs:
@@ -14031,11 +15113,21 @@ stats/workspace-memory-utilization:
                         type: string
                     value:
                         type: float
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/core.GenericChartEntry
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/core.GenericChartEntry
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+            type: struct
 stats/workspace-traffic-utilization:
     requestSchema:
         structs:
@@ -14058,12 +15150,23 @@ stats/workspace-traffic-utilization:
                         type: string
                     value:
                         type: float
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+                properties:
+                    data:
+                        elementType:
+                            structRef: mogenius-k8s-manager/src/core.GenericChartEntry
+                            type: struct
+                        type: array
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            elementType:
-                structRef: mogenius-k8s-manager/src/core.GenericChartEntry
-                type: struct
-            type: array
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·9,[]mogenius-k8s-manager/src/core.GenericChartEntry]
+            type: struct
 storage/create-volume:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.NfsVolumeRequest:
@@ -14091,6 +15194,7 @@ storage/create-volume:
             structRef: mogenius-k8s-manager/src/structs.DefaultResponse
             type: struct
 storage/delete-volume:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.NfsVolumeRequest:
@@ -14118,6 +15222,7 @@ storage/delete-volume:
             structRef: mogenius-k8s-manager/src/structs.DefaultResponse
             type: struct
 storage/namespace/stats:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.NfsNamespaceStatsRequest:
@@ -14147,6 +15252,7 @@ storage/namespace/stats:
                 type: struct
             type: array
 storage/stats:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.NfsVolumeStatsRequest:
@@ -14176,6 +15282,7 @@ storage/stats:
             structRef: mogenius-k8s-manager/src/services.NfsVolumeStatsResponse
             type: struct
 storage/status:
+    legacyResponseLayout: true
     requestSchema:
         structs:
             mogenius-k8s-manager/src/services.NfsStatusRequest:
@@ -14259,9 +15366,19 @@ trigger/workload:
                         valueType:
                             pointer: true
                             type: any
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceItem,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
             type: struct
 uninstall-cert-manager:
     requestSchema:
@@ -14273,8 +15390,19 @@ uninstall-cert-manager:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 uninstall-cluster-issuer:
     requestSchema:
         structs:
@@ -14285,8 +15413,19 @@ uninstall-cluster-issuer:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 uninstall-ingress-controller-traefik:
     requestSchema:
         structs:
@@ -14297,8 +15436,19 @@ uninstall-ingress-controller-traefik:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 uninstall-kepler:
     requestSchema:
         structs:
@@ -14309,8 +15459,19 @@ uninstall-kepler:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 uninstall-metallb:
     requestSchema:
         structs:
@@ -14321,8 +15482,19 @@ uninstall-metallb:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 uninstall-metrics-server:
     requestSchema:
         structs:
@@ -14333,8 +15505,19 @@ uninstall-metrics-server:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 update/grant:
     requestSchema:
         structs:
@@ -14355,8 +15538,19 @@ update/grant:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·31,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·31,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·31,string]
+            type: struct
 update/network_policies_template:
     requestSchema:
         structs:
@@ -14378,11 +15572,21 @@ update/network_policies_template:
             type: array
     responseSchema:
         structs:
-            ANON_STRUCT_0:
+            ANON_STRUCT_1:
                 properties: {}
+            mogenius-k8s-manager/src/core.Result[[]mogenius-k8s-manager/src/kubernetes.NetworkPolicy,mogenius-k8s-manager/src/core.Void]:
+                name: mogenius-k8s-manager/src/core.Result[[]mogenius-k8s-manager/src/kubernetes.NetworkPolicy,mogenius-k8s-manager/src/core.Void]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: ANON_STRUCT_1
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: ANON_STRUCT_0
+            structRef: mogenius-k8s-manager/src/core.Result[[]mogenius-k8s-manager/src/kubernetes.NetworkPolicy,mogenius-k8s-manager/src/core.Void]
             type: struct
 update/user:
     requestSchema:
@@ -14417,8 +15621,19 @@ update/user:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·26,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·26,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·26,string]
+            type: struct
 update/workload:
     requestSchema:
         structs:
@@ -14453,9 +15668,19 @@ update/workload:
                         valueType:
                             pointer: true
                             type: any
+            ? mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+            :   name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
+                properties:
+                    data:
+                        pointer: true
+                        structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            pointer: true
-            structRef: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/utils.ResourceData,*k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured]
             type: struct
 update/workspace:
     requestSchema:
@@ -14485,8 +15710,19 @@ update/workspace:
             structRef: mogenius-k8s-manager/src/core.Request
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·21,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·21,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·21,string]
+            type: struct
 upgrade-cert-manager:
     requestSchema:
         structs:
@@ -14497,8 +15733,19 @@ upgrade-cert-manager:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 upgrade-ingress-controller-traefik:
     requestSchema:
         structs:
@@ -14509,8 +15756,19 @@ upgrade-ingress-controller-traefik:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 upgrade-kepler:
     requestSchema:
         structs:
@@ -14521,8 +15779,19 @@ upgrade-kepler:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 upgrade-metallb:
     requestSchema:
         structs:
@@ -14533,8 +15802,19 @@ upgrade-metallb:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 upgrade-metrics-server:
     requestSchema:
         structs:
@@ -14545,8 +15825,19 @@ upgrade-metrics-server:
             structRef: ANON_STRUCT_0
             type: struct
     responseSchema:
+        structs:
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+                properties:
+                    data:
+                        type: string
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            type: string
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Void,string]
+            type: struct
 workspace/clean-up:
     requestSchema:
         structs:
@@ -14623,6 +15914,16 @@ workspace/clean-up:
                         type: string
                     reason:
                         type: string
+            mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·20,mogenius-k8s-manager/src/core.CleanUpResult]:
+                name: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·20,mogenius-k8s-manager/src/core.CleanUpResult]
+                properties:
+                    data:
+                        structRef: mogenius-k8s-manager/src/core.CleanUpResult
+                        type: struct
+                    message:
+                        type: string
+                    status:
+                        type: string
         typeInfo:
-            structRef: mogenius-k8s-manager/src/core.CleanUpResult
+            structRef: mogenius-k8s-manager/src/core.Result[mogenius-k8s-manager/src/core.Request·20,mogenius-k8s-manager/src/core.CleanUpResult]
             type: struct

--- a/src/cmd/patterns.go
+++ b/src/cmd/patterns.go
@@ -381,6 +381,11 @@ func structRefToTypescriptName(normalizedPatternWithScope string, structref stri
 	structref = strings.ReplaceAll(structref, "/", "_")
 	structref = strings.ReplaceAll(structref, ".", "_")
 	structref = strings.ReplaceAll(structref, "-", "_")
+	structref = strings.ReplaceAll(structref, ",", "_")
+	structref = strings.ReplaceAll(structref, "[", "")
+	structref = strings.ReplaceAll(structref, "]", "")
+	structref = strings.ReplaceAll(structref, "*", "")
+	structref = strings.ReplaceAll(structref, "·", "")
 	return normalizedPatternWithScope + "__" + structref
 }
 

--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -47,12 +47,7 @@ type SocketApi interface {
 	Status() SocketApiStatus
 	ExecuteCommandRequest(datagram structs.Datagram) interface{}
 	ParseDatagram(data []byte) (structs.Datagram, error)
-	RegisterPatternHandler(
-		pattern string,
-		config PatternConfig,
-		callback func(datagram structs.Datagram) (any, error),
-	)
-	RegisterPatternHandlerRaw(
+	AddPatternHandler(
 		pattern string,
 		config PatternConfig,
 		callback func(datagram structs.Datagram) any,
@@ -106,11 +101,15 @@ type PatternHandler struct {
 }
 
 type PatternConfig struct {
-	RequestSchema     *schema.Schema `json:"requestSchema,omitempty"`
-	ResponseSchema    *schema.Schema `json:"responseSchema,omitempty"`
-	Deprecated        bool           `json:"deprecated,omitempty"`
-	DeprecatedMessage string         `json:"deprecatedMessage,omitempty"`
-	NeedsUser         bool           `json:"needsUser,omitempty"`
+	Deprecated        bool   `json:"deprecated,omitempty"`
+	DeprecatedMessage string `json:"deprecatedMessage,omitempty"`
+	NeedsUser         bool   `json:"needsUser,omitempty"`
+	// @readonly: do not set this manually
+	LegacyResponseLayout bool `json:"legacyResponseLayout,omitempty"`
+	// @readonly: do not set this manually
+	RequestSchema *schema.Schema `json:"requestSchema,omitempty"`
+	// @readonly: do not set this manually
+	ResponseSchema *schema.Schema `json:"responseSchema,omitempty"`
 }
 
 type Void *struct{}
@@ -192,7 +191,153 @@ type PatternHandle struct {
 	Pattern   string
 }
 
-func RegisterPatternHandler[RequestType any, ResponseType any](handle PatternHandle, config PatternConfig, callback func(request RequestType) (ResponseType, error)) {
+// Register a pattern handler which responds with Payload{"status":"success"|"error","data":{...}}
+//
+// The API response field `"payload"` is a tagged union type with two fields called `status` and `data`.
+//
+// if `status` equals "success" the field `data` contains `ResponseType`
+// if `status` equals "error" the field `data` contains a `string` with the an message
+func RegisterPatternHandler[RequestType any, ResponseType any](
+	handle PatternHandle,
+	config PatternConfig,
+	callback func(datagram structs.Datagram, request RequestType) (ResponseType, error),
+) {
+	assert.Assert(handle.SocketApi != nil, "SocketApi has to be given")
+	assert.Assert(handle.Pattern != "", "Pattern has to be defined")
+
+	type Result struct {
+		Status  string       `json:"status"` // success, error
+		Message string       `json:"message,omitempty"`
+		Data    ResponseType `json:"data"`
+	}
+
+	buildResponse := func(result interface{}, err error) Result {
+		if err != nil {
+			return Result{
+				Status:  "error",
+				Message: err.Error(),
+			}
+		}
+		if str, ok := result.(string); ok {
+			return Result{
+				Status:  "success",
+				Message: str,
+			}
+		}
+		return Result{
+			Status: "success",
+			Data:   result.(ResponseType),
+		}
+	}
+
+	config.LegacyResponseLayout = false
+
+	assert.Assert(config.RequestSchema == nil, "config.RequestSchema should be empty", "RegisterPatternHandler overrides this field.")
+	var requestType RequestType
+	config.RequestSchema = schema.Generate(requestType)
+
+	assert.Assert(config.ResponseSchema == nil, "config.ResponseSchema should be empty", "RegisterPatternHandler overrides this field.")
+	var responseType Result
+	config.ResponseSchema = schema.Generate(responseType)
+
+	handle.SocketApi.AddPatternHandler(handle.Pattern, config, func(datagram structs.Datagram) any {
+		var data RequestType
+		kind := reflect.TypeOf(data).Kind()
+
+		if kind != reflect.Pointer {
+			err := handle.SocketApi.LoadRequest(&datagram, &data)
+			if err != nil {
+				return buildResponse(nil, err)
+			}
+		}
+
+		if kind == reflect.Pointer && datagram.Payload != nil {
+			err := handle.SocketApi.LoadRequest(&datagram, &data)
+			if err != nil {
+				return buildResponse(nil, err)
+			}
+		}
+
+		result, err := callback(datagram, data)
+
+		return buildResponse(result, err)
+	})
+}
+
+// Register a pattern handler which responds with Payload{...}
+//
+// The API response field `"payload"` is a Union type of either `ResponseType`|`error`.
+//
+// The `error` variant stems from serialization and validation steps before the handler itself is called. `ResponseType` stems from the handler.
+//
+// While `RegisterPatternHandler` has a field to identify if the request was successful `RegisterPatternHandlerRaw` generates
+// responses which have to be parsed and evaluated on the other side.
+//
+// @deprecated: use `RegisterPatternHandler` instead
+func RegisterPatternHandlerRaw[RequestType any, ResponseType any](
+	handle PatternHandle,
+	config PatternConfig,
+	callback func(datagram structs.Datagram, request RequestType) ResponseType,
+) {
+	assert.Assert(
+		slices.Contains([]string{
+			"ClusterResourceInfo",
+			"UpgradeK8sManager",
+			"ClusterForceReconnect",
+			"ClusterForceDisconnect",
+			"SYSTEM_CHECK",
+			"print-current-config",
+			"stats/podstat/all-for-controller",
+			"stats/traffic/all-for-controller",
+			"stats/podstat/last-for-controller",
+			"stats/traffic/sum-for-controller",
+			"stats/traffic/for-controller-socket-connections",
+			"stats/traffic/sum-for-namespace",
+			"metrics/deployment/average-utilization",
+			"files/list",
+			"files/create-folder",
+			"files/rename",
+			"files/chown",
+			"files/chmod",
+			"files/delete",
+			"files/download",
+			"files/info",
+			"cluster/backup",
+			"cluster/update-local-tls-secret",
+			"namespace/create",
+			"namespace/delete",
+			"namespace/backup",
+			"service/create",
+			"service/delete",
+			"SERVICE_PODS",
+			"service/resource-status",
+			"service/restart",
+			"service/stop",
+			"service/start",
+			"service/update-service",
+			"service/trigger-job",
+			"service/status",
+			"storage/create-volume",
+			"storage/delete-volume",
+			"storage/stats",
+			"storage/namespace/stats",
+			"storage/status",
+			"external-secret-store/create",
+			"external-secret-store/list",
+			"external-secret/list-available-secrets",
+			"external-secret-store/delete",
+			"list/cronjob-jobs",
+			"live-stream/workspace-cpu",
+			"live-stream/workspace-memory",
+			"live-stream/workspace-traffic",
+		}, handle.Pattern),
+		"DEPRECATED: new patterns should always be implemented using `RegisterPatternHandler`",
+		"this assertion is here to prevent new routes from accidentally (e.g. AI slop) using the legacy register system",
+		handle.Pattern,
+	)
+
+	config.LegacyResponseLayout = true
+
 	assert.Assert(handle.SocketApi != nil, "SocketApi has to be given")
 	assert.Assert(handle.Pattern != "", "Pattern has to be defined")
 
@@ -204,56 +349,36 @@ func RegisterPatternHandler[RequestType any, ResponseType any](handle PatternHan
 	var responseType ResponseType
 	config.ResponseSchema = schema.Generate(responseType)
 
-	handle.SocketApi.RegisterPatternHandler(handle.Pattern, config, func(datagram structs.Datagram) (any, error) {
+	handle.SocketApi.AddPatternHandler(handle.Pattern, config, func(datagram structs.Datagram) any {
 		var data RequestType
 		kind := reflect.TypeOf(data).Kind()
 
 		if kind != reflect.Pointer {
 			err := handle.SocketApi.LoadRequest(&datagram, &data)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 
 		if kind == reflect.Pointer && datagram.Payload != nil {
 			err := handle.SocketApi.LoadRequest(&datagram, &data)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 
-		return callback(data)
+		return callback(datagram, data)
 	})
 }
 
-func (self *socketApi) RegisterPatternHandler(
-	pattern string,
-	config PatternConfig,
-	callback func(datagram structs.Datagram) (any, error),
-) {
-	assert.Assert(config.RequestSchema != nil, "config.RequestSchema has to be set")
-	assert.Assert(config.ResponseSchema != nil, "config.ResponseSchema has to be set")
-
-	self.patternHandlerLock.Lock()
-	defer self.patternHandlerLock.Unlock()
-
-	_, exists := self.patternHandler[pattern]
-	assert.Assert(!exists, "patterns may only be registered once", pattern)
-
-	self.patternHandler[pattern] = PatternHandler{
-		Config: config,
-		Callback: func(datagram structs.Datagram) any {
-			result, err := callback(datagram)
-			return NewMessageResponse(result, err)
-		},
-	}
-}
-
-func (self *socketApi) RegisterPatternHandlerRaw(
+func (self *socketApi) AddPatternHandler(
 	pattern string,
 	config PatternConfig,
 	callback func(datagram structs.Datagram) any,
 ) {
+	assert.Assert(config.RequestSchema != nil, "config.RequestSchema has to be set")
+	assert.Assert(config.ResponseSchema != nil, "config.ResponseSchema has to be set")
+
 	self.patternHandlerLock.Lock()
 	defer self.patternHandlerLock.Unlock()
 
@@ -289,7 +414,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "describe"},
 			PatternConfig{},
-			func(request Void) (Response, error) {
+			func(datagram structs.Datagram, request Void) (Response, error) {
 				resp := Response{}
 				resp.BuildInfo.BuildType = "prod"
 				if utils.IsDevBuild() {
@@ -301,12 +426,12 @@ func (self *socketApi) registerPatterns() {
 			})
 	}
 
-	self.RegisterPatternHandlerRaw(
-		"K8sNotification",
+	RegisterPatternHandler(
+		PatternHandle{self, "K8sNotification"},
 		PatternConfig{},
-		func(datagram structs.Datagram) any {
-			self.logger.Info("Received pattern", "pattern", datagram.Pattern)
-			return nil
+		func(datagram structs.Datagram, request Void) (Void, error) {
+			self.logger.Info("Received pattern", "pattern", "K8sNotification")
+			return nil, nil
 		},
 	)
 
@@ -319,23 +444,22 @@ func (self *socketApi) registerPatterns() {
 			CniConfig               []structs.CniData     `json:"cniConfig"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"ClusterResourceInfo",
-			PatternConfig{
-				ResponseSchema: schema.Generate(Response{}),
-			},
-			func(datagram structs.Datagram) any {
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "ClusterResourceInfo"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Void) Response {
 				nodeStats := self.moKubernetes.GetNodeStats()
 				loadBalancerExternalIps := kubernetes.GetClusterExternalIps()
 				country, _ := utils.GuessClusterCountry()
 				cniConfig, _ := self.dbstats.GetCniData()
-				return Response{
+				response := Response{
 					NodeStats:               nodeStats,
 					LoadBalancerExternalIps: loadBalancerExternalIps,
 					Country:                 country,
 					Provider:                string(utils.ClusterProviderCached),
 					CniConfig:               cniConfig,
 				}
+				return response
 			},
 		)
 	}
@@ -344,50 +468,38 @@ func (self *socketApi) registerPatterns() {
 		type Request struct {
 			Command string `json:"command" validate:"required"` // complete helm command from platform ui
 		}
-		self.RegisterPatternHandlerRaw(
-			"UpgradeK8sManager",
-			PatternConfig{
-				RequestSchema:  schema.Generate(Request{}),
-				ResponseSchema: schema.Generate(&structs.Job{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return self.upgradeK8sManager(data.Command)
+
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "UpgradeK8sManager"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) *structs.Job {
+				return self.upgradeK8sManager(request.Command)
 			},
 		)
 	}
 
-	self.RegisterPatternHandlerRaw(
-		"ClusterForceReconnect",
-		PatternConfig{
-			ResponseSchema: schema.Boolean(),
-		},
-		func(datagram structs.Datagram) any {
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "ClusterForceReconnect"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request Void) bool {
 			time.Sleep(1 * time.Second)
 			return kubernetes.ClusterForceReconnect()
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"ClusterForceDisconnect",
-		PatternConfig{
-			ResponseSchema: schema.Boolean(),
-		},
-		func(datagram structs.Datagram) any {
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "ClusterForceDisconnect"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request Void) bool {
 			time.Sleep(1 * time.Second)
 			return kubernetes.ClusterForceDisconnect()
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"SYSTEM_CHECK",
-		PatternConfig{
-			ResponseSchema: schema.Generate(services.SystemCheckResponse{}),
-		},
-		func(datagram structs.Datagram) any {
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "SYSTEM_CHECK"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request Void) services.SystemCheckResponse {
 			return services.SystemCheck()
 		},
 	)
@@ -401,18 +513,16 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "cluster/clear-valkey-cache"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.valkeyClient.ClearNonEssentialKeys(request.IncludeTraffic, request.IncludePodStats, request.IncludeNodeStats)
 			},
 		)
 	}
 
-	self.RegisterPatternHandlerRaw(
-		"print-current-config",
-		PatternConfig{
-			ResponseSchema: schema.String(),
-		},
-		func(datagram structs.Datagram) any {
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "print-current-config"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request Void) string {
 			return self.config.AsEnvs()
 		},
 	)
@@ -420,7 +530,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "install-metrics-server"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.InstallMetricsServer()
 		},
 	)
@@ -428,7 +538,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "install-ingress-controller-traefik"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.InstallIngressControllerTreafik()
 		},
 	)
@@ -436,7 +546,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "install-cert-manager"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.InstallCertManager()
 		},
 	)
@@ -449,7 +559,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "install-cluster-issuer"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				secrets.AddSecret(request.Email)
 				return services.InstallClusterIssuer(request.Email, 0)
 			},
@@ -459,7 +569,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "install-metallb"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.InstallMetalLb()
 		},
 	)
@@ -467,7 +577,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "install-kepler"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.InstallKepler()
 		},
 	)
@@ -475,7 +585,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "uninstall-metrics-server"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UninstallMetricsServer()
 		},
 	)
@@ -483,7 +593,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "uninstall-ingress-controller-traefik"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UninstallIngressControllerTreafik()
 		},
 	)
@@ -491,7 +601,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "uninstall-cert-manager"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UninstallCertManager()
 		},
 	)
@@ -499,7 +609,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "uninstall-cluster-issuer"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UninstallClusterIssuer()
 		},
 	)
@@ -507,7 +617,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "uninstall-metallb"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UninstallMetalLb()
 		},
 	)
@@ -515,7 +625,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "uninstall-kepler"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UninstallKepler()
 		},
 	)
@@ -523,7 +633,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "upgrade-metrics-server"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UpgradeMetricsServer()
 		},
 	)
@@ -531,7 +641,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "upgrade-ingress-controller-traefik"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UpgradeIngressControllerTreafik()
 		},
 	)
@@ -539,7 +649,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "upgrade-cert-manager"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UpgradeCertManager()
 		},
 	)
@@ -547,7 +657,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "upgrade-metallb"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UpgradeMetalLb()
 		},
 	)
@@ -555,7 +665,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "upgrade-kepler"},
 		PatternConfig{},
-		func(request Void) (string, error) {
+		func(datagram structs.Datagram, request Void) (string, error) {
 			return services.UpgradeKepler()
 		},
 	)
@@ -568,85 +678,52 @@ func (self *socketApi) registerPatterns() {
 			TimeOffsetMinutes int    `json:"timeOffsetMinutes"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"stats/podstat/all-for-controller",
-			PatternConfig{
-				RequestSchema:  schema.Generate(Request{}),
-				ResponseSchema: schema.Generate(&[]structs.PodStats{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "stats/podstat/all-for-controller"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) *[]structs.PodStats {
+				if request.TimeOffsetMinutes <= 0 {
+					request.TimeOffsetMinutes = 60 * 24 // 1 day
 				}
-				if data.TimeOffsetMinutes <= 0 {
-					data.TimeOffsetMinutes = 60 * 24 // 1 day
-				}
-				return self.dbstats.GetPodStatsEntriesForController(data.Kind, data.Name, data.Namespace, int64(data.TimeOffsetMinutes))
+				entries := self.dbstats.GetPodStatsEntriesForController(request.Kind, request.Name, request.Namespace, int64(request.TimeOffsetMinutes))
+				return entries
 			},
 		)
 
-		self.RegisterPatternHandlerRaw(
-			"stats/traffic/all-for-controller",
-			PatternConfig{
-				RequestSchema:  schema.Generate(Request{}),
-				ResponseSchema: schema.Generate(&[]networkmonitor.PodNetworkStats{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "stats/traffic/all-for-controller"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) *[]networkmonitor.PodNetworkStats {
+				if request.TimeOffsetMinutes <= 0 {
+					request.TimeOffsetMinutes = 60 * 24 // 1 day
 				}
-				if data.TimeOffsetMinutes <= 0 {
-					data.TimeOffsetMinutes = 60 * 24 // 1 day
-				}
-				return self.dbstats.GetTrafficStatsEntriesForController(data.Kind, data.Name, data.Namespace, int64(data.TimeOffsetMinutes))
+				stats := self.dbstats.GetTrafficStatsEntriesForController(request.Kind, request.Name, request.Namespace, int64(request.TimeOffsetMinutes))
+				return stats
 			},
 		)
 	}
 
-	self.RegisterPatternHandlerRaw(
-		"stats/podstat/last-for-controller",
-		PatternConfig{
-			RequestSchema:  schema.Generate(dtos.K8sController{}),
-			ResponseSchema: schema.Generate(&structs.PodStats{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := dtos.K8sController{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return self.dbstats.GetLastPodStatsEntryForController(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "stats/podstat/last-for-controller"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request dtos.K8sController) *structs.PodStats {
+			return self.dbstats.GetLastPodStatsEntryForController(request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"stats/traffic/sum-for-controller",
-		PatternConfig{
-			RequestSchema:  schema.Generate(dtos.K8sController{}),
-			ResponseSchema: schema.Generate(&networkmonitor.PodNetworkStats{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := dtos.K8sController{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return self.dbstats.GetTrafficStatsEntrySumForController(data, false)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "stats/traffic/sum-for-controller"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request dtos.K8sController) *networkmonitor.PodNetworkStats {
+			return self.dbstats.GetTrafficStatsEntrySumForController(request, false)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"stats/traffic/for-controller-socket-connections",
-		PatternConfig{
-			RequestSchema:  schema.Generate(dtos.K8sController{}),
-			ResponseSchema: schema.Generate(&structs.SocketConnections{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := dtos.K8sController{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return self.dbstats.GetSocketConnectionsForController(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "stats/traffic/for-controller-socket-connections"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request dtos.K8sController) *structs.SocketConnections {
+			return self.dbstats.GetSocketConnectionsForController(request)
 		},
 	)
 
@@ -655,18 +732,11 @@ func (self *socketApi) registerPatterns() {
 			Namespace string `json:"namespace" validate:"required"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"stats/traffic/sum-for-namespace",
-			PatternConfig{
-				RequestSchema:  schema.Generate(Request{}),
-				ResponseSchema: schema.Generate([]networkmonitor.PodNetworkStats{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return self.dbstats.GetTrafficStatsEntriesSumForNamespace(data.Namespace)
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "stats/traffic/sum-for-namespace"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) []networkmonitor.PodNetworkStats {
+				return self.dbstats.GetTrafficStatsEntriesSumForNamespace(request.Namespace)
 			},
 		)
 	}
@@ -681,7 +751,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "stats/workspace-cpu-utilization"},
 			PatternConfig{},
-			func(request Request) ([]GenericChartEntry, error) {
+			func(datagram structs.Datagram, request Request) ([]GenericChartEntry, error) {
 				resources, err := self.apiService.GetWorkspaceControllers(request.WorkspaceName)
 				if err != nil {
 					return nil, err
@@ -693,7 +763,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "stats/workspace-memory-utilization"},
 			PatternConfig{},
-			func(request Request) ([]GenericChartEntry, error) {
+			func(datagram structs.Datagram, request Request) ([]GenericChartEntry, error) {
 				resources, err := self.apiService.GetWorkspaceControllers(request.WorkspaceName)
 				if err != nil {
 					return nil, err
@@ -705,7 +775,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "stats/workspace-traffic-utilization"},
 			PatternConfig{},
-			func(request Request) ([]GenericChartEntry, error) {
+			func(datagram structs.Datagram, request Request) ([]GenericChartEntry, error) {
 				resources, err := self.apiService.GetWorkspaceControllers(request.WorkspaceName)
 				if err != nil {
 					return nil, err
@@ -715,20 +785,25 @@ func (self *socketApi) registerPatterns() {
 		)
 	}
 
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "metrics/deployment/average-utilization"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request dtos.K8sController) *kubernetes.Metrics {
+			request.Kind = "Deployment"
+			return kubernetes.GetAverageUtilizationForDeployment(request)
+		},
+	)
+
 	{
-		self.RegisterPatternHandlerRaw(
-			"metrics/deployment/average-utilization",
-			PatternConfig{
-				RequestSchema:  schema.Generate(dtos.K8sController{}),
-				ResponseSchema: schema.Generate(&kubernetes.Metrics{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := dtos.K8sController{}
-				data.Kind = "Deployment"
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return kubernetes.GetAverageUtilizationForDeployment(data)
+		type Request struct {
+			Folder dtos.PersistentFileRequestDto `json:"folder" validate:"required"`
+		}
+
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "files/list"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) []dtos.PersistentFileDto {
+				return services.List(request.Folder)
 			},
 		)
 	}
@@ -738,38 +813,11 @@ func (self *socketApi) registerPatterns() {
 			Folder dtos.PersistentFileRequestDto `json:"folder" validate:"required"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"files/list",
-			PatternConfig{
-				RequestSchema:  schema.Generate(Request{}),
-				ResponseSchema: schema.Generate([]dtos.PersistentFileDto{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return services.List(data.Folder)
-			},
-		)
-	}
-
-	{
-		type Request struct {
-			Folder dtos.PersistentFileRequestDto `json:"folder" validate:"required"`
-		}
-
-		self.RegisterPatternHandlerRaw(
-			"files/create-folder",
-			PatternConfig{
-				RequestSchema: schema.Generate(Request{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return services.CreateFolder(data.Folder)
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "files/create-folder"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) error {
+				return services.CreateFolder(request.Folder)
 			},
 		)
 	}
@@ -780,17 +828,11 @@ func (self *socketApi) registerPatterns() {
 			NewName string                        `json:"newName" validate:"required"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"files/rename",
-			PatternConfig{
-				RequestSchema: schema.Generate(Request{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return services.Rename(data.File, data.NewName)
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "files/rename"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) error {
+				return services.Rename(request.File, request.NewName)
 			},
 		)
 	}
@@ -802,17 +844,11 @@ func (self *socketApi) registerPatterns() {
 			Gid  string                        `json:"gid" validate:"required"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"files/chown",
-			PatternConfig{
-				RequestSchema: schema.Generate(Request{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return services.Chown(data.File, data.Uid, data.Gid)
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "files/chown"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) any {
+				return services.Chown(request.File, request.Uid, request.Gid)
 			},
 		)
 	}
@@ -823,17 +859,11 @@ func (self *socketApi) registerPatterns() {
 			Mode string                        `json:"mode" validate:"required"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"files/chmod",
-			PatternConfig{
-				RequestSchema: schema.Generate(Request{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return services.Chmod(data.File, data.Mode)
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "files/chmod"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) any {
+				return services.Chmod(request.File, request.Mode)
 			},
 		)
 	}
@@ -843,17 +873,11 @@ func (self *socketApi) registerPatterns() {
 			File dtos.PersistentFileRequestDto `json:"file" validate:"required"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"files/delete",
-			PatternConfig{
-				RequestSchema: schema.Generate(Request{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return services.Delete(data.File)
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "files/delete"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) any {
+				return services.Delete(request.File)
 			},
 		)
 	}
@@ -864,40 +888,27 @@ func (self *socketApi) registerPatterns() {
 			PostTo string                        `json:"postTo" validate:"required"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"files/download",
-			PatternConfig{
-				RequestSchema: schema.Generate(Request{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return services.Download(data.File, data.PostTo)
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "files/download"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) services.FilesDownloadResponse {
+				return services.Download(request.File, request.PostTo)
 			},
 		)
 	}
 
-	self.RegisterPatternHandlerRaw(
-		"files/info",
-		PatternConfig{
-			RequestSchema:  schema.Generate(dtos.PersistentFileRequestDto{}),
-			ResponseSchema: schema.Generate(dtos.PersistentFileRequestDto{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := dtos.PersistentFileRequestDto{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.Info(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "files/info"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request dtos.PersistentFileRequestDto) dtos.PersistentFileDto {
+			return services.Info(request)
 		},
 	)
 
 	RegisterPatternHandler(
 		PatternHandle{self, "prometheus/query"},
 		PatternConfig{},
-		func(request PrometheusRequest) (*PrometheusQueryResponse, error) {
+		func(datagram structs.Datagram, request PrometheusRequest) (*PrometheusQueryResponse, error) {
 			return ExecutePrometheusQuery(request)
 		},
 	)
@@ -905,7 +916,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "prometheus/is-reachable"},
 		PatternConfig{},
-		func(request PrometheusRequest) (bool, error) {
+		func(datagram structs.Datagram, request PrometheusRequest) (bool, error) {
 			return IsPrometheusReachable(request)
 		},
 	)
@@ -913,7 +924,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "prometheus/values"},
 		PatternConfig{},
-		func(request PrometheusRequest) ([]string, error) {
+		func(datagram structs.Datagram, request PrometheusRequest) ([]string, error) {
 			return PrometheusValues(request)
 		},
 	)
@@ -921,7 +932,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "prometheus/charts/add"},
 		PatternConfig{},
-		func(request PrometheusRequestRedis) (*string, error) {
+		func(datagram structs.Datagram, request PrometheusRequestRedis) (*string, error) {
 			return PrometheusSaveQueryToRedis(self.valkeyClient, request)
 		},
 	)
@@ -929,7 +940,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "prometheus/charts/remove"},
 		PatternConfig{},
-		func(request PrometheusRequestRedis) (*string, error) {
+		func(datagram structs.Datagram, request PrometheusRequestRedis) (*string, error) {
 			return PrometheusRemoveQueryFromRedis(self.valkeyClient, request)
 		},
 	)
@@ -937,7 +948,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "prometheus/charts/get"},
 		PatternConfig{},
-		func(request PrometheusRequestRedis) (*PrometheusStoreObject, error) {
+		func(datagram structs.Datagram, request PrometheusRequestRedis) (*PrometheusStoreObject, error) {
 			return PrometheusGetQueryFromRedis(self.valkeyClient, request)
 		},
 	)
@@ -945,17 +956,16 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "prometheus/charts/list"},
 		PatternConfig{},
-		func(request PrometheusRequestRedisList) (map[string]PrometheusStoreObject, error) {
-			return PrometheusListQueriesFromRedis(self.valkeyClient, request)
+		func(datagram structs.Datagram, request PrometheusRequestRedisList) (map[string]PrometheusStoreObject, error) {
+			result, err := PrometheusListQueriesFromRedis(self.valkeyClient, request)
+			return result, err
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"cluster/backup",
-		PatternConfig{
-			ResponseSchema: schema.Generate(kubernetes.NamespaceBackupResponse{}),
-		},
-		func(datagram structs.Datagram) any {
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "cluster/backup"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request Void) any {
 			result, err := kubernetes.BackupNamespace("")
 			if err != nil {
 				return err.Error()
@@ -967,68 +977,41 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/list-persistent-volume-claims"},
 		PatternConfig{},
-		func(request services.ClusterListWorkloads) ([]v1.PersistentVolumeClaim, error) {
+		func(datagram structs.Datagram, request services.ClusterListWorkloads) ([]v1.PersistentVolumeClaim, error) {
 			return kubernetes.ListPersistentVolumeClaimsWithFieldSelector(request.Namespace, request.LabelSelector, request.Prefix)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"cluster/update-local-tls-secret",
-		PatternConfig{
-			RequestSchema: schema.Generate(services.ClusterUpdateLocalTlsSecret{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ClusterUpdateLocalTlsSecret{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return kubernetes.CreateMogeniusContainerRegistryTlsSecret(data.LocalTlsCrt, data.LocalTlsKey)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "cluster/update-local-tls-secret"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ClusterUpdateLocalTlsSecret) error {
+			return kubernetes.CreateMogeniusContainerRegistryTlsSecret(request.LocalTlsCrt, request.LocalTlsKey)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"namespace/create",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.NamespaceCreateRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.NamespaceCreateRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			data.Project.AddSecretsToRedaction()
-			return services.CreateNamespace(self.eventsClient, data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "namespace/create"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.NamespaceCreateRequest) *structs.Job {
+			request.Project.AddSecretsToRedaction()
+			return services.CreateNamespace(self.eventsClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"namespace/delete",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.NamespaceDeleteRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.NamespaceDeleteRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.DeleteNamespace(self.eventsClient, data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "namespace/delete"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.NamespaceDeleteRequest) *structs.Job {
+			return services.DeleteNamespace(self.eventsClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"namespace/backup",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.NamespaceBackupRequest{}),
-			ResponseSchema: schema.Generate(kubernetes.NamespaceBackupResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.NamespaceBackupRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err.Error()
-			}
-			result, err := kubernetes.BackupNamespace(data.NamespaceName)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "namespace/backup"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.NamespaceBackupRequest) any {
+			result, err := kubernetes.BackupNamespace(request.NamespaceName)
 			if err != nil {
 				return err.Error()
 			}
@@ -1040,10 +1023,11 @@ func (self *socketApi) registerPatterns() {
 		type Request struct {
 			Nodes []string `json:"nodes" validate:"required"`
 		}
+
 		RegisterPatternHandler(
 			PatternHandle{self, "cluster/machine-stats"},
 			PatternConfig{},
-			func(request Request) ([]structs.MachineStats, error) {
+			func(datagram structs.Datagram, request Request) ([]structs.MachineStats, error) {
 				return self.dbstats.GetMachineStatsForNodes(request.Nodes), nil
 			},
 		)
@@ -1052,7 +1036,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-repo-add"},
 		PatternConfig{},
-		func(request helm.HelmRepoAddRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmRepoAddRequest) (string, error) {
 			return helm.HelmRepoAdd(request)
 		},
 	)
@@ -1060,7 +1044,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-repo-patch"},
 		PatternConfig{},
-		func(request helm.HelmRepoPatchRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmRepoPatchRequest) (string, error) {
 			return helm.HelmRepoPatch(request)
 		},
 	)
@@ -1068,7 +1052,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-repo-update"},
 		PatternConfig{},
-		func(request Void) ([]helm.HelmEntryStatus, error) {
+		func(datagram structs.Datagram, request Void) ([]helm.HelmEntryStatus, error) {
 			return helm.HelmRepoUpdate()
 		},
 	)
@@ -1076,14 +1060,14 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-repo-list"},
 		PatternConfig{},
-		func(request Void) ([]*helm.HelmEntryWithoutPassword, error) {
+		func(datagram structs.Datagram, request Void) ([]*helm.HelmEntryWithoutPassword, error) {
 			return helm.HelmRepoList()
 		},
 	)
 
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-chart-remove"},
-		PatternConfig{}, func(request helm.HelmRepoRemoveRequest) (string, error) {
+		PatternConfig{}, func(datagram structs.Datagram, request helm.HelmRepoRemoveRequest) (string, error) {
 			return helm.HelmRepoRemove(request)
 		},
 	)
@@ -1091,7 +1075,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-chart-search"},
 		PatternConfig{},
-		func(request helm.HelmChartSearchRequest) ([]helm.HelmChartInfo, error) {
+		func(datagram structs.Datagram, request helm.HelmChartSearchRequest) ([]helm.HelmChartInfo, error) {
 			return helm.HelmChartSearch(request)
 		},
 	)
@@ -1099,7 +1083,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-chart-install"},
 		PatternConfig{},
-		func(request helm.HelmChartInstallUpgradeRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmChartInstallUpgradeRequest) (string, error) {
 			return helm.HelmChartInstall(request)
 		},
 	)
@@ -1107,7 +1091,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-chart-install-oci"},
 		PatternConfig{},
-		func(request helm.HelmChartOciInstallUpgradeRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmChartOciInstallUpgradeRequest) (string, error) {
 			return helm.HelmOciInstall(request)
 		},
 	)
@@ -1115,7 +1099,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-chart-show"},
 		PatternConfig{},
-		func(request helm.HelmChartShowRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmChartShowRequest) (string, error) {
 			return helm.HelmChartShow(request)
 		},
 	)
@@ -1123,7 +1107,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-chart-versions"},
 		PatternConfig{},
-		func(request helm.HelmChartVersionRequest) ([]helm.HelmChartInfo, error) {
+		func(datagram structs.Datagram, request helm.HelmChartVersionRequest) ([]helm.HelmChartInfo, error) {
 			return helm.HelmChartVersion(request)
 		},
 	)
@@ -1131,7 +1115,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-release-upgrade"},
 		PatternConfig{},
-		func(request helm.HelmChartInstallUpgradeRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmChartInstallUpgradeRequest) (string, error) {
 			return helm.HelmReleaseUpgrade(request)
 		},
 	)
@@ -1139,7 +1123,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-release-uninstall"},
 		PatternConfig{},
-		func(request helm.HelmReleaseUninstallRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmReleaseUninstallRequest) (string, error) {
 			return helm.HelmReleaseUninstall(request)
 		},
 	)
@@ -1147,7 +1131,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-release-list"},
 		PatternConfig{},
-		func(request helm.HelmReleaseListRequest) ([]*release.Release, error) {
+		func(datagram structs.Datagram, request helm.HelmReleaseListRequest) ([]*release.Release, error) {
 			return helm.HelmReleaseList(request)
 		},
 	)
@@ -1155,7 +1139,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-release-status"},
 		PatternConfig{},
-		func(request helm.HelmReleaseStatusRequest) (*helm.HelmReleaseStatusInfo, error) {
+		func(datagram structs.Datagram, request helm.HelmReleaseStatusRequest) (*helm.HelmReleaseStatusInfo, error) {
 			return helm.HelmReleaseStatus(request)
 		},
 	)
@@ -1163,7 +1147,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-release-history"},
 		PatternConfig{},
-		func(request helm.HelmReleaseHistoryRequest) ([]*release.Release, error) {
+		func(datagram structs.Datagram, request helm.HelmReleaseHistoryRequest) ([]*release.Release, error) {
 			return helm.HelmReleaseHistory(request)
 		},
 	)
@@ -1171,7 +1155,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-release-rollback"},
 		PatternConfig{},
-		func(request helm.HelmReleaseRollbackRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmReleaseRollbackRequest) (string, error) {
 			return helm.HelmReleaseRollback(request)
 		},
 	)
@@ -1179,7 +1163,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-release-get"},
 		PatternConfig{},
-		func(request helm.HelmReleaseGetRequest) (string, error) {
+		func(datagram structs.Datagram, request helm.HelmReleaseGetRequest) (string, error) {
 			return helm.HelmReleaseGet(request)
 		},
 	)
@@ -1187,234 +1171,140 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "cluster/helm-release-get-workloads"},
 		PatternConfig{},
-		func(request helm.HelmReleaseGetWorkloadsRequest) ([]unstructured.Unstructured, error) {
+		func(datagram structs.Datagram, request helm.HelmReleaseGetWorkloadsRequest) ([]unstructured.Unstructured, error) {
 			return helm.HelmReleaseGetWorkloads(self.valkeyClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/create",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceUpdateRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceUpdateRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			data.Service.AddSecretsToRedaction()
-			data.Project.AddSecretsToRedaction()
-			return services.UpdateService(self.eventsClient, data, self.config)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/create"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceUpdateRequest) *structs.Job {
+			request.Service.AddSecretsToRedaction()
+			request.Project.AddSecretsToRedaction()
+			return services.UpdateService(self.eventsClient, request, self.config)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/delete",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceDeleteRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceDeleteRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			data.Service.AddSecretsToRedaction()
-			data.Project.AddSecretsToRedaction()
-			return services.DeleteService(self.eventsClient, data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/delete"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceDeleteRequest) *structs.Job {
+			request.Service.AddSecretsToRedaction()
+			request.Project.AddSecretsToRedaction()
+			return services.DeleteService(self.eventsClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"SERVICE_PODS",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServicePodsRequest{}),
-			ResponseSchema: schema.Generate([]v1.Pod{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServicePodsRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.ServicePodStatus(self.eventsClient, data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "SERVICE_PODS"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServicePodsRequest) []v1.Pod {
+			return services.ServicePodStatus(self.eventsClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/resource-status",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceResourceStatusRequest{}),
-			ResponseSchema: schema.Generate(&v1.Pod{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceResourceStatusRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return kubernetes.PodStatus(data.Namespace, data.Name, data.StatusOnly)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/resource-status"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceResourceStatusRequest) *v1.Pod {
+			return kubernetes.PodStatus(request.Namespace, request.Name, request.StatusOnly)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/restart",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceRestartRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceRestartRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			data.Service.AddSecretsToRedaction()
-			return services.Restart(self.eventsClient, data, self.config)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/restart"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceRestartRequest) *structs.Job {
+			request.Service.AddSecretsToRedaction()
+			return services.Restart(self.eventsClient, request, self.config)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/stop",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceStopRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceStopRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			data.Service.AddSecretsToRedaction()
-			return services.StopService(self.eventsClient, data, self.config)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/stop"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceStopRequest) *structs.Job {
+			request.Service.AddSecretsToRedaction()
+			return services.StopService(self.eventsClient, request, self.config)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/start",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceStartRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceStartRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			data.Service.AddSecretsToRedaction()
-			return services.StartService(self.eventsClient, data, self.config)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/start"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceStartRequest) *structs.Job {
+			request.Service.AddSecretsToRedaction()
+			return services.StartService(self.eventsClient, request, self.config)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/update-service",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceUpdateRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceUpdateRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			data.Project.AddSecretsToRedaction()
-			data.Service.AddSecretsToRedaction()
-			return services.UpdateService(self.eventsClient, data, self.config)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/update-service"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceUpdateRequest) any {
+			request.Project.AddSecretsToRedaction()
+			request.Service.AddSecretsToRedaction()
+			return services.UpdateService(self.eventsClient, request, self.config)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/trigger-job",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceTriggerJobRequest{}),
-			ResponseSchema: schema.Generate(&structs.Job{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceTriggerJobRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.TriggerJobService(self.eventsClient, data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/trigger-job"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceTriggerJobRequest) *structs.Job {
+			return services.TriggerJobService(self.eventsClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/status",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.ServiceStatusRequest{}),
-			ResponseSchema: schema.Generate(services.ServiceStatusResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.ServiceStatusRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.StatusServiceDebounced(self.valkeyClient, data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "service/status"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.ServiceStatusRequest) services.ServiceStatusResponse {
+			return services.StatusServiceDebounced(self.valkeyClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/exec-sh-connection-request",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.PodCmdConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.PodCmdConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go self.execShConnection(data)
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "service/exec-sh-connection-request"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.PodCmdConnectionRequest) (Void, error) {
+			go self.execShConnection(request)
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/log-stream-connection-request",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.PodCmdConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.PodCmdConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go self.logStreamConnection(data)
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "service/log-stream-connection-request"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.PodCmdConnectionRequest) (Void, error) {
+			go self.logStreamConnection(request)
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"cluster/component-log-stream-connection-request",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.ComponentLogConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.ComponentLogConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go componentLogStreamConnection(data)
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "cluster/component-log-stream-connection-request"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.ComponentLogConnectionRequest) (Void, error) {
+			go componentLogStreamConnection(request)
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"service/pod-event-stream-connection-request",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.PodEventConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.PodEventConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go podEventStreamConnection(data)
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "service/pod-event-stream-connection-request"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.PodEventConnectionRequest) (Void, error) {
+			go podEventStreamConnection(request)
+			return nil, nil
 		},
 	)
 
 	RegisterPatternHandler(
 		PatternHandle{self, "list/all-workloads"},
 		PatternConfig{},
-		func(request Void) ([]utils.ResourceEntry, error) {
+		func(datagram structs.Datagram, request Void) ([]utils.ResourceEntry, error) {
 			return kubernetes.GetAvailableResources()
 		},
 	)
@@ -1422,7 +1312,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "get/workload-list"},
 		PatternConfig{},
-		func(request utils.ResourceEntry) (unstructured.UnstructuredList, error) {
+		func(datagram structs.Datagram, request utils.ResourceEntry) (unstructured.UnstructuredList, error) {
 			return kubernetes.GetUnstructuredResourceListFromStore(request.Group, request.Kind, request.Version, request.Name, request.Namespace)
 		},
 	)
@@ -1430,7 +1320,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "get/namespace-workload-list"},
 		PatternConfig{},
-		func(request kubernetes.GetUnstructuredNamespaceResourceListRequest) ([]unstructured.Unstructured, error) {
+		func(datagram structs.Datagram, request kubernetes.GetUnstructuredNamespaceResourceListRequest) ([]unstructured.Unstructured, error) {
 			return kubernetes.GetUnstructuredNamespaceResourceList(request.Namespace, request.Whitelist, request.Blacklist)
 		},
 	)
@@ -1438,7 +1328,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "get/labeled-workload-list"},
 		PatternConfig{},
-		func(request kubernetes.GetUnstructuredLabeledResourceListRequest) (unstructured.UnstructuredList, error) {
+		func(datagram structs.Datagram, request kubernetes.GetUnstructuredLabeledResourceListRequest) (unstructured.UnstructuredList, error) {
 			return kubernetes.GetUnstructuredLabeledResourceList(request.Label, request.Whitelist, request.Blacklist)
 		},
 	)
@@ -1446,7 +1336,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "describe/workload"},
 		PatternConfig{},
-		func(request utils.ResourceItem) (string, error) {
+		func(datagram structs.Datagram, request utils.ResourceItem) (string, error) {
 			return kubernetes.DescribeUnstructuredResource(request.Group, request.Version, request.Name, request.Namespace, request.ResourceName)
 		},
 	)
@@ -1454,7 +1344,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "create/new-workload"},
 		PatternConfig{},
-		func(request utils.ResourceData) (*unstructured.Unstructured, error) {
+		func(datagram structs.Datagram, request utils.ResourceData) (*unstructured.Unstructured, error) {
 			return kubernetes.CreateUnstructuredResource(request.Group, request.Version, request.Name, request.Namespace, request.YamlData)
 		},
 	)
@@ -1462,7 +1352,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "get/workload"},
 		PatternConfig{},
-		func(request utils.ResourceItem) (*unstructured.Unstructured, error) {
+		func(datagram structs.Datagram, request utils.ResourceItem) (*unstructured.Unstructured, error) {
 			return kubernetes.GetUnstructuredResource(request.Group, request.Version, request.Name, request.Namespace, request.ResourceName)
 		},
 	)
@@ -1470,7 +1360,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "get/workload-status"},
 		PatternConfig{},
-		func(request kubernetes.GetWorkloadStatusRequest) ([]kubernetes.WorkloadStatusDto, error) {
+		func(datagram structs.Datagram, request kubernetes.GetWorkloadStatusRequest) ([]kubernetes.WorkloadStatusDto, error) {
 			return kubernetes.GetWorkloadStatus(request)
 		},
 	)
@@ -1478,7 +1368,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "get/workload-example"},
 		PatternConfig{},
-		func(request utils.ResourceItem) (string, error) {
+		func(datagram structs.Datagram, request utils.ResourceItem) (string, error) {
 			return kubernetes.GetResourceTemplateYaml(request.Group, request.Version, request.Name, request.Kind, request.Namespace, request.ResourceName), nil
 		},
 	)
@@ -1486,7 +1376,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "update/workload"},
 		PatternConfig{},
-		func(request utils.ResourceData) (*unstructured.Unstructured, error) {
+		func(datagram structs.Datagram, request utils.ResourceData) (*unstructured.Unstructured, error) {
 			return kubernetes.UpdateUnstructuredResource(request.Group, request.Version, request.Name, request.Namespace, request.YamlData)
 		},
 	)
@@ -1494,7 +1384,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "delete/workload"},
 		PatternConfig{},
-		func(request utils.ResourceItem) (Void, error) {
+		func(datagram structs.Datagram, request utils.ResourceItem) (Void, error) {
 			return nil, kubernetes.DeleteUnstructuredResource(request.Group, request.Version, request.Name, request.Namespace, request.ResourceName)
 		},
 	)
@@ -1502,7 +1392,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "trigger/workload"},
 		PatternConfig{},
-		func(request utils.ResourceItem) (*unstructured.Unstructured, error) {
+		func(datagram structs.Datagram, request utils.ResourceItem) (*unstructured.Unstructured, error) {
 			return kubernetes.TriggerUnstructuredResource(request.Group, request.Version, request.Name, request.Namespace, request.ResourceName)
 		},
 	)
@@ -1510,7 +1400,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "get/workspaces"},
 		PatternConfig{},
-		func(request Void) ([]GetWorkspaceResult, error) {
+		func(datagram structs.Datagram, request Void) ([]GetWorkspaceResult, error) {
 			return self.apiService.GetAllWorkspaces()
 		},
 	)
@@ -1525,7 +1415,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "create/workspace"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.CreateWorkspace(request.Name, v1alpha1.NewWorkspaceSpec(
 					request.DisplayName,
 					request.Resources,
@@ -1542,7 +1432,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "get/workspace"},
 			PatternConfig{},
-			func(request Request) (*GetWorkspaceResult, error) {
+			func(datagram structs.Datagram, request Request) (*GetWorkspaceResult, error) {
 				return self.apiService.GetWorkspace(request.Name)
 			},
 		)
@@ -1564,7 +1454,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "workspace/clean-up"},
 			PatternConfig{},
-			func(request Request) (CleanUpResult, error) {
+			func(datagram structs.Datagram, request Request) (CleanUpResult, error) {
 				return self.moKubernetes.CleanUp(
 					self.apiService,
 					request.Name,
@@ -1590,7 +1480,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "update/workspace"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.UpdateWorkspace(request.Name, v1alpha1.NewWorkspaceSpec(
 					request.DisplayName,
 					request.Resources,
@@ -1607,7 +1497,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "delete/workspace"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.DeleteWorkspace(request.Name)
 			},
 		)
@@ -1621,7 +1511,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "get/users"},
 			PatternConfig{},
-			func(request Request) ([]v1alpha1.User, error) {
+			func(datagram structs.Datagram, request Request) ([]v1alpha1.User, error) {
 				return self.apiService.GetAllUsers(request.Email)
 			},
 		)
@@ -1639,7 +1529,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "create/user"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.CreateUser(request.Name, v1alpha1.NewUserSpec(
 					request.FirstName,
 					request.LastName,
@@ -1658,7 +1548,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "get/user"},
 			PatternConfig{},
-			func(request Request) (*v1alpha1.User, error) {
+			func(datagram structs.Datagram, request Request) (*v1alpha1.User, error) {
 				return self.apiService.GetUser(request.Name)
 			},
 		)
@@ -1676,7 +1566,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "update/user"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.UpdateUser(request.Name, v1alpha1.NewUserSpec(
 					request.FirstName,
 					request.LastName,
@@ -1695,7 +1585,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "delete/user"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.DeleteUser(request.Name)
 			},
 		)
@@ -1711,7 +1601,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "get/grants"},
 			PatternConfig{},
-			func(request Request) ([]v1alpha1.Grant, error) {
+			func(datagram structs.Datagram, request Request) ([]v1alpha1.Grant, error) {
 				return self.apiService.GetAllGrants(request.TargetType, request.TargetName)
 			},
 		)
@@ -1729,7 +1619,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "create/grant"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.CreateGrant(request.Name, v1alpha1.NewGrantSpec(
 					request.Grantee,
 					request.TargetType,
@@ -1748,7 +1638,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "get/grant"},
 			PatternConfig{},
-			func(request Request) (*v1alpha1.Grant, error) {
+			func(datagram structs.Datagram, request Request) (*v1alpha1.Grant, error) {
 				return self.apiService.GetGrant(request.Name)
 			},
 		)
@@ -1766,7 +1656,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "update/grant"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.UpdateGrant(request.Name, v1alpha1.NewGrantSpec(
 					request.Grantee,
 					request.TargetType,
@@ -1785,7 +1675,7 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "delete/grant"},
 			PatternConfig{},
-			func(request Request) (string, error) {
+			func(datagram structs.Datagram, request Request) (string, error) {
 				return self.apiService.DeleteGrant(request.Name)
 			},
 		)
@@ -1802,84 +1692,49 @@ func (self *socketApi) registerPatterns() {
 		RegisterPatternHandler(
 			PatternHandle{self, "get/workspace-workloads"},
 			PatternConfig{},
-			func(request Request) ([]unstructured.Unstructured, error) {
+			func(datagram structs.Datagram, request Request) ([]unstructured.Unstructured, error) {
 				return self.apiService.GetWorkspaceResources(request.WorkspaceName, request.Whitelist, request.Blacklist, request.NamespaceWhitelist)
 			},
 		)
 	}
 
-	self.RegisterPatternHandlerRaw(
-		"storage/create-volume",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.NfsVolumeRequest{}),
-			ResponseSchema: schema.Generate(structs.DefaultResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.NfsVolumeRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.CreateMogeniusNfsVolume(self.eventsClient, data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "storage/create-volume"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.NfsVolumeRequest) structs.DefaultResponse {
+			return services.CreateMogeniusNfsVolume(self.eventsClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"storage/delete-volume",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.NfsVolumeRequest{}),
-			ResponseSchema: schema.Generate(structs.DefaultResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.NfsVolumeRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.DeleteMogeniusNfsVolume(self.eventsClient, data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "storage/delete-volume"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.NfsVolumeRequest) structs.DefaultResponse {
+			return services.DeleteMogeniusNfsVolume(self.eventsClient, request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"storage/stats",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.NfsVolumeStatsRequest{}),
-			ResponseSchema: schema.Generate(services.NfsVolumeStatsResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.NfsVolumeStatsRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.StatsMogeniusNfsVolume(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "storage/stats"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.NfsVolumeStatsRequest) services.NfsVolumeStatsResponse {
+			return services.StatsMogeniusNfsVolume(request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"storage/namespace/stats",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.NfsNamespaceStatsRequest{}),
-			ResponseSchema: schema.Generate([]services.NfsVolumeStatsResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.NfsNamespaceStatsRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.StatsMogeniusNfsNamespace(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "storage/namespace/stats"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.NfsNamespaceStatsRequest) []services.NfsVolumeStatsResponse {
+			return services.StatsMogeniusNfsNamespace(request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"storage/status",
-		PatternConfig{
-			RequestSchema:  schema.Generate(services.NfsStatusRequest{}),
-			ResponseSchema: schema.Generate(services.NfsStatusResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := services.NfsStatusRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return services.StatusMogeniusNfs(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "storage/status"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.NfsStatusRequest) services.NfsStatusResponse {
+			return services.StatusMogeniusNfs(request)
 		},
 	)
 
@@ -1887,63 +1742,35 @@ func (self *socketApi) registerPatterns() {
 	// External Secrets
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-	self.RegisterPatternHandlerRaw(
-		"external-secret-store/create",
-		PatternConfig{
-			RequestSchema:  schema.Generate(controllers.CreateSecretsStoreRequest{}),
-			ResponseSchema: schema.Generate(controllers.CreateSecretsStoreResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := controllers.CreateSecretsStoreRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return controllers.CreateExternalSecretStore(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "external-secret-store/create"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request controllers.CreateSecretsStoreRequest) controllers.CreateSecretsStoreResponse {
+			return controllers.CreateExternalSecretStore(request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"external-secret-store/list",
-		PatternConfig{
-			RequestSchema:  schema.Generate(controllers.ListSecretStoresRequest{}),
-			ResponseSchema: schema.Generate([]kubernetes.SecretStore{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := controllers.ListSecretStoresRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return controllers.ListExternalSecretsStores(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "external-secret-store/list"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request controllers.ListSecretStoresRequest) []kubernetes.SecretStore {
+			return controllers.ListExternalSecretsStores(request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"external-secret/list-available-secrets",
-		PatternConfig{
-			RequestSchema:  schema.Generate(controllers.ListSecretsRequest{}),
-			ResponseSchema: schema.Generate([]string{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := controllers.ListSecretsRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return controllers.ListAvailableExternalSecrets(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "external-secret/list-available-secrets"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request controllers.ListSecretsRequest) []string {
+			return controllers.ListAvailableExternalSecrets(request)
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"external-secret-store/delete",
-		PatternConfig{
-			RequestSchema:  schema.Generate(controllers.DeleteSecretsStoreRequest{}),
-			ResponseSchema: schema.Generate(controllers.DeleteSecretsStoreResponse{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := controllers.DeleteSecretsStoreRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			return controllers.DeleteExternalSecretsStore(data)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "external-secret-store/delete"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request controllers.DeleteSecretsStoreRequest) controllers.DeleteSecretsStoreResponse {
+			return controllers.DeleteExternalSecretsStore(request)
 		},
 	)
 
@@ -1953,7 +1780,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "attach/labeled_network_policy"},
 		PatternConfig{},
-		func(request controllers.AttachLabeledNetworkPolicyRequest) (string, error) {
+		func(datagram structs.Datagram, request controllers.AttachLabeledNetworkPolicyRequest) (string, error) {
 			return controllers.AttachLabeledNetworkPolicy(request)
 		},
 	)
@@ -1961,7 +1788,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "detach/labeled_network_policy"},
 		PatternConfig{},
-		func(request controllers.DetachLabeledNetworkPolicyRequest) (string, error) {
+		func(datagram structs.Datagram, request controllers.DetachLabeledNetworkPolicyRequest) (string, error) {
 			return controllers.DetachLabeledNetworkPolicy(request)
 		},
 	)
@@ -1969,7 +1796,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "list/labeled_network_policy_ports"},
 		PatternConfig{},
-		func(request Void) ([]dtos.K8sLabeledNetworkPolicyDto, error) {
+		func(datagram structs.Datagram, request Void) ([]dtos.K8sLabeledNetworkPolicyDto, error) {
 			return controllers.ListLabeledNetworkPolicyPorts()
 		},
 	)
@@ -1977,7 +1804,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "list/conflicting_network_policies"},
 		PatternConfig{},
-		func(request controllers.ListConflictingNetworkPoliciesRequest) ([]controllers.K8sConflictingNetworkPolicyDto, error) {
+		func(datagram structs.Datagram, request controllers.ListConflictingNetworkPoliciesRequest) ([]controllers.K8sConflictingNetworkPolicyDto, error) {
 			return controllers.ListAllConflictingNetworkPolicies(request)
 		},
 	)
@@ -1985,7 +1812,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "remove/conflicting_network_policies"},
 		PatternConfig{},
-		func(request controllers.RemoveConflictingNetworkPoliciesRequest) (string, error) {
+		func(datagram structs.Datagram, request controllers.RemoveConflictingNetworkPoliciesRequest) (string, error) {
 			return controllers.RemoveConflictingNetworkPolicies(request)
 		},
 	)
@@ -1993,7 +1820,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "list/controller_network_policies"},
 		PatternConfig{},
-		func(request controllers.ListControllerLabeledNetworkPoliciesRequest) (controllers.ListControllerLabeledNetworkPoliciesResponse, error) {
+		func(datagram structs.Datagram, request controllers.ListControllerLabeledNetworkPoliciesRequest) (controllers.ListControllerLabeledNetworkPoliciesResponse, error) {
 			return controllers.ListControllerLabeledNetwork(request)
 		},
 	)
@@ -2001,7 +1828,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "update/network_policies_template"},
 		PatternConfig{},
-		func(request []kubernetes.NetworkPolicy) (Void, error) {
+		func(datagram structs.Datagram, request []kubernetes.NetworkPolicy) (Void, error) {
 			return nil, controllers.UpdateNetworkPolicyTemplate(request)
 		},
 	)
@@ -2009,7 +1836,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "list/all_network_policies"},
 		PatternConfig{},
-		func(request Void) ([]controllers.ListNetworkPolicyNamespace, error) {
+		func(datagram structs.Datagram, request Void) ([]controllers.ListNetworkPolicyNamespace, error) {
 			return controllers.ListAllNetworkPolicies(self.valkeyClient)
 		},
 	)
@@ -2017,7 +1844,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "list/namespace_network_policies"},
 		PatternConfig{},
-		func(request controllers.ListNamespaceLabeledNetworkPoliciesRequest) ([]controllers.ListNetworkPolicyNamespace, error) {
+		func(datagram structs.Datagram, request controllers.ListNamespaceLabeledNetworkPoliciesRequest) ([]controllers.ListNetworkPolicyNamespace, error) {
 			return controllers.ListNamespaceNetworkPolicies(self.valkeyClient, request)
 		},
 	)
@@ -2025,7 +1852,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "enforce/network_policy_manager"},
 		PatternConfig{},
-		func(request controllers.EnforceNetworkPolicyManagerRequest) (Void, error) {
+		func(datagram structs.Datagram, request controllers.EnforceNetworkPolicyManagerRequest) (Void, error) {
 			return nil, controllers.EnforceNetworkPolicyManager(request.NamespaceName)
 		},
 	)
@@ -2033,7 +1860,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "disable/network_policy_manager"},
 		PatternConfig{},
-		func(request controllers.DisableNetworkPolicyManagerRequest) (Void, error) {
+		func(datagram structs.Datagram, request controllers.DisableNetworkPolicyManagerRequest) (Void, error) {
 			return nil, controllers.DisableNetworkPolicyManager(request.NamespaceName)
 		},
 	)
@@ -2041,7 +1868,7 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "remove/unmanaged_network_policies"},
 		PatternConfig{},
-		func(request controllers.RemoveUnmanagedNetworkPoliciesRequest) (Void, error) {
+		func(datagram structs.Datagram, request controllers.RemoveUnmanagedNetworkPoliciesRequest) (Void, error) {
 			return nil, controllers.RemoveUnmanagedNetworkPolicies(request)
 		},
 	)
@@ -2049,7 +1876,10 @@ func (self *socketApi) registerPatterns() {
 	RegisterPatternHandler(
 		PatternHandle{self, "list/only_namespace_network_policies"},
 		PatternConfig{},
-		func(request controllers.ListNamespaceLabeledNetworkPoliciesRequest) ([]controllers.ListManagedAndUnmanagedNetworkPolicyNamespace, error) {
+		func(
+			datagram structs.Datagram,
+			request controllers.ListNamespaceLabeledNetworkPoliciesRequest,
+		) ([]controllers.ListManagedAndUnmanagedNetworkPolicyNamespace, error) {
 			return controllers.ListManagedAndUnmanagedNamespaceNetworkPolicies(self.valkeyClient, request)
 		},
 	)
@@ -2064,164 +1894,104 @@ func (self *socketApi) registerPatterns() {
 			ControllerName string `json:"controllerName" validate:"required"`
 		}
 
-		self.RegisterPatternHandlerRaw(
-			"list/cronjob-jobs",
-			PatternConfig{
-				RequestSchema: schema.Generate(Request{}),
-			},
-			func(datagram structs.Datagram) any {
-				data := Request{}
-				if err := self.LoadRequest(&datagram, &data); err != nil {
-					return err
-				}
-				return kubernetes.ListCronjobJobs(data.ControllerName, data.NamespaceName, data.ProjectId)
+		RegisterPatternHandlerRaw(
+			PatternHandle{self, "list/cronjob-jobs"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) kubernetes.ListJobInfoResponse {
+				return kubernetes.ListCronjobJobs(request.ControllerName, request.NamespaceName, request.ProjectId)
 			},
 		)
 	}
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/nodes-traffic",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, []string{})
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "live-stream/nodes-traffic"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) (Void, error) {
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, []string{})
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/nodes-memory",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, []string{})
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "live-stream/nodes-memory"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) (Void, error) {
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, []string{})
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/nodes-cpu",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, []string{})
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "live-stream/nodes-cpu"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) (Void, error) {
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, []string{})
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/pod-cpu",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, []string{data.PodName})
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "live-stream/pod-cpu"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) (Void, error) {
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, []string{request.PodName})
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/pod-memory",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, []string{data.PodName})
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "live-stream/pod-memory"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) (Void, error) {
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, []string{request.PodName})
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/pod-traffic",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, []string{data.PodName})
-			return nil
+	RegisterPatternHandler(
+		PatternHandle{self, "live-stream/pod-traffic"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) (Void, error) {
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, []string{request.PodName})
+			return nil, nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/workspace-cpu",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			podNames, err := self.apiService.GetWorkspacePodsNames(data.Workspace)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "live-stream/workspace-cpu"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) any {
+			podNames, err := self.apiService.GetWorkspacePodsNames(request.Workspace)
 			if err != nil {
 				return fmt.Errorf("failed to get workspace pods: %w", err)
 			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, podNames)
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, podNames)
 			return nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/workspace-memory",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			podNames, err := self.apiService.GetWorkspacePodsNames(data.Workspace)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "live-stream/workspace-memory"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) any {
+			podNames, err := self.apiService.GetWorkspacePodsNames(request.Workspace)
 			if err != nil {
 				return fmt.Errorf("failed to get workspace pods: %w", err)
 			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, podNames)
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, podNames)
 			return nil
 		},
 	)
 
-	self.RegisterPatternHandlerRaw(
-		"live-stream/workspace-traffic",
-		PatternConfig{
-			RequestSchema: schema.Generate(xterm.WsConnectionRequest{}),
-		},
-		func(datagram structs.Datagram) any {
-			data := xterm.WsConnectionRequest{}
-			if err := self.LoadRequest(&datagram, &data); err != nil {
-				return err
-			}
-			podNames, err := self.apiService.GetWorkspacePodsNames(data.Workspace)
+	RegisterPatternHandlerRaw(
+		PatternHandle{self, "live-stream/workspace-traffic"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request xterm.WsConnectionRequest) any {
+			podNames, err := self.apiService.GetWorkspacePodsNames(request.Workspace)
 			if err != nil {
 				return fmt.Errorf("failed to get workspace pods: %w", err)
 			}
-			go self.xtermService.LiveStreamConnection(data, datagram, self.httpService, self.valkeyClient, podNames)
+			go self.xtermService.LiveStreamConnection(request, datagram, self.httpService, self.valkeyClient, podNames)
 			return nil
 		},
 	)

--- a/src/schema/schema.go
+++ b/src/schema/schema.go
@@ -146,6 +146,12 @@ func parseSchema(schema *Schema, input reflect.Type, depth int) (*TypeInfo, erro
 	typeInfo := &TypeInfo{}
 	typeInfo.Pointer = false
 
+	if input == nil {
+		typeInfo.Type = SchemaTypeAny
+		typeInfo.Pointer = true
+		return typeInfo, nil
+	}
+
 	if input.Kind() == reflect.Ptr {
 		input = input.Elem()
 		typeInfo.Pointer = true

--- a/src/xterm/xtermcommandstreamconnection.go
+++ b/src/xterm/xtermcommandstreamconnection.go
@@ -34,7 +34,7 @@ func injectContent(content io.Reader, conn *websocket.Conn, connWriteLock *sync.
 			err := conn.WriteMessage(websocket.TextMessage, []byte(err.Error()))
 			connWriteLock.Unlock()
 			if err != nil {
-				xtermLogger.Error("WriteMessage", "error", err)
+				xtermLogger.Error("failed to write websocket message", "error", err)
 			}
 		}
 		return
@@ -49,16 +49,15 @@ func injectContent(content io.Reader, conn *websocket.Conn, connWriteLock *sync.
 			if err == io.EOF {
 				break
 			}
-
-			xtermLogger.Error("WriteMessage", "error", err)
-			break
+			xtermLogger.Error("failed to read from pseudoterminal", "error", err)
+			continue
 		}
 		if conn != nil {
 			connWriteLock.Lock()
 			err := conn.WriteMessage(websocket.BinaryMessage, buf[:n])
 			connWriteLock.Unlock()
 			if err != nil {
-				xtermLogger.Error("WriteMessage", "error", err)
+				xtermLogger.Error("failed to write websocket message", "error", err)
 				break
 			}
 		} else {


### PR DESCRIPTION
The schema generation now handles the field payload directly rather than only the success case. As a trade-off all raw patterns use the any type now. Golang does not support explicite unions of T|error and basically enforces this.