### PR TITLE
fix(gitops): Flux-Install-Pfad reparieren + Argo-Finalizer-Placement

### DIFF
--- a/src/gitops/argocd.go
+++ b/src/gitops/argocd.go
@@ -66,11 +66,11 @@ func buildArgoApplication(component string, artifact GitOpsArtifact, namespace s
 			"apiVersion": "argoproj.io/v1alpha1",
 			"kind":       "Application",
 			"metadata": map[string]any{
-				"name":      component,
-				"namespace": namespace,
-				"labels":    defaultLabels(component),
+				"name":       component,
+				"namespace":  namespace,
+				"labels":     defaultLabels(component),
+				"finalizers": []any{"resources-finalizer.argocd.argoproj.io"}, // ensure resources are deleted when app is deleted
 			},
-			"finalizers": []any{"resources-finalizer.argocd.argoproj.io"}, // ensure resources are deleted when app is deleted
 			"spec": map[string]any{
 				"revisionHistoryLimit": 1,
 				"project":              getArgoProject(artifact),
@@ -103,11 +103,11 @@ func buildArgoMoacApplication(component string, artifact GitOpsArtifact, namespa
 			"apiVersion": "argoproj.io/v1alpha1",
 			"kind":       "Application",
 			"metadata": map[string]any{
-				"name":      name,
-				"namespace": namespace,
-				"labels":    defaultLabels(component),
+				"name":       name,
+				"namespace":  namespace,
+				"labels":     defaultLabels(component),
+				"finalizers": []any{"resources-finalizer.argocd.argoproj.io"}, // ensure resources are deleted when app is deleted
 			},
-			"finalizers": []any{"resources-finalizer.argocd.argoproj.io"}, // ensure resources are deleted when app is deleted
 			"spec": map[string]any{
 				"revisionHistoryLimit": 1,
 				"project":              getArgoProject(artifact),

--- a/src/gitops/flux.go
+++ b/src/gitops/flux.go
@@ -53,20 +53,18 @@ func (f *fluxInstaller) Install(component string, artifact GitOpsArtifact) error
 		if err := applyUnstructured(f.clientProvider, fluxHelmReleaseGVR, f.namespace, release); err != nil {
 			return fmt.Errorf("apply flux helmrelease %s: %w", component, err)
 		}
+	} else {
+		repo := buildFluxHelmRepository(component, artifact.HelmChart.Repository, f.namespace)
+		repo.SetOwnerReferences(f.ownerRefs)
+		if err := applyUnstructured(f.clientProvider, fluxHelmRepositoryGVR, f.namespace, repo); err != nil {
+			return fmt.Errorf("apply flux helmrepository %s: %w", component, err)
+		}
 
-		return nil
-	}
-
-	repo := buildFluxHelmRepository(component, artifact.HelmChart.Repository, f.namespace)
-	repo.SetOwnerReferences(f.ownerRefs)
-	if err := applyUnstructured(f.clientProvider, fluxHelmRepositoryGVR, f.namespace, repo); err != nil {
-		return fmt.Errorf("apply flux helmrepository %s: %w", component, err)
-	}
-
-	release := buildFluxHelmRelease(component, artifact, artifact.Values, f.namespace)
-	release.SetOwnerReferences(f.ownerRefs)
-	if err := applyUnstructured(f.clientProvider, fluxHelmReleaseGVR, f.namespace, release); err != nil {
-		return fmt.Errorf("apply flux helmrelease %s: %w", component, err)
+		release := buildFluxHelmRelease(component, artifact, artifact.Values, f.namespace)
+		release.SetOwnerReferences(f.ownerRefs)
+		if err := applyUnstructured(f.clientProvider, fluxHelmReleaseGVR, f.namespace, release); err != nil {
+			return fmt.Errorf("apply flux helmrelease %s: %w", component, err)
+		}
 	}
 
 	if len(artifact.ExtraObjects) > 0 {
@@ -196,14 +194,15 @@ func buildFluxOCIRepository(name, url, version, namespace string) *unstructured.
 
 func buildFluxOCIHelmRelease(component string, artifact GitOpsArtifact, namespace string) *unstructured.Unstructured {
 	spec := map[string]any{
-		"interval":           "10m",
-		"releaseName":        artifact.HelmChart.Name,
-		"serviceAccountName": component,
+		"interval":        "10m",
+		"releaseName":     artifact.HelmChart.Name,
+		"targetNamespace": artifact.Namespace,
 		"chartRef": map[string]any{
 			"kind": "OCIRepository",
 			"name": component,
 		},
 		"install": map[string]any{
+			"createNamespace": true,
 			"strategy": map[string]any{
 				"name":          "RetryOnFailure",
 				"retryInterval": "3m",

--- a/src/reconciler/platform_fluxcd.go
+++ b/src/reconciler/platform_fluxcd.go
@@ -26,7 +26,11 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 			defaultNamespace: fluxcdDefaultNamespace,
 		},
 		func(ctx context.Context) ([]any, error) {
-			extraObjects := []any{}
+			// The FluxInstance is what actually deploys the Flux controllers; the
+			// flux-operator chart alone installs none. Since extra objects ship via a
+			// moac HelmRelease that needs helm-controller to reconcile, the very first
+			// install requires the Flux controllers to be bootstrapped out-of-band.
+			extraObjects := []any{fluxInstanceObject(namespace)}
 
 			for _, repo := range spec.GitOps.Repositories {
 				name := repo.Name
@@ -42,8 +46,17 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 							return nil, fmt.Errorf("repository %q: provide externalSecret.vault or define a vault in spec.externalSecretsOperator", repo.URL)
 						}
 					}
+					repoSecretKey := "token"
+					if repo.ExternalSecret.Key != "" {
+						repoSecretKey = repo.ExternalSecret.Key
+					}
 					if d.crdChecker.IsAvailable(utils.ExternalSecretResource) {
-						extraObjects = append(extraObjects, externalSecretResource(name, namespace, *repo.ExternalSecret, nil, nil))
+						extraObjects = append(extraObjects, externalSecretResource(name, namespace, *repo.ExternalSecret, nil,
+							map[string]string{
+								"username": "git",
+								"password": fmt.Sprintf("{{ .%s }}", repoSecretKey),
+							},
+						))
 					}
 				}
 
@@ -53,9 +66,6 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 				)
 			}
 
-			if len(extraObjects) == 0 {
-				return nil, nil
-			}
 			return extraObjects, nil
 		},
 		func(ctx context.Context) (map[string]any, error) {
@@ -69,6 +79,29 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 			return nil, nil
 		},
 	)
+}
+
+func fluxInstanceObject(namespace string) map[string]any {
+	return map[string]any{
+		"apiVersion": "fluxcd.controlplane.io/v1",
+		"kind":       "FluxInstance",
+		"metadata": map[string]any{
+			"name":      "flux",
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"distribution": map[string]any{
+				"version":  "2.x",
+				"registry": "ghcr.io/fluxcd",
+			},
+			"components": []any{
+				"source-controller",
+				"kustomize-controller",
+				"helm-controller",
+				"notification-controller",
+			},
+		},
+	}
 }
 
 func fluxKustomizationObject(name string, repo v1alpha1.GitOpsRepositoryConfig, namespace string) map[string]any {

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -252,6 +252,27 @@ var AppProjectResource = ResourceDescriptor{
 	Namespaced: true,
 }
 
+var KustomizationResource = ResourceDescriptor{
+	Kind:       "Kustomization",
+	Plural:     "kustomizations",
+	ApiVersion: "kustomize.toolkit.fluxcd.io/v1",
+	Namespaced: true,
+}
+
+var FluxHelmReleaseResource = ResourceDescriptor{
+	Kind:       "HelmRelease",
+	Plural:     "helmreleases",
+	ApiVersion: "helm.toolkit.fluxcd.io/v2",
+	Namespaced: true,
+}
+
+var GitRepositoryResource = ResourceDescriptor{
+	Kind:       "GitRepository",
+	Plural:     "gitrepositories",
+	ApiVersion: "source.toolkit.fluxcd.io/v1",
+	Namespaced: true,
+}
+
 var ServiceMonitorResource = ResourceDescriptor{
 	Kind:       "ServiceMonitor",
 	Plural:     "servicemonitors",

--- a/tools/patternbench/main.go
+++ b/tools/patternbench/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"math"
 	"mogenius-operator/src/structs"
@@ -243,10 +244,11 @@ func writePatternCounter(file *os.File, loglines []LogLine) error {
 }
 
 func benchmarkDatagram(datagram structs.Datagram) error {
-	data, err := json.MarshalToString(datagram)
+	dataBytes, err := json.Marshal(datagram)
 	if err != nil {
 		return err
 	}
+	data := string(dataBytes)
 
 	err = execCmd(
 		"hyperfine",


### PR DESCRIPTION
## Flux GitOps Integration — Teil 2/5 (unabhängig mergebar)

Phase-0-Fixes am bestehenden Flux-Install-Backend (`src/gitops/`, `src/reconciler/`):

- **OCI-Branch verwarf `ExtraObjects`** (early return) → moac-HelmRepository/HelmRelease läuft jetzt für OCI- und HTTP-Branch; damit ist `spec.gitOps.repositories` unter Flux nicht mehr wirkungslos
- OCI-HelmRelease: `targetNamespace` + `install.createNamespace: true` ergänzt, hartkodierter `serviceAccountName` entfernt
- Repo-ExternalSecret bekommt ein `target.template` mit `username`/`password` — vorher hatte das Secret nur einen Key und Flux-Git-Auth wäre fehlgeschlagen
- **`FluxInstance`-CR wird jetzt erzeugt** (fluxcd.controlplane.io/v1, name `flux`) — ohne sie installiert das flux-operator-Chart keine Flux-Controller (Bootstrap-Caveat als Code-Kommentar)
- Argo: `finalizers` lag top-level statt unter `metadata` und wurde vom API-Server stillschweigend verworfen — gefixt in beiden Application-Buildern
- Flux-Resource-Descriptors in `src/utils/config.go` für künftige CRD-Checks
- Nebenbei: fehlender `encoding/json`-Import in `tools/patternbench/main.go` (brach `go build ./...` auf develop)

`gofmt`, `go build ./...`, `go vet ./...` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)