### PR TITLE
fix(ci): disable setup-go cache to stop runner pod evictions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,11 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
-          cache-dependency-path: go.sum
+          # Cache disabled: tarring GOMODCACHE+GOCACHE in the post step exceeds the
+          # ARC runner pod's ephemeral storage and gets the pod evicted mid-save
+          # ("runner lost communication"). Re-enable once the runner pods have
+          # ephemeral-storage limits provisioned (mo-argocd-applications).
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
@@ -41,7 +45,8 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
-          cache-dependency-path: go.sum
+          # Cache disabled: see comment in the lint job above.
+          cache: false
       - name: Execute tests
         run: |
           go mod download


### PR DESCRIPTION
## Problem

Every `develop` push CI run since cb7739ce (`go mod tidy after renovate merges`) fails with **"The self-hosted runner lost communication with the server"** — 3/3 runs, on both the amd64 and arm64 runner sets ([30258847039](https://github.com/mogenius/mogenius-operator/actions/runs/30258847039) + rerun, [30261038569](https://github.com/mogenius/mogenius-operator/actions/runs/30261038569)).

The job logs show the actual work always succeeds (lint 6.5min ✓, tests 5.5min ✓). The runner dies in the `Post Run actions/setup-go` step:

```
11:06:22  tar --posix -cf cache.tgz ...   ← packing GOMODCACHE + GOCACHE
11:06:55  ##[error]The runner has received a shutdown signal.
```

## Root cause

The `go.sum` change means a cache **miss**, so after the (cold, multi-GB) build setup-go tries to **save** a fresh cache. Tarring GOMODCACHE+GOCACHE on top of the already-full overlay FS exceeds the ARC runner pod's ephemeral storage → kubelet evicts the pod (SIGTERM) mid-save → GitHub reports lost communication. PR runs on older branches survive because an exact cache hit skips the save entirely. The runner pods (`mo-argocd-applications/tools/arc-runner-set-*`) define no ephemeral-storage requests/limits, and the Go caches live on the container overlay FS, not the `work` emptyDir.

## Fix (stopgap)

Disable the setup-go cache in both jobs. Cold runs complete reliably in ~6min (observed twice). The golangci-lint action's own cache (~3MB) is unaffected and stays on.

## Proper fix (follow-up, infra)

Give the runner pods ephemeral-storage requests/limits in `mo-argocd-applications` (both runner sets), then revert this commit. I couldn't validate node disk capacity from here (runner cluster only reachable via Tailscale), so I didn't push that change blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)