### PR TITLE
fix: use standard library slices.Contains

### DIFF
--- a/src/core/xtermservice.go
+++ b/src/core/xtermservice.go
@@ -7,10 +7,10 @@ import (
 	"mogenius-k8s-manager/src/networkmonitor"
 	"mogenius-k8s-manager/src/rammonitor"
 	"mogenius-k8s-manager/src/structs"
-	"mogenius-k8s-manager/src/utils"
 	"mogenius-k8s-manager/src/valkeyclient"
 	"mogenius-k8s-manager/src/xterm"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -113,7 +113,7 @@ func (self *xtermService) LiveStreamConnection(conReq xterm.WsConnectionRequest,
 			}
 			// remove entries which are not the requested pod
 			for i := 0; i < len(data); i++ {
-				if !utils.Contains(podNames, data[i].Name) {
+				if !slices.Contains(podNames, data[i].Name) {
 					data = append(data[:i], data[i+1:]...)
 					i--
 				}
@@ -127,7 +127,7 @@ func (self *xtermService) LiveStreamConnection(conReq xterm.WsConnectionRequest,
 				return
 			}
 			for i := 0; i < len(data); i++ {
-				if !utils.Contains(podNames, data[i].Name) {
+				if !slices.Contains(podNames, data[i].Name) {
 					data = append(data[:i], data[i+1:]...)
 					i--
 				}
@@ -141,7 +141,7 @@ func (self *xtermService) LiveStreamConnection(conReq xterm.WsConnectionRequest,
 				return
 			}
 			for i := 0; i < len(data); i++ {
-				if !utils.Contains(podNames, data[i].Pod) {
+				if !slices.Contains(podNames, data[i].Pod) {
 					data = append(data[:i], data[i+1:]...)
 					i--
 				}

--- a/src/kubernetes/utils.go
+++ b/src/kubernetes/utils.go
@@ -11,6 +11,7 @@ import (
 	"mogenius-k8s-manager/src/utils"
 	"mogenius-k8s-manager/src/version"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -262,11 +263,7 @@ func Umount(volumeNamespace string, volumeName string) {
 
 func IsLocalClusterSetup() bool {
 	ips := GetClusterExternalIps()
-	if utils.Contains(ips, "192.168.66.1") || utils.Contains(ips, "localhost") {
-		return true
-	} else {
-		return false
-	}
+	return slices.Contains(ips, "192.168.66.1") || slices.Contains(ips, "localhost")
 }
 
 func GetCustomDeploymentTemplate() *v1.Deployment {

--- a/src/kubernetes/watcheractions.go
+++ b/src/kubernetes/watcheractions.go
@@ -220,7 +220,7 @@ func GetUnstructuredNamespaceResourceList(namespace string, whitelist []*utils.R
 					return &result
 				} else {
 					// fallback: gather the data when the store is empty (can be slow)
-					if utils.Contains(MirroredResourceKinds, v.Kind) {
+					if slices.Contains(MirroredResourceKinds, v.Kind) {
 						return nil
 					}
 					list, err := GetUnstructuredResourceList(v.Group, v.Version, v.Name, v.Namespace)

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -260,15 +260,6 @@ func CreateError(err error) ResponseError {
 	}
 }
 
-func Contains(s []string, str string) bool {
-	for _, v := range s {
-		if strings.Contains(str, v) {
-			return true
-		}
-	}
-	return false
-}
-
 func RunOnLocalShell(cmd string) *exec.Cmd {
 	switch runtime.GOOS {
 	case "linux":


### PR DESCRIPTION
```golang
func Contains(s []string, str string) bool {
	for _, v := range s {
		if strings.Contains(str, v) {
			return true
		}
	}
	return false
}
```

This function works different to what the name suggests. It checks if the provided `str` contains any of the elements of `s` as substring. Ofcourse this also works if the values are equal.

Judging by the usage in our Code __today__ the `utils.Contains` method is used on values to compare for equality always. This probably wasn't the case when it was written.

Also with one of the newer Golang versions we got `slices.Contains` which now replaces this usage completely.