### PR TITLE
fix: adding options to disable automatic upgrades in the operator

### DIFF
--- a/helm/charts/mogenius-operator/templates/deployment.yaml
+++ b/helm/charts/mogenius-operator/templates/deployment.yaml
@@ -103,6 +103,8 @@ spec:
             - name: PATH
               value: "/netshoot/usr/bin:/netshoot/bin:/netshoot/usr/sbin:/netshoot/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             {{- end }}
+            - name: MO_ENABLE_AUTO_UPGRADE
+              value: {{ .Values.features.autoUpgrade.enabled | quote }}
           volumeMounts:
             - mountPath: /app/helm-data
               name: helm-data

--- a/helm/charts/mogenius-operator/values.yaml
+++ b/helm/charts/mogenius-operator/values.yaml
@@ -17,6 +17,8 @@ cluster:
 
 # -- feature toggles for the mogenius-operator
 features:
+  autoUpgrade:
+    enabled: true
   debugTools:
     # -- enable the debug tools container in the mogenius-operator pod
     enabled: false

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -337,6 +337,18 @@ func LoadConfigDeclarations(configModule *config.Config) {
 		},
 	})
 	configModule.Declare(config.ConfigDeclaration{
+		Key:          "MO_ENABLE_AUTO_UPGRADE",
+		DefaultValue: utils.Pointer("true"),
+		Description:  utils.Pointer("enable automatic operator self-upgrades triggered by the platform "),
+		Validate: func(value string) error {
+			_, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("'MO_ENABLE_AUTO_UPGRADE' needs to be a boolean: %s", err.Error())
+			}
+			return nil
+		},
+	})
+	configModule.Declare(config.ConfigDeclaration{
 		Key:          "MO_SNOOPY_IMPLEMENTATION",
 		DefaultValue: utils.Pointer("auto"),
 		Description:  utils.Pointer("set which implementation for tracking network traffic should be used"),
@@ -399,4 +411,3 @@ func LoadConfigDeclarations(configModule *config.Config) {
 		},
 	})
 }
-

--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -2578,6 +2578,15 @@ func (self *socketApi) ExecuteCommandRequest(datagram structs.Datagram) any {
 func (self *socketApi) upgradeK8sManager(command string) (*structs.Job, error) {
 	job := structs.CreateJob(self.eventsClient, "Upgrade mogenius platform", "UPGRADE", "", "", self.logger)
 	job.Start(self.eventsClient)
+
+	if self.config.Get("MO_ENABLE_AUTO_UPGRADE") != "true" {
+		msg := "Automatic Upgrades are disabled. If you are using GitOps please update the Operator in your GitOps Repository"
+		job.Fail(msg)
+		job.Finished = time.Now()
+		structs.ReportJobStateToServer(self.eventsClient, job)
+		return job, fmt.Errorf("%s", msg)
+	}
+
 	_, err := kubernetes.UpgradeMyself(self.eventsClient, job, command)
 	job.Finish(self.eventsClient)
 	return job, err


### PR DESCRIPTION
Issue: [MOG-4286](https://linear.app/mogenius/issue/MOG-4286/add-option-to-deactivate-mogenius-operator-auto-update-for-gitops)