### PR TITLE
fix(helm): wait for valkey readiness before operator starts

### DIFF
--- a/helm/charts/mogenius-operator/templates/deployment.yaml
+++ b/helm/charts/mogenius-operator/templates/deployment.yaml
@@ -37,8 +37,38 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.features.debugTools.enabled }}
+      {{- if or .Values.valkey.enabled .Values.features.debugTools.enabled }}
       initContainers:
+        {{- if .Values.valkey.enabled }}
+        - name: wait-for-valkey
+          image: {{ .Values.valkey.image.registry }}/{{ .Values.valkey.image.repository }}:{{ .Values.valkey.image.tag }}
+          imagePullPolicy: {{ .Values.valkey.imagePullPolicy }}
+          env:
+            - name: VALKEY_HOST
+              value: {{ .Values.fullnameOverride }}-valkey
+            - name: VALKEY_PORT
+              value: {{ .Values.valkey.port | quote }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fullnameOverride }}-valkey
+                  key: valkey-password
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              echo "waiting for valkey at $VALKEY_HOST:$VALKEY_PORT..."
+              until valkey-cli -h "$VALKEY_HOST" -p "$VALKEY_PORT" -a "$VALKEY_PASSWORD" --no-auth-warning ping 2>/dev/null | grep -q PONG; do
+                echo "valkey not ready, retrying in 2s..."
+                sleep 2
+              done
+              echo "valkey is ready"
+          {{- with .Values.valkey.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.features.debugTools.enabled }}
         - name: debug-tools-init
           image: {{ .Values.features.debugTools.image.registry }}/{{ .Values.features.debugTools.image.repository }}:{{ .Values.features.debugTools.image.tag }}
           imagePullPolicy: {{ .Values.features.debugTools.image.pullPolicy }}
@@ -61,6 +91,7 @@ spec:
           volumeMounts:
             - mountPath: /netshoot
               name: debug-tools
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Values.fullnameOverride }}


### PR DESCRIPTION
## Summary
- Adds a `wait-for-valkey` initContainer to the operator Deployment that polls valkey with `valkey-cli ping` until it responds `PONG`.
- Prevents CrashLoopBackOff on fresh installs: the Go client is built with `DisableRetry: true` and fails hard on the first PING if valkey isn't ready yet ([src/valkeyclient/valkeyclient.go](src/valkeyclient/valkeyclient.go)).
- Reuses the existing valkey image, Secret (`{{ fullnameOverride }}-valkey` / key `valkey-password`), and `valkey.containerSecurityContext` — no new values.
- Gated on `valkey.enabled` so users running against an external valkey can opt out.

## Test plan
- [x] `helm lint ./helm/charts/mogenius-operator`
- [x] `helm template` with defaults — `wait-for-valkey` initContainer rendered with correct host/port/secret
- [x] `helm template --set valkey.enabled=false` — no `wait-for-valkey` initContainer, no empty `initContainers:` key
- [x] `helm template --set features.debugTools.enabled=true` — both init containers under a single `initContainers:` list
- [ ] Live install on a test cluster: operator pod sits in `Init:0/1` until valkey is ready, then transitions to `Running` without CrashLoopBackOff