### PR TITLE
fix(watcher): exclude helm release secrets from secret watch (MOG-4324, MOG-4325)

### DIFF
--- a/src/ai/aimanager_api.go
+++ b/src/ai/aimanager_api.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"errors"
 	"fmt"
 	"mogenius-operator/src/crds/v1alpha1"
 	"mogenius-operator/src/store"
@@ -305,11 +306,18 @@ func (ai *aiManager) GetStatus(workspace *string) AiManagerStatus {
 	}
 	aiStatusMu.RUnlock()
 
-	sdk, _ := ai.getSdkType()
-	limit, _ := ai.getDailyTokenLimit()
-	model, _ := ai.getAiModel()
-	maxToolCalls, _ := ai.getAiMaxToolCalls()
-	apiUrl, _ := ai.getBaseUrl()
+	// Errors here are non-fatal - the status is returned with zero values
+	// for whatever could not be read. They were previously discarded
+	// silently, which hid the empty-state cause (e.g. AI config secret not
+	// reachable). Collect and log them once so the condition is visible.
+	sdk, sdkErr := ai.getSdkType()
+	limit, limitErr := ai.getDailyTokenLimit()
+	model, modelErr := ai.getAiModel()
+	maxToolCalls, maxToolCallsErr := ai.getAiMaxToolCalls()
+	apiUrl, apiUrlErr := ai.getBaseUrl()
+	if settingsErr := errors.Join(sdkErr, limitErr, modelErr, maxToolCallsErr, apiUrlErr); settingsErr != nil {
+		ai.logger.Warn("failed to read one or more AI config settings", "error", settingsErr)
+	}
 	tokensUsed, todaysProcessedTasks, _ := ai.getTodayTokenUsage()
 
 	if tokensUsed > limit {

--- a/src/ai/aimanager_config.go
+++ b/src/ai/aimanager_config.go
@@ -56,6 +56,13 @@ func (ai *aiManager) isAiPromptConfigInitialized() bool {
 
 func (ai *aiManager) isAiModelConfigInitialized() bool {
 	ownNamespace := ai.config.Get("MO_OWN_NAMESPACE")
+	// Mirror getAiSettingByKey: try the cache first, then fall back to a
+	// direct API read. Using only the direct call made this flag report
+	// false whenever that single Get failed (e.g. API throttling), even
+	// though the config existed and the cache held it.
+	if store.GetSecret(ownNamespace, AI_CONFIG_SECRET_NAME) != nil {
+		return true
+	}
 	configSecret, err := ai.secretGetter(ownNamespace, AI_CONFIG_SECRET_NAME)
 	return err == nil && configSecret != nil
 }

--- a/src/watcher/watcher.go
+++ b/src/watcher/watcher.go
@@ -13,11 +13,23 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 )
+
+// Helm stores up to 10 history revisions per release as Secrets of type
+// helm.sh/release.v1. In clusters with many releases these dominate the
+// Secret list (often thousands, several KB each) and push the initial
+// cache sync past the 30s timeout below, so the Secret watcher never
+// syncs and the cache stays empty. These secrets are never read from the
+// operator's store (Helm uses its own storage driver, which talks to the
+// API directly), so they are excluded server-side via a field selector on
+// a dedicated informer factory for Secrets.
+const helmReleaseSecretType = "helm.sh/release.v1"
+const secretWatchFieldSelector = "type!=" + helmReleaseSecretType
 
 // A generic kubernetes resource watcher
 type WatcherModule interface {
@@ -75,6 +87,13 @@ type watcher struct {
 	// up by GVR (factory.ForResource returns the same instance on repeat
 	// calls).
 	factory dynamicinformer.DynamicSharedInformerFactory
+	// secretFactory is a dedicated factory used only for the Secret GVR. It
+	// carries a field selector that excludes Helm release-history secrets
+	// (see secretWatchFieldSelector). It must be separate from `factory`
+	// because the field selector references the `type` field, which only
+	// Secrets expose - applying it to the shared factory would break the
+	// List/Watch of every other resource kind.
+	secretFactory dynamicinformer.DynamicSharedInformerFactory
 	// factoryStopCh is allocated but intentionally never closed by this
 	// package - the shared factory runs for the watcher's lifetime, the
 	// OS reclaims its reflectors at process exit. Closing it from
@@ -104,6 +123,14 @@ func NewWatcher(logger *slog.Logger, clientProvider k8sclient.K8sClientProvider)
 		utils.ResourceResyncTime,
 		v1.NamespaceAll,
 		nil,
+	)
+	self.secretFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(
+		clientProvider.DynamicClient(),
+		utils.ResourceResyncTime,
+		v1.NamespaceAll,
+		func(opts *metav1.ListOptions) {
+			opts.FieldSelector = secretWatchFieldSelector
+		},
 	)
 	self.informersConfigured = make(map[schema.GroupVersionResource]bool)
 	self.objectSubsAdd = make(map[objectSubscriptionKey][]func(*unstructured.Unstructured))
@@ -234,7 +261,13 @@ func (self *watcher) registerAndStartInformer(gvr schema.GroupVersionResource, r
 	self.handlerMapLock.Lock()
 	defer self.handlerMapLock.Unlock()
 
-	resourceInformer := self.factory.ForResource(gvr).Informer()
+	// Secrets are watched through a dedicated factory carrying a field
+	// selector that drops Helm release-history secrets; every other kind
+	// uses the shared factory. The factory.Start race documented in
+	// startSingleWatcher is per-factory, so isolating Secrets onto their
+	// own factory preserves that invariant.
+	factory := self.factoryForGVR(gvr)
+	resourceInformer := factory.ForResource(gvr).Informer()
 
 	if !self.informersConfigured[gvr] {
 		// Strip large metadata fields before caching to reduce in-process
@@ -271,11 +304,22 @@ func (self *watcher) registerAndStartInformer(gvr schema.GroupVersionResource, r
 		self.informersConfigured[gvr] = true
 	}
 
-	// Start the shared factory under the same lock. Idempotent for
+	// Start the selected factory under the same lock. Idempotent for
 	// already-running informers; this newly-registered one is launched.
-	self.factory.Start(self.factoryStopCh)
+	factory.Start(self.factoryStopCh)
 
 	return resourceInformer, nil
+}
+
+// factoryForGVR returns the informer factory responsible for the given GVR.
+// The core/v1 Secret GVR is routed to secretFactory (which excludes Helm
+// release-history secrets via a field selector); everything else uses the
+// shared factory.
+func (self *watcher) factoryForGVR(gvr schema.GroupVersionResource) dynamicinformer.DynamicSharedInformerFactory {
+	if gvr.Group == "" && gvr.Version == "v1" && gvr.Resource == "secrets" {
+		return self.secretFactory
+	}
+	return self.factory
 }
 
 func (self *watcher) startSingleWatcher(ctx context.Context, resource utils.ResourceDescriptor, onAdd WatcherOnAdd, onUpdate WatcherOnUpdate, onDelete WatcherOnDelete) error {

--- a/src/watcher/watcher_test.go
+++ b/src/watcher/watcher_test.go
@@ -1,0 +1,54 @@
+package watcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+)
+
+// newRoutingTestWatcher builds a watcher with two distinct factories so we can
+// assert that factoryForGVR routes Secrets to the dedicated (field-selector)
+// factory and everything else to the shared one.
+func newRoutingTestWatcher() (*watcher, dynamicinformer.DynamicSharedInformerFactory, dynamicinformer.DynamicSharedInformerFactory) {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	shared := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, time.Minute, metav1.NamespaceAll, nil)
+	secret := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, time.Minute, metav1.NamespaceAll, func(opts *metav1.ListOptions) {
+		opts.FieldSelector = secretWatchFieldSelector
+	})
+	return &watcher{factory: shared, secretFactory: secret}, shared, secret
+}
+
+func TestFactoryForGVR_RoutesSecretsToSecretFactory(t *testing.T) {
+	w, _, secret := newRoutingTestWatcher()
+
+	secretsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	assert.Same(t, secret, w.factoryForGVR(secretsGVR),
+		"core/v1 Secret must route to the dedicated secretFactory")
+}
+
+func TestFactoryForGVR_RoutesOtherResourcesToSharedFactory(t *testing.T) {
+	w, shared, _ := newRoutingTestWatcher()
+
+	cases := []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "pods"},
+		{Group: "", Version: "v1", Resource: "configmaps"},
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+		// A secrets resource in a non-core group must NOT be treated as the
+		// core Secret kind - it would not expose the `type` field selector.
+		{Group: "example.com", Version: "v1", Resource: "secrets"},
+	}
+	for _, gvr := range cases {
+		assert.Same(t, shared, w.factoryForGVR(gvr),
+			"non core/v1-Secret GVR %v must route to the shared factory", gvr)
+	}
+}
+
+func TestSecretWatchFieldSelectorExcludesHelmReleases(t *testing.T) {
+	assert.Equal(t, "type!=helm.sh/release.v1", secretWatchFieldSelector)
+}


### PR DESCRIPTION
## Problem

Beim Kunden 4finance laden im Resource Browser (Cluster-Level) **keine Secrets** (MOG-4324) und die **AI-Insights-Konfiguration** wird nicht erkannt — Empty State trotz konfiguriertem Anthropic (MOG-4325).

**Root Cause:** Der Operator watcht alle Secrets ungefiltert über eine geteilte Informer-Factory. Im Cluster liegen ~9k Secrets, davon die meisten große Helm-Release-History-Secrets (`sh.helm.release.v1.*`, Typ `helm.sh/release.v1`). Der initiale Cache-Sync überschreitet dadurch den hart kodierten 30s-Timeout → der Secret-Watcher synct nie → der Valkey-Cache bleibt leer:

```
WARN watcher .../watcher.go:137 Watcher failed, will retry
  {"attempt":7,"error":"cache sync timeout after 30s","resource":{"kind":"Secret",...}}
```

Resource Browser und AI-Insights-Config lesen beide aus diesem Cache (kein API-Fallback) → leere Liste bzw. Empty State.

## Fix

- **Watcher:** Das core/v1-Secret-GVR läuft jetzt über eine dedizierte Informer-Factory mit serverseitigem Field-Selector `type!=helm.sh/release.v1`. Der Selector referenziert das Secret-spezifische `type`-Feld und kann daher nicht auf der geteilten Factory liegen. Helm-Release-Secrets werden vom Operator nirgends aus dem Store gelesen (Helm nutzt seinen eigenen Storage-Driver), das Ausschließen ist also sicher — genau wie vom Kunden vorgeschlagen.
- **AI-Status gehärtet:** `isAiModelConfigInitialized()` liest jetzt cache-first-then-direct (konsistent zu `getAiSettingByKey`); `GetStatus` loggt die zuvor still mit `_` verworfenen Setting-Lese-Fehler.
- **Tests:** Watcher-Routing-Tests (Secrets → secretFactory, andere → shared, inkl. Nicht-core `secrets`-Group).

## Behavior-Change (bewusst)

`sh.helm.release.v1.*`-Secrets erscheinen nicht mehr im Resource Browser / Valkey-Cache.

## Verifikation

- `go build ./src/...` ✅
- `just test-unit` → 123/123 grün (inkl. 3 neue) ✅
- Lint: keine neuen Issues durch diese Änderung (gemeldete Issues liegen in unberührten Dateien).
- **Offen:** End-to-End auf einem Cluster mit vielen Helm-Secrets — `cache sync timeout after 30s` für `kind:Secret` muss verschwinden, Resource Browser + AI-Insights müssen laden.

Closes MOG-4324, Closes MOG-4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)