### PR TITLE
OCI Support for Helm Chart with cosign

### DIFF
--- a/.github/workflows/develop-and-feature-branches.yml
+++ b/.github/workflows/develop-and-feature-branches.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   IMAGE_NAME: ghcr.io/mogenius/mogenius-operator-dev
-  REGISTRY: ghcr.io 
+  REGISTRY: ghcr.io
   DOCKER_CONFIG: ./.docker
   HELMNAME: "mogenius-operator-dev"
   HELMREPO: "mogenius/helm-k8s-manager"
@@ -102,6 +102,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Check out code
         uses: actions/checkout@v5
@@ -119,6 +120,9 @@ jobs:
         with:
           chart-search-root: helm
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
       - name: package and push
         run: |
           cd ./helm/charts/mogenius-operator
@@ -127,3 +131,15 @@ jobs:
           sed -i -e "s/name: mogenius-operator/name: mogenius-operator-dev/" Chart.yaml    
           helm package -d /tmp/ --version ${{ env.SEMVERSION }} --app-version ${{ env.SEMVERSION }} .
           curl -XPOST -L -k --data-binary "@/tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz" https://${{ secrets.MO_HELMUSER }}:${{ secrets.MO_HELMPASS }}@helm.mogenius.com/api/public/charts
+
+          echo "Pushing to OCI registry"
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+          CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
+          if [ -z "$CHART_DIGEST" ]; then
+            echo "Failed to extract chart digest"
+            exit 1
+          fi
+          echo "Chart digest: $CHART_DIGEST"
+
+          echo "Signing Helm chart with cosign"
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/helm-charts/${{ env.HELMNAME }}@${CHART_DIGEST}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,9 +125,9 @@ jobs:
 
           echo "Pushing to OCI registry"
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
-          CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-$VERSION.tgz oci://ghcr.io/${{ github.repository_owner }} 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
+          CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-$VERSION.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
 
           echo "Chart digest: $CHART_DIGEST"
 
           echo "Signing Helm chart with cosign"
-          cosign sign --yes ghcr.io/${{ github.repository_owner }}/${{ env.HELMNAME }}@${CHART_DIGEST}
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/helm-charts/${{ env.HELMNAME }}@${CHART_DIGEST}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         env:
@@ -94,6 +94,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Check out code
         uses: actions/checkout@v5
@@ -101,11 +102,14 @@ jobs:
           fetch-depth: 0
 
       - name: set version env
-        run: echo "SEMVERSION=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV  
+        run: echo "SEMVERSION=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
 
       - name: Install Helm
         uses: azure/setup-helm@v4.3.1
         id: install
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
 
       - name: Run helm-docs
         uses: losisin/helm-docs-github-action@v1.6.2
@@ -118,4 +122,12 @@ jobs:
           sed -i -e "s/v1.0.72/${{ env.SEMVERSION }}/" values.yaml
           helm package -d /tmp/ --version ${{ env.SEMVERSION }} --app-version ${{ env.SEMVERSION }} .
           curl -XPOST -L -k --data-binary "@/tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz" https://${{ secrets.MO_HELMUSER }}:${{ secrets.MO_HELMPASS }}@helm.mogenius.com/api/public/charts
-   
+
+          echo "Pushing to OCI registry"
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+          CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-$VERSION.tgz oci://ghcr.io/${{ github.repository_owner }} 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
+
+          echo "Chart digest: $CHART_DIGEST"
+
+          echo "Signing Helm chart with cosign"
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/${{ env.HELMNAME }}@${CHART_DIGEST}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
 
           echo "Pushing to OCI registry"
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
-          CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-$VERSION.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
+          CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
 
           echo "Chart digest: $CHART_DIGEST"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,10 @@ jobs:
           echo "Pushing to OCI registry"
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
           CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
-
+          if [ -z "$CHART_DIGEST" ]; then
+            echo "Failed to extract chart digest"
+            exit 1
+          fi
           echo "Chart digest: $CHART_DIGEST"
 
           echo "Signing Helm chart with cosign"

--- a/README.md
+++ b/README.md
@@ -80,21 +80,26 @@ Prerequisites:
 
 - A running mogenius platform (see official docs) or at least the helm chart installed.
 - Go 1.25+
-- `just` task runner (https://github.com/casey/just)
+- `just` task runner (<https://github.com/casey/just>)
 - Access to a Kubernetes cluster with the operator namespace (`mogenius`).
 
 Steps:
 
 1. Create `.env` (see section 5).
 2. Optionally scale down in-cluster deployment to avoid conflicts:
+
    ```sh
    just scale-down
    ```
+
 3. Build & generate artifacts:
+
    ```sh
    just build
    ```
+
 4. Run locally:
+
    ```sh
    just run
    ```
@@ -241,11 +246,27 @@ helm upgrade --install mogenius-platform mo-public/mogenius-operator \
   --set global.api_key="<api-key>"
 ```
 
+Add & install with OCI:
+
+```sh
+helm -n mogenius upgrade --install mogenius-platform \
+  oci://ghcr.io/mogenius/helm-charts/mogenius-operator \
+  --create-namespace \
+  --set global.cluster_name="<cluster>" \
+  --set global.api_key="<api-key>"
+```
+
 Upgrade:
 
 ```sh
 helm repo update
 helm upgrade mogenius-platform mo-public/mogenius-operator
+```
+
+Upgrade with OCI:
+
+```sh
+helm upgrade mogenius-platform oci://ghcr.io/mogenius/helm-charts/mogenius-operator
 ```
 
 Uninstall:

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ helm upgrade mogenius-platform mo-public/mogenius-operator
 Upgrade with OCI:
 
 ```sh
-helm upgrade mogenius-platform oci://ghcr.io/mogenius/helm-charts/mogenius-operator
+helm -n mogenius upgrade mogenius-platform oci://ghcr.io/mogenius/helm-charts/mogenius-operator
 ```
 
 Uninstall:


### PR DESCRIPTION
## Summary
- Added cosign-based signing for Helm charts published to OCI registry
- Uses keyless signing with Sigstore

## Changes
- Added `id-token: write` permission for OIDC authentication
- Installed cosign in CI workflow
- Signs chart by digest after OCI push
- Updated documentation