### PR TITLE
fix: pin release-please target branch to main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main


### PR DESCRIPTION
## Problem

The release-please workflow triggers on pushes to `main`, but without an explicit `target-branch` the action defaults to the repo default branch (`develop`). This caused the v2.26.0 release PR (#1111) to be opened against `develop` — and after merging it, the tagging run never fired, because merging into `develop` doesn't trigger the workflow. The release got stuck with `autorelease: pending` (no tag, no GitHub release, no build). It was unstuck manually by re-running the workflow.

## Fix

Pin `target-branch: main` so release PRs are opened against `main` and the merge of a release PR triggers the tagging run on the next push. Flow is then as intended: merge develop → main, merge the release PR (against main), tag `vX.Y.Z` + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)