### PR TITLE
OCI Support for Helm Chart with cosign

### DIFF
--- a/.github/workflows/develop-and-feature-branches.yml
+++ b/.github/workflows/develop-and-feature-branches.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   IMAGE_NAME: ghcr.io/mogenius/mogenius-operator-dev
-  REGISTRY: ghcr.io 
+  REGISTRY: ghcr.io
   DOCKER_CONFIG: ./.docker
   HELMNAME: "mogenius-operator-dev"
   HELMREPO: "mogenius/helm-k8s-manager"
@@ -102,6 +102,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Check out code
         uses: actions/checkout@v5
@@ -119,11 +120,31 @@ jobs:
         with:
           chart-search-root: helm
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
       - name: package and push
         run: |
           cd ./helm/charts/mogenius-operator
           sed -i -e "s/v1.0.72/${{ env.SEMVERSION }}/" values.yaml
           sed -i -e "s/repository: mogenius\/mogenius-operator/repository: mogenius\/mogenius-operator-dev/" values.yaml
           sed -i -e "s/name: mogenius-operator/name: mogenius-operator-dev/" Chart.yaml    
+
+          echo "Packaging Helm chart"
           helm package -d /tmp/ --version ${{ env.SEMVERSION }} --app-version ${{ env.SEMVERSION }} .
+
+          echo "Pushing to Mogenius Helm repo"
           curl -XPOST -L -k --data-binary "@/tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz" https://${{ secrets.MO_HELMUSER }}:${{ secrets.MO_HELMPASS }}@helm.mogenius.com/api/public/charts
+
+          echo "Pushing to OCI registry"
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+          CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
+          if [ -z "$CHART_DIGEST" ]; then
+            echo "Failed to extract chart digest"
+            exit 1
+          fi
+          echo "Chart digest: $CHART_DIGEST"
+
+          echo "Signing Helm chart with cosign"
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/helm-charts/${{ env.HELMNAME }}@${CHART_DIGEST}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         env:
@@ -94,6 +94,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Check out code
         uses: actions/checkout@v5
@@ -101,11 +102,14 @@ jobs:
           fetch-depth: 0
 
       - name: set version env
-        run: echo "SEMVERSION=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV  
+        run: echo "SEMVERSION=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
 
       - name: Install Helm
         uses: azure/setup-helm@v4.3.1
         id: install
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
 
       - name: Run helm-docs
         uses: losisin/helm-docs-github-action@v1.6.2
@@ -114,8 +118,26 @@ jobs:
 
       - name: package and push
         run: |
+          set -x
+
           cd ./helm/charts/mogenius-operator
           sed -i -e "s/v1.0.72/${{ env.SEMVERSION }}/" values.yaml
+
+          echo "Packaging Helm chart"
           helm package -d /tmp/ --version ${{ env.SEMVERSION }} --app-version ${{ env.SEMVERSION }} .
+
+          echo "Pushing to Mogenius Helm repo"
           curl -XPOST -L -k --data-binary "@/tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz" https://${{ secrets.MO_HELMUSER }}:${{ secrets.MO_HELMPASS }}@helm.mogenius.com/api/public/charts
-   
+
+          echo "Pushing to OCI registry"
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+          CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-${{ env.SEMVERSION }}.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
+          if [ -z "$CHART_DIGEST" ]; then
+            echo "Failed to extract chart digest"
+            exit 1
+          fi
+          echo "Chart digest: $CHART_DIGEST"
+
+          echo "Signing Helm chart with cosign"
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/helm-charts/${{ env.HELMNAME }}@${CHART_DIGEST}


### PR DESCRIPTION
## Summary
- Added cosign-based signing for Helm charts published to OCI registry
- Uses keyless signing with Sigstore

## Changes
- Added `id-token: write` permission for OIDC authentication
- Installed cosign in CI workflow
- Signs chart by digest after OCI push
- Added OCI registry login and push steps for both main and develop workflows
- Improved logging and error handling for chart digest extraction
- Updated documentation