### PR TITLE
feat(gitops): cluster/flux-* Commands, Workspace-Typ, Helm-Tagging, AI-Tools

### DIFF
--- a/src/ai/aimanager_api.go
+++ b/src/ai/aimanager_api.go
@@ -152,7 +152,7 @@ func (ai *aiManager) GetAiTasksForWorkspace(workspace string) ([]AiTask, error) 
 					tasks = append(tasks, task)
 				}
 			}
-		case "helm", "argocd":
+		case "helm", "argocd", "flux":
 			ai.logger.Debug("Retrieving AI Tasks for this workspace type will be possible in the future", "workspace", workspace, "type", workspaceResource.Type)
 		default:
 			ai.logger.Error("Retrieving AI Tasks for unknown workspace type is not possible", "workspace", workspace, "type", workspaceResource.Type)
@@ -249,7 +249,7 @@ func (ai *aiManager) GetAiLatestTasksForWorkspace(workspace string) ([]AiTask, e
 			if latestNamespaceTask != nil {
 				tasks = append(tasks, *latestNamespaceTask)
 			}
-		case "helm", "argocd":
+		case "helm", "argocd", "flux":
 			ai.logger.Debug("Retrieving AI Tasks for this workspace type will be possible in the future", "workspace", workspace, "type", workspaceResource.Type)
 		default:
 			ai.logger.Error("Retrieving AI Tasks for unknown workspace type is not possible", "workspace", workspace, "type", workspaceResource.Type)
@@ -455,7 +455,7 @@ func (ai *aiManager) GetStatus(workspace *string) AiManagerStatus {
 					switch workspaceResource.Type {
 					case "namespace":
 						workspaceNamespaces[workspaceResource.Id] = true
-					case "helm", "argocd":
+					case "helm", "argocd", "flux":
 						ai.logger.Debug("Retrieving AI Tasks for this workspace type will be possible in the future", "workspace", workspace, "type", workspaceResource.Type)
 					default:
 						ai.logger.Error("Retrieving AI Tasks for unknown workspace type is not possible", "workspace", workspace, "type", workspaceResource.Type)
@@ -590,4 +590,3 @@ func (ai *aiManager) ResolveWorkspaceContext(userEmail string, workspaceName str
 
 	return workspaceSpec, grantSpec
 }
-

--- a/src/ai/tools.go
+++ b/src/ai/tools.go
@@ -9,6 +9,7 @@ import (
 	"mogenius-operator/src/structs"
 	"mogenius-operator/src/utils"
 	"mogenius-operator/src/valkeyclient"
+	"strings"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -21,6 +22,7 @@ type ToolContext struct {
 	AllowedNamespaces   map[string]bool            // namespaces with full access (from type="namespace"); nil = no restriction
 	AllowedHelmReleases map[string]map[string]bool // namespace → {releaseName: true} (from type="helm"); nil = no helm-level restriction
 	AllowedArgoCDApps   map[string]bool            // ArgoCD app names (from type="argocd"); nil = no argocd-level restriction
+	AllowedFluxReleases map[string]bool            // Flux owner keys (from type="flux", see fluxOwnerKey); nil = no flux-level restriction
 	Role                string                     // "viewer", "editor", "admin", "" = no restriction
 
 	// Audit attribution — who triggered this tool call. Nil User means the
@@ -87,12 +89,32 @@ func (tc *ToolContext) IsResourceExcluded(apiVersion, kind, namespace, name stri
 	return tc.ExcludeResources[aiResourceKey(apiVersion, kind, namespace, name)]
 }
 
+// fluxOwnerKey is the lookup key for AllowedFluxReleases: the identity of the
+// owning Flux CR. kind is "Kustomization" or "HelmRelease" — the two kinds
+// whose controllers stamp ownership labels
+// (kustomize|helm.toolkit.fluxcd.io/name|namespace) on applied objects.
+func fluxOwnerKey(kind, namespace, name string) string {
+	return kind + "\x00" + namespace + "\x00" + name
+}
+
 // hasRestrictions returns true when any scoping is configured.
 func (tc *ToolContext) hasRestrictions() bool {
 	if tc == nil {
 		return false
 	}
-	return tc.AllowedNamespaces != nil || tc.AllowedHelmReleases != nil || tc.AllowedArgoCDApps != nil
+	return tc.AllowedNamespaces != nil || tc.AllowedHelmReleases != nil || tc.AllowedArgoCDApps != nil || tc.AllowedFluxReleases != nil
+}
+
+// hasOwnershipRestrictions reports whether a resource outside an allowed
+// namespace could still be allowed via GitOps ownership (ArgoCD instance
+// annotation or Flux ownership labels). Callers that would otherwise reject a
+// namespace early must then defer the decision to IsResourceAllowed on the
+// concrete object.
+func (tc *ToolContext) hasOwnershipRestrictions() bool {
+	if tc == nil {
+		return false
+	}
+	return tc.AllowedArgoCDApps != nil || tc.AllowedFluxReleases != nil
 }
 
 func (tc *ToolContext) IsNamespaceAllowed(namespace string) bool {
@@ -151,6 +173,22 @@ func (tc *ToolContext) IsResourceAllowed(namespace string, annotations map[strin
 		appName := annotations["argocd.argoproj.io/instance"]
 		if appName != "" && tc.AllowedArgoCDApps[appName] {
 			return true
+		}
+	}
+	// Check Flux ownership (labels stamped by kustomize-/helm-controller on
+	// every object they apply).
+	if tc.AllowedFluxReleases != nil {
+		if name := annotations["kustomize.toolkit.fluxcd.io/name"]; name != "" {
+			ns := annotations["kustomize.toolkit.fluxcd.io/namespace"]
+			if tc.AllowedFluxReleases[fluxOwnerKey("Kustomization", ns, name)] {
+				return true
+			}
+		}
+		if name := annotations["helm.toolkit.fluxcd.io/name"]; name != "" {
+			ns := annotations["helm.toolkit.fluxcd.io/namespace"]
+			if tc.AllowedFluxReleases[fluxOwnerKey("HelmRelease", ns, name)] {
+				return true
+			}
 		}
 	}
 	return false
@@ -220,6 +258,17 @@ func newToolContextFromUserGrant(user *structs.User, workspace string, isAdmin b
 						tc.AllowedArgoCDApps = make(map[string]bool)
 					}
 					tc.AllowedArgoCDApps[res.Id] = true
+				}
+			case "flux":
+				// Workspace resource id is "<Kind>/<name>", namespace is the
+				// CR's namespace — matching the ownership labels Flux stamps
+				// on applied objects (see fluxOwnerKey).
+				kind, name, found := strings.Cut(res.Id, "/")
+				if found && name != "" && res.Namespace != "" {
+					if tc.AllowedFluxReleases == nil {
+						tc.AllowedFluxReleases = make(map[string]bool)
+					}
+					tc.AllowedFluxReleases[fluxOwnerKey(kind, res.Namespace, name)] = true
 				}
 			}
 		}

--- a/src/ai/tools_kubernetes.go
+++ b/src/ai/tools_kubernetes.go
@@ -79,7 +79,7 @@ func listKubernetesResourcesTool(args map[string]any, tc *ToolContext, valkeyCli
 	}
 	namespace, _ := args["namespace"].(string)
 
-	if namespace != "" && !tc.IsNamespaceAllowed(namespace) && tc.AllowedArgoCDApps == nil {
+	if namespace != "" && !tc.IsNamespaceAllowed(namespace) && !tc.hasOwnershipRestrictions() {
 		return fmt.Sprintf("Error: access to namespace %q is not allowed", namespace)
 	}
 
@@ -188,7 +188,7 @@ func checkKubernetesResourceTool(args map[string]any, tc *ToolContext, valkeyCli
 	name, _ := args["name"].(string)
 	namespace, _ := args["namespace"].(string)
 
-	if !tc.IsNamespaceAllowed(namespace) && tc.AllowedArgoCDApps == nil {
+	if !tc.IsNamespaceAllowed(namespace) && !tc.hasOwnershipRestrictions() {
 		return fmt.Sprintf("Error: access to namespace %q is not allowed", namespace)
 	}
 
@@ -326,8 +326,8 @@ func getKubernetesResourcesTool(args map[string]any, tc *ToolContext, valkeyClie
 	name, _ := args["name"].(string)
 	namespace, _ := args["namespace"].(string)
 
-	// Early reject if namespace is definitely not allowed (no ArgoCD fallback needed)
-	if !tc.IsNamespaceAllowed(namespace) && tc.AllowedArgoCDApps == nil {
+	// Early reject if namespace is definitely not allowed (no GitOps ownership fallback needed)
+	if !tc.IsNamespaceAllowed(namespace) && !tc.hasOwnershipRestrictions() {
 		return fmt.Sprintf("Error: access to namespace %q is not allowed", namespace)
 	}
 
@@ -442,7 +442,7 @@ func deleteKubernetesResourceTool(args map[string]any, tc *ToolContext, valkeyCl
 		return "Error: name is required for delete operation"
 	}
 
-	if !tc.IsNamespaceAllowed(namespace) && tc.AllowedArgoCDApps == nil {
+	if !tc.IsNamespaceAllowed(namespace) && !tc.hasOwnershipRestrictions() {
 		return fmt.Sprintf("Error: access to namespace %q is not allowed", namespace)
 	}
 
@@ -479,7 +479,7 @@ func createKubernetesResourceTool(args map[string]any, tc *ToolContext, valkeyCl
 		return fmt.Sprintf("Error: failed to unmarshal YAML data: %v", err)
 	}
 
-	if !tc.IsNamespaceAllowed(obj.GetNamespace()) && tc.AllowedArgoCDApps == nil {
+	if !tc.IsNamespaceAllowed(obj.GetNamespace()) && !tc.hasOwnershipRestrictions() {
 		return fmt.Sprintf("Error: access to namespace %q is not allowed", obj.GetNamespace())
 	}
 
@@ -527,7 +527,7 @@ func getPodLogsTool(args map[string]any, tc *ToolContext, valkeyClient valkeycli
 		return "Error: namespace and podName are required"
 	}
 
-	if !tc.IsNamespaceAllowed(namespace) && tc.AllowedArgoCDApps == nil {
+	if !tc.IsNamespaceAllowed(namespace) && !tc.hasOwnershipRestrictions() {
 		return fmt.Sprintf("Error: access to namespace %q is not allowed", namespace)
 	}
 
@@ -583,7 +583,7 @@ func getPodEventsTool(args map[string]any, tc *ToolContext, valkeyClient valkeyc
 		return "Error: namespace and podName are required"
 	}
 
-	if !tc.IsNamespaceAllowed(namespace) && tc.AllowedArgoCDApps == nil {
+	if !tc.IsNamespaceAllowed(namespace) && !tc.hasOwnershipRestrictions() {
 		return fmt.Sprintf("Error: access to namespace %q is not allowed", namespace)
 	}
 

--- a/src/cmd/cluster.go
+++ b/src/cmd/cluster.go
@@ -10,6 +10,7 @@ import (
 	"mogenius-operator/src/containerenumerator"
 	"mogenius-operator/src/core"
 	"mogenius-operator/src/cpumonitor"
+	"mogenius-operator/src/flux"
 	"mogenius-operator/src/helm"
 	mokubernetes "mogenius-operator/src/kubernetes"
 	"mogenius-operator/src/logging"
@@ -151,12 +152,13 @@ func initializeClusterSystems(
 	)
 
 	argocdModule := argocd.NewArgoCd(logManagerModule, configModule, base.clientProvider, base.valkeyClient)
+	fluxModule := flux.NewFlux(logManagerModule, base.clientProvider)
 	workspaceManager := core.NewWorkspaceManager(logManagerModule.CreateLogger("workspace-manager"), configModule, base.clientProvider)
 	apiModule := core.NewApi(logManagerModule.CreateLogger("api"), base.valkeyClient, configModule)
 	aiApi := core.NewAiApi(logManagerModule.CreateLogger("apApi"), aiManager)
 	httpApi := core.NewHttpApi(logManagerModule, configModule)
 	alertmanager := core.NewAlertmanagerService(logManagerModule.CreateLogger("alertmanager"), configModule)
-	socketApi := core.NewSocketApi(logManagerModule.CreateLogger("socketapi"), configModule, jobClients, eventConnectionClient, base.valkeyClient, argocdModule, alertmanager)
+	socketApi := core.NewSocketApi(logManagerModule.CreateLogger("socketapi"), configModule, jobClients, eventConnectionClient, base.valkeyClient, argocdModule, fluxModule, alertmanager)
 	xtermService := core.NewXtermService(logManagerModule.CreateLogger("xterm-service"))
 	aiWebsocketConnection := ai.NewAiWebsocketConnection(logManagerModule.CreateLogger("ai-websocket-connection"), aiManager)
 	valkeyLoggerService := core.NewValkeyLogger(base.valkeyClient, valkeyLogChannel)

--- a/src/core/api.go
+++ b/src/core/api.go
@@ -633,8 +633,9 @@ func (self *api) GetWorkspaceResourcesPaginated(workspaceName string, req Worksp
 //   - a non-empty whitelist: the index enumerates shards per kind, so it can't
 //     answer the "all kinds" query an empty whitelist expresses.
 //   - a namespace-only selection: a helm entry selects by release label (plus
-//     Pod ownerRef traversal), which the index does not model. argocd entries
-//     are ignored by GetWorkspaceResources too, so they don't affect the result.
+//     Pod ownerRef traversal), which the index does not model. argocd and flux
+//     entries are ignored by GetWorkspaceResources too, so they don't affect
+//     the result.
 //
 // For the cluster-wide case (empty workspaceName) the namespace list is
 // req.NamespaceWhitelist verbatim: empty there means "all namespaces", which the
@@ -681,7 +682,7 @@ func (self *api) indexableWorkspaceNamespaces(workspaceName string, req Workspac
 			seen[v.Id] = struct{}{}
 			namespaces = append(namespaces, v.Id)
 		}
-		// other types (e.g. "argocd") are ignored, matching GetWorkspaceResources.
+		// other types (e.g. "argocd", "flux") are ignored, matching GetWorkspaceResources.
 	}
 	if len(namespaces) == 0 {
 		return nil, false

--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -10,6 +10,7 @@ import (
 	"mogenius-operator/src/config"
 	"mogenius-operator/src/crds/v1alpha1"
 	"mogenius-operator/src/dtos"
+	"mogenius-operator/src/flux"
 	"mogenius-operator/src/helm"
 	"mogenius-operator/src/kubernetes"
 	moMetrics "mogenius-operator/src/metrics"
@@ -149,6 +150,7 @@ type socketApi struct {
 	moKubernetes          MoKubernetes
 	sealedSecret          SealedSecretManager
 	argocd                argocd.Argocd
+	flux                  flux.Flux
 	alertmanager          AlertmanagerService
 	aiApi                 AiApi
 	aiWebsocketConnection ai.AiWebsocketConnection
@@ -181,6 +183,7 @@ func NewSocketApi(
 	eventsClient websocket.WebsocketClient,
 	valkeyClient valkeyclient.ValkeyClient,
 	argocd argocd.Argocd,
+	flux flux.Flux,
 	alertmanager AlertmanagerService,
 ) SocketApi {
 	self := &socketApi{}
@@ -193,6 +196,7 @@ func NewSocketApi(
 	self.status = NewSocketApiStatus()
 	self.statusLock = sync.RWMutex{}
 	self.argocd = argocd
+	self.flux = flux
 	self.alertmanager = alertmanager
 
 	self.loadpatternlogger()
@@ -1074,10 +1078,16 @@ func (self *socketApi) registerPatterns() {
 		PatternHandle{self, "cluster/helm-release-list-paginated"},
 		PatternConfig{},
 		func(datagram structs.Datagram, request helm.HelmReleaseListPaginatedRequest) (helm.HelmReleaseListPaginatedResponse, error) {
+			// Flux helm-controller creates REAL helm releases, so unlike Argo
+			// nothing extra is merged in; matching list entries are only tagged
+			// with their owning HelmRelease CR. Listed once per request and
+			// shared by the workspace scoping and the tagging below.
+			fluxReleases := self.fluxHelmReleases()
+
 			// Empty workspace name = cluster-wide (no filter). A workspace name
 			// scopes the result to that workspace's registered helm releases AND
-			// Argo applications, resolved here from the Workspace CRD so the
-			// operator can filter before paginating.
+			// GitOps-managed entries, resolved here from the Workspace CRD so
+			// the operator can filter before paginating.
 			var scope *helm.HelmWorkspaceScope
 			if request.WorkspaceName != "" {
 				workspace, err := self.apiService.GetWorkspace(request.WorkspaceName)
@@ -1086,11 +1096,29 @@ func (self *socketApi) registerPatterns() {
 				}
 				allowed := make(map[string]struct{})
 				for _, resource := range workspace.Resources {
-					// "helm" keys on (install namespace, release name); "argocd"
-					// keys on (Argo install namespace, release name). Both map to
-					// the same WorkspaceHelmKey the paginator checks.
-					if resource.Type == "helm" || resource.Type == "argocd" {
+					switch resource.Type {
+					case "helm", "argocd":
+						// "helm" keys on (install namespace, release name);
+						// "argocd" keys on (Argo install namespace, release
+						// name). Both map to the same WorkspaceHelmKey the
+						// paginator checks.
 						allowed[helm.WorkspaceHelmKey(resource.Namespace, resource.Id)] = struct{}{}
+					case "flux":
+						// Flux resource ids are "<Kind>/<name>"; only
+						// HelmRelease CRs surface in the helm list. The CR
+						// resolves to its real helm release via
+						// spec.releaseName/targetNamespace (with metadata
+						// fallbacks); entries whose CR is gone are skipped.
+						kind, name, found := strings.Cut(resource.Id, "/")
+						if !found || !strings.EqualFold(kind, "HelmRelease") {
+							continue
+						}
+						for _, fr := range fluxReleases {
+							if fr.Name == name && fr.Namespace == resource.Namespace {
+								allowed[helm.WorkspaceHelmKey(fr.TargetNamespace, fr.ReleaseName)] = struct{}{}
+								break
+							}
+						}
 					}
 				}
 				scope = &helm.HelmWorkspaceScope{Allowed: allowed}
@@ -1102,7 +1130,15 @@ func (self *socketApi) registerPatterns() {
 			// the (far more important) real release listing.
 			argoItems := self.argoHelmReleaseItems()
 
-			return helm.HelmReleaseListPaginated(request, scope, argoItems)
+			fluxIndex := make(map[string]*helm.FluxReleaseInfo, len(fluxReleases))
+			for _, fr := range fluxReleases {
+				fluxIndex[helm.WorkspaceHelmKey(fr.TargetNamespace, fr.ReleaseName)] = &helm.FluxReleaseInfo{
+					ParentName:      fr.Name,
+					ParentNamespace: fr.Namespace,
+				}
+			}
+
+			return helm.HelmReleaseListPaginated(request, scope, argoItems, fluxIndex)
 		},
 	)
 
@@ -1206,6 +1242,54 @@ func (self *socketApi) registerPatterns() {
 		PatternConfig{},
 		func(datagram structs.Datagram, request argocd.ArgoCdResourceActionRequest) (bool, error) {
 			result, err := self.argocd.ArgoCdResourceAction(request)
+			return store.AddToAuditLog(datagram, self.logger, result, err, nil, nil)
+		},
+	)
+
+	// The flux request payload carries kind/namespace/name at top level, which
+	// is what AddToAuditLog's fallback extraction reads - the audit entries
+	// therefore attribute to the CR's namespace bucket, not to _cluster.
+	RegisterPatternHandler(
+		PatternHandle{self, "cluster/flux-reconcile"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request flux.FluxResourceRequest) (bool, error) {
+			result, err := self.flux.FluxReconcile(request)
+			return store.AddToAuditLog(datagram, self.logger, result, err, nil, nil)
+		},
+	)
+
+	RegisterPatternHandler(
+		PatternHandle{self, "cluster/flux-reconcile-with-source"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request flux.FluxResourceRequest) (bool, error) {
+			result, err := self.flux.FluxReconcileWithSource(request)
+			return store.AddToAuditLog(datagram, self.logger, result, err, nil, nil)
+		},
+	)
+
+	RegisterPatternHandler(
+		PatternHandle{self, "cluster/flux-suspend"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request flux.FluxResourceRequest) (bool, error) {
+			result, err := self.flux.FluxSuspend(request)
+			return store.AddToAuditLog(datagram, self.logger, result, err, nil, nil)
+		},
+	)
+
+	RegisterPatternHandler(
+		PatternHandle{self, "cluster/flux-resume"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request flux.FluxResourceRequest) (bool, error) {
+			result, err := self.flux.FluxResume(request)
+			return store.AddToAuditLog(datagram, self.logger, result, err, nil, nil)
+		},
+	)
+
+	RegisterPatternHandler(
+		PatternHandle{self, "cluster/flux-force"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request flux.FluxResourceRequest) (bool, error) {
+			result, err := self.flux.FluxForce(request)
 			return store.AddToAuditLog(datagram, self.logger, result, err, nil, nil)
 		},
 	)
@@ -2699,6 +2783,19 @@ func (self *socketApi) argoHelmReleaseItems() []*helm.HelmRelease {
 		}))
 	}
 	return items
+}
+
+// fluxHelmReleases returns the Flux HelmRelease CRs used to tag matching real
+// helm releases in the paginated list and to resolve "flux" workspace
+// resources. Errors are logged and swallowed: Flux is optional and must never
+// break the real release listing (mirrors argoHelmReleaseItems).
+func (self *socketApi) fluxHelmReleases() []flux.FluxHelmRelease {
+	releases, err := self.flux.ListHelmReleases()
+	if err != nil {
+		self.logger.Warn("failed to list Flux HelmReleases for helm release list", "error", err.Error())
+		return nil
+	}
+	return releases
 }
 
 func (self *socketApi) LoadRequest(datagram *structs.Datagram, data any) error {

--- a/src/crds/v1alpha1/type_workspace.go
+++ b/src/crds/v1alpha1/type_workspace.go
@@ -61,12 +61,15 @@ type WorkspaceResourceIdentifier struct {
 	// target entity identifier (name)
 	Id string `json:"id,omitempty"`
 
-	// allowed values: "namespace", "helm", "argocd"
+	// allowed values: "namespace", "helm", "argocd", "flux"
+	// Type=="flux": Id is "<Kind>/<name>" of the Flux custom resource
+	// (e.g. "Kustomization/podinfo")
 	Type string `json:"type,omitempty"`
 
 	// Type=="namespace": unused
 	// Type=="helm": namespace in which the chart was installed
 	// Type=="argocd": namespace in which the application was installed
+	// Type=="flux": namespace of the Flux custom resource
 	Namespace string `json:"namespace,omitempty"`
 }
 

--- a/src/crds/yaml/mogenius.com_workspaces.yaml
+++ b/src/crds/yaml/mogenius.com_workspaces.yaml
@@ -76,9 +76,13 @@ spec:
                         Type=="namespace": unused
                         Type=="helm": namespace in which the chart was installed
                         Type=="argocd": namespace in which the application was installed
+                        Type=="flux": namespace of the Flux custom resource
                       type: string
                     type:
-                      description: 'allowed values: "namespace", "helm", "argocd"'
+                      description: |-
+                        allowed values: "namespace", "helm", "argocd", "flux"
+                        Type=="flux": Id is "<Kind>/<name>" of the Flux custom resource
+                        (e.g. "Kustomization/podinfo")
                       type: string
                   type: object
                 type: array

--- a/src/flux/flux.go
+++ b/src/flux/flux.go
@@ -1,0 +1,306 @@
+// Package flux implements the operator-side handlers for the
+// cluster/flux-* socket commands. Unlike ArgoCD (src/argocd), Flux has no
+// server API: every operation is an annotation or spec patch on a Flux
+// custom resource, applied through the dynamic client. There is therefore
+// no token, ConfigMap or server-URL discovery logic in this package.
+package flux
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"mogenius-operator/src/k8sclient"
+	"mogenius-operator/src/logging"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// Flux reconcile annotations, see
+	// https://fluxcd.io/flux/components/helm/helmreleases/#triggering-a-reconcile
+	FLUX_REQUESTED_AT_ANNOTATION = "reconcile.fluxcd.io/requestedAt"
+	FLUX_FORCE_AT_ANNOTATION     = "reconcile.fluxcd.io/forceAt"
+	FLUX_RESET_AT_ANNOTATION     = "reconcile.fluxcd.io/resetAt"
+
+	kindHelmRelease = "HelmRelease"
+)
+
+type Flux interface {
+	FluxReconcile(data FluxResourceRequest) (bool, error)
+	FluxReconcileWithSource(data FluxResourceRequest) (bool, error)
+	FluxSuspend(data FluxResourceRequest) (bool, error)
+	FluxResume(data FluxResourceRequest) (bool, error)
+	FluxForce(data FluxResourceRequest) (bool, error)
+	ListHelmReleases() ([]FluxHelmRelease, error)
+}
+
+type flux struct {
+	logger         *slog.Logger
+	clientProvider k8sclient.K8sClientProvider
+}
+
+func NewFlux(logManager logging.SlogManager, clientProviderModule k8sclient.K8sClientProvider) Flux {
+	flux := flux{
+		logger:         logManager.CreateLogger("flux"),
+		clientProvider: clientProviderModule,
+	}
+	return &flux
+}
+
+// FluxResourceRequest identifies a single Flux custom resource. The json
+// keys kind/namespace/name are deliberately top-level: the audit-log
+// fallback extraction (store.AddToAuditLog) reads exactly these keys from
+// the datagram payload so entries attribute to the resource's namespace
+// bucket instead of the generic _cluster bucket.
+type FluxResourceRequest struct {
+	Kind      string `json:"kind" validate:"required"`
+	Namespace string `json:"namespace" validate:"required"`
+	Name      string `json:"name" validate:"required"`
+}
+
+// fluxKindGVRs is the allowlist of kinds the cluster/flux-* commands accept.
+// API versions must match what the platform's DefaultResourceDescriptor and
+// src/gitops/flux.go use (source/kustomize v1, helm v2).
+var fluxKindGVRs = map[string]schema.GroupVersionResource{
+	"Kustomization":  {Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"},
+	kindHelmRelease:  {Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
+	"GitRepository":  {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+	"OCIRepository":  {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"},
+	"HelmRepository": {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"},
+	"Bucket":         {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "buckets"},
+}
+
+// fluxSourceRefKindGVRs maps the kinds a sourceRef/chartRef may point at.
+// Superset of the source kinds in fluxKindGVRs: a HelmRelease chartRef can
+// also reference a HelmChart, which is not directly addressable via the
+// socket commands but must be annotatable for reconcile-with-source.
+var fluxSourceRefKindGVRs = map[string]schema.GroupVersionResource{
+	"GitRepository":  {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+	"OCIRepository":  {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"},
+	"HelmRepository": {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"},
+	"Bucket":         {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "buckets"},
+	"HelmChart":      {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmcharts"},
+}
+
+// resolveKindGVR validates the request kind against the allowlist
+// (case-insensitively) and returns its GroupVersionResource.
+func resolveKindGVR(kind string) (schema.GroupVersionResource, error) {
+	if gvr, ok := fluxKindGVRs[kind]; ok {
+		return gvr, nil
+	}
+	for canonical, gvr := range fluxKindGVRs {
+		if strings.EqualFold(canonical, kind) {
+			return gvr, nil
+		}
+	}
+	return schema.GroupVersionResource{}, fmt.Errorf("unsupported flux resource kind: %q", kind)
+}
+
+// fluxSourceRef is a resolved spec.sourceRef / spec.chartRef target.
+type fluxSourceRef struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+// resolveSourceRef extracts the source reference of a Flux object:
+// spec.chartRef or spec.chart.spec.sourceRef for a HelmRelease (chartRef
+// wins, mirroring the platform API fallback), spec.sourceRef for everything
+// else. Returns nil when the object carries no (complete) source reference
+// - source kinds like GitRepository have none.
+func resolveSourceRef(obj *unstructured.Unstructured) *fluxSourceRef {
+	if obj == nil {
+		return nil
+	}
+
+	paths := [][]string{{"spec", "sourceRef"}}
+	if obj.GetKind() == kindHelmRelease {
+		paths = [][]string{
+			{"spec", "chartRef"},
+			{"spec", "chart", "spec", "sourceRef"},
+		}
+	}
+
+	for _, path := range paths {
+		ref, found, err := unstructured.NestedMap(obj.Object, path...)
+		if err != nil || !found {
+			continue
+		}
+		kind, _ := ref["kind"].(string)
+		name, _ := ref["name"].(string)
+		namespace, _ := ref["namespace"].(string)
+		if kind == "" || name == "" {
+			continue
+		}
+		if namespace == "" {
+			namespace = obj.GetNamespace()
+		}
+		return &fluxSourceRef{Kind: kind, Name: name, Namespace: namespace}
+	}
+	return nil
+}
+
+// reconcileToken returns the timestamp value Flux expects in its reconcile
+// annotations. All annotations of a single operation must carry the SAME
+// token, so callers generate it once and reuse it.
+func reconcileToken() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+// mergePatch applies a JSON merge patch (RFC 7386: nested maps merge, only
+// the given keys are replaced) to the resource identified by gvr/namespace/name.
+func (self *flux) mergePatch(gvr schema.GroupVersionResource, namespace string, name string, patch map[string]any) error {
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch for %s %s/%s: %w", gvr.Resource, namespace, name, err)
+	}
+	_, err = self.clientProvider.DynamicClient().
+		Resource(gvr).
+		Namespace(namespace).
+		Patch(context.Background(), name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch %s %s/%s: %w", gvr.Resource, namespace, name, err)
+	}
+	return nil
+}
+
+func annotationPatch(annotations map[string]string) map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{
+			"annotations": annotations,
+		},
+	}
+}
+
+// FluxReconcile triggers a reconciliation of the resource by setting the
+// reconcile.fluxcd.io/requestedAt annotation.
+func (self *flux) FluxReconcile(data FluxResourceRequest) (bool, error) {
+	gvr, err := resolveKindGVR(data.Kind)
+	if err != nil {
+		return false, err
+	}
+	err = self.mergePatch(gvr, data.Namespace, data.Name, annotationPatch(map[string]string{
+		FLUX_REQUESTED_AT_ANNOTATION: reconcileToken(),
+	}))
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// FluxReconcileWithSource annotates the resource's source (resolved from
+// spec.sourceRef, or spec.chartRef / spec.chart.spec.sourceRef for a
+// HelmRelease) first and then the resource itself. Resources without a
+// source reference (e.g. GitRepository) are reconciled directly.
+func (self *flux) FluxReconcileWithSource(data FluxResourceRequest) (bool, error) {
+	gvr, err := resolveKindGVR(data.Kind)
+	if err != nil {
+		return false, err
+	}
+
+	obj, err := self.clientProvider.DynamicClient().
+		Resource(gvr).
+		Namespace(data.Namespace).
+		Get(context.Background(), data.Name, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get %s %s/%s: %w", gvr.Resource, data.Namespace, data.Name, err)
+	}
+
+	token := reconcileToken()
+	if sourceRef := resolveSourceRef(obj); sourceRef != nil {
+		sourceGVR, ok := fluxSourceRefKindGVRs[sourceRef.Kind]
+		if !ok {
+			self.logger.Warn("skipping source annotation for unsupported sourceRef kind",
+				slog.String("sourceRefKind", sourceRef.Kind),
+				slog.String("kind", data.Kind),
+				slog.String("namespace", data.Namespace),
+				slog.String("name", data.Name),
+			)
+		} else {
+			err = self.mergePatch(sourceGVR, sourceRef.Namespace, sourceRef.Name, annotationPatch(map[string]string{
+				FLUX_REQUESTED_AT_ANNOTATION: token,
+			}))
+			if err != nil {
+				return false, err
+			}
+		}
+	}
+
+	err = self.mergePatch(gvr, data.Namespace, data.Name, annotationPatch(map[string]string{
+		FLUX_REQUESTED_AT_ANNOTATION: token,
+	}))
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// FluxSuspend sets spec.suspend=true, pausing reconciliation of the resource.
+func (self *flux) FluxSuspend(data FluxResourceRequest) (bool, error) {
+	gvr, err := resolveKindGVR(data.Kind)
+	if err != nil {
+		return false, err
+	}
+	err = self.mergePatch(gvr, data.Namespace, data.Name, map[string]any{
+		"spec": map[string]any{
+			"suspend": true,
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// FluxResume sets spec.suspend=false and requests an immediate reconcile in
+// the same patch so the resource does not wait a full interval after resuming.
+func (self *flux) FluxResume(data FluxResourceRequest) (bool, error) {
+	gvr, err := resolveKindGVR(data.Kind)
+	if err != nil {
+		return false, err
+	}
+	err = self.mergePatch(gvr, data.Namespace, data.Name, map[string]any{
+		"spec": map[string]any{
+			"suspend": false,
+		},
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				FLUX_REQUESTED_AT_ANNOTATION: reconcileToken(),
+			},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// FluxForce triggers a one-off forced reconcile of a HelmRelease (upgrade
+// even without changes, reset of the failure counters). forceAt, resetAt and
+// requestedAt must carry the same token for helm-controller to honor them.
+// Only HelmRelease supports these annotations.
+func (self *flux) FluxForce(data FluxResourceRequest) (bool, error) {
+	gvr, err := resolveKindGVR(data.Kind)
+	if err != nil {
+		return false, err
+	}
+	if !strings.EqualFold(data.Kind, kindHelmRelease) {
+		return false, fmt.Errorf("flux force is only supported for HelmRelease, got %q", data.Kind)
+	}
+	token := reconcileToken()
+	err = self.mergePatch(gvr, data.Namespace, data.Name, annotationPatch(map[string]string{
+		FLUX_REQUESTED_AT_ANNOTATION: token,
+		FLUX_FORCE_AT_ANNOTATION:     token,
+		FLUX_RESET_AT_ANNOTATION:     token,
+	}))
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/src/flux/flux_test.go
+++ b/src/flux/flux_test.go
@@ -1,0 +1,188 @@
+package flux
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestResolveKindGVR(t *testing.T) {
+	cases := []struct {
+		kind string
+		want schema.GroupVersionResource
+	}{
+		{"Kustomization", schema.GroupVersionResource{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}},
+		{"HelmRelease", schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}},
+		{"GitRepository", schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"}},
+		{"OCIRepository", schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"}},
+		{"HelmRepository", schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"}},
+		{"Bucket", schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "buckets"}},
+		// kind matching is case-insensitive
+		{"kustomization", schema.GroupVersionResource{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}},
+		{"ocirepository", schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"}},
+	}
+	for _, tc := range cases {
+		got, err := resolveKindGVR(tc.kind)
+		if err != nil {
+			t.Errorf("resolveKindGVR(%q) returned error: %v", tc.kind, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("resolveKindGVR(%q) = %v, want %v", tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestResolveKindGVRRejectsUnsupportedKinds(t *testing.T) {
+	for _, kind := range []string{"", "Deployment", "Application", "HelmChart", "FluxInstance"} {
+		if _, err := resolveKindGVR(kind); err == nil {
+			t.Errorf("resolveKindGVR(%q) = nil error, want error", kind)
+		}
+	}
+}
+
+func TestResolveSourceRefKustomization(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "podinfo", "namespace": "flux-system"},
+		"spec": map[string]any{
+			"sourceRef": map[string]any{
+				"kind": "GitRepository",
+				"name": "podinfo",
+			},
+		},
+	}}
+	ref := resolveSourceRef(obj)
+	if ref == nil {
+		t.Fatal("resolveSourceRef returned nil, want a sourceRef")
+	}
+	if ref.Kind != "GitRepository" || ref.Name != "podinfo" {
+		t.Errorf("resolveSourceRef = %+v, want kind GitRepository name podinfo", ref)
+	}
+	if ref.Namespace != "flux-system" {
+		t.Errorf("sourceRef namespace = %q, want fallback to object namespace flux-system", ref.Namespace)
+	}
+}
+
+func TestResolveSourceRefCrossNamespace(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "podinfo", "namespace": "apps"},
+		"spec": map[string]any{
+			"sourceRef": map[string]any{
+				"kind":      "GitRepository",
+				"name":      "podinfo",
+				"namespace": "flux-system",
+			},
+		},
+	}}
+	ref := resolveSourceRef(obj)
+	if ref == nil {
+		t.Fatal("resolveSourceRef returned nil, want a sourceRef")
+	}
+	if ref.Namespace != "flux-system" {
+		t.Errorf("sourceRef namespace = %q, want explicit flux-system", ref.Namespace)
+	}
+}
+
+func TestResolveSourceRefHelmReleaseChartSpec(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata":   map[string]any{"name": "podinfo", "namespace": "flux-system"},
+		"spec": map[string]any{
+			"chart": map[string]any{
+				"spec": map[string]any{
+					"chart": "podinfo",
+					"sourceRef": map[string]any{
+						"kind": "HelmRepository",
+						"name": "podinfo-repo",
+					},
+				},
+			},
+		},
+	}}
+	ref := resolveSourceRef(obj)
+	if ref == nil {
+		t.Fatal("resolveSourceRef returned nil, want a sourceRef")
+	}
+	if ref.Kind != "HelmRepository" || ref.Name != "podinfo-repo" || ref.Namespace != "flux-system" {
+		t.Errorf("resolveSourceRef = %+v, want HelmRepository podinfo-repo in flux-system", ref)
+	}
+}
+
+func TestResolveSourceRefHelmReleaseChartRefWins(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata":   map[string]any{"name": "podinfo", "namespace": "flux-system"},
+		"spec": map[string]any{
+			"chartRef": map[string]any{
+				"kind": "OCIRepository",
+				"name": "podinfo-oci",
+			},
+			"chart": map[string]any{
+				"spec": map[string]any{
+					"sourceRef": map[string]any{
+						"kind": "HelmRepository",
+						"name": "podinfo-repo",
+					},
+				},
+			},
+		},
+	}}
+	ref := resolveSourceRef(obj)
+	if ref == nil {
+		t.Fatal("resolveSourceRef returned nil, want a sourceRef")
+	}
+	if ref.Kind != "OCIRepository" || ref.Name != "podinfo-oci" {
+		t.Errorf("resolveSourceRef = %+v, want chartRef (OCIRepository podinfo-oci) to win over chart.spec.sourceRef", ref)
+	}
+}
+
+func TestResolveSourceRefNoneForSourceKinds(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1",
+		"kind":       "GitRepository",
+		"metadata":   map[string]any{"name": "podinfo", "namespace": "flux-system"},
+		"spec": map[string]any{
+			"url": "https://github.com/stefanprodan/podinfo",
+		},
+	}}
+	if ref := resolveSourceRef(obj); ref != nil {
+		t.Errorf("resolveSourceRef = %+v, want nil for a source kind without sourceRef", ref)
+	}
+}
+
+func TestResolveSourceRefIncompleteRefIsSkipped(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "podinfo", "namespace": "flux-system"},
+		"spec": map[string]any{
+			"sourceRef": map[string]any{
+				"kind": "GitRepository",
+				// name missing
+			},
+		},
+	}}
+	if ref := resolveSourceRef(obj); ref != nil {
+		t.Errorf("resolveSourceRef = %+v, want nil for an incomplete sourceRef", ref)
+	}
+	if ref := resolveSourceRef(nil); ref != nil {
+		t.Errorf("resolveSourceRef(nil) = %+v, want nil", ref)
+	}
+}
+
+func TestSourceRefKindGVRsCoverChartRefKinds(t *testing.T) {
+	// chartRef may point at a HelmChart, which is not directly addressable
+	// via the socket commands but must be resolvable as a source.
+	for _, kind := range []string{"GitRepository", "OCIRepository", "HelmRepository", "Bucket", "HelmChart"} {
+		if _, ok := fluxSourceRefKindGVRs[kind]; !ok {
+			t.Errorf("fluxSourceRefKindGVRs is missing kind %q", kind)
+		}
+	}
+}

--- a/src/flux/helmreleases.go
+++ b/src/flux/helmreleases.go
@@ -1,0 +1,65 @@
+package flux
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// FluxHelmRelease is a flattened view of a Flux HelmRelease CR carrying the
+// resolved identity of the real helm release that helm-controller creates for
+// it. Unlike Argo CD (src/argocd/applications.go), Flux-managed charts already
+// appear in the helm release list as genuine releases — the list pipeline uses
+// this data to TAG the matching entries, never to add duplicates.
+type FluxHelmRelease struct {
+	// Name / Namespace are the HelmRelease CR's own metadata.
+	Name      string
+	Namespace string
+	// ReleaseName is spec.releaseName, defaulting to the CR name — the
+	// platform contract's "spec.releaseName || metadata.name" matching rule.
+	ReleaseName string
+	// TargetNamespace is spec.targetNamespace, defaulting to the CR namespace
+	// ("spec.targetNamespace || metadata.namespace").
+	TargetNamespace string
+}
+
+// ListHelmReleases returns all Flux HelmRelease CRs cluster-wide. When the
+// HelmRelease CRD is not installed it returns an empty list and no error, so
+// clusters without Flux do not log a warning on every helm list request.
+func (self *flux) ListHelmReleases() ([]FluxHelmRelease, error) {
+	list, err := self.clientProvider.DynamicClient().
+		Resource(fluxKindGVRs[kindHelmRelease]).
+		Namespace(metav1.NamespaceAll).
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	results := make([]FluxHelmRelease, 0, len(list.Items))
+	for i := range list.Items {
+		hr := list.Items[i]
+
+		releaseName, _, _ := unstructured.NestedString(hr.Object, "spec", "releaseName")
+		if releaseName == "" {
+			releaseName = hr.GetName()
+		}
+		targetNamespace, _, _ := unstructured.NestedString(hr.Object, "spec", "targetNamespace")
+		if targetNamespace == "" {
+			targetNamespace = hr.GetNamespace()
+		}
+
+		results = append(results, FluxHelmRelease{
+			Name:            hr.GetName(),
+			Namespace:       hr.GetNamespace(),
+			ReleaseName:     releaseName,
+			TargetNamespace: targetNamespace,
+		})
+	}
+	return results, nil
+}

--- a/src/helm/helm.go
+++ b/src/helm/helm.go
@@ -182,6 +182,25 @@ type HelmRelease struct {
 	// (MOG-4394). MarshalJSON emits the shape the frontend's
 	// ClusterHelmReleaseDto expects for type "git-ops-argo-cd-application".
 	Argo *ArgoReleaseInfo `json:"-"`
+
+	// Flux, when non-nil, tags this entry as managed by a Flux HelmRelease
+	// CR. Unlike Argo entries these ARE real helm releases (helm-controller
+	// creates genuine release secrets), so all release data stays intact and
+	// MarshalJSON only adds the "git-ops-flux-helm-release" type marker plus
+	// the parent CR reference — never a duplicate list entry.
+	Flux *FluxReleaseInfo `json:"-"`
+}
+
+// FluxReleaseInfo identifies the Flux HelmRelease CR that owns a real helm
+// release in the list. The caller (socketapi) resolves the matches by
+// (releaseName, targetNamespace); helm only carries the reference through to
+// MarshalJSON.
+type FluxReleaseInfo struct {
+	// ParentName / ParentNamespace identify the HelmRelease CR (the
+	// frontend's GitOps actions read data.parentApplication.resourceName
+	// and .namespace).
+	ParentName      string
+	ParentNamespace string
 }
 
 // ArgoReleaseInfo carries the data needed to render an Argo CD Application as a
@@ -1473,13 +1492,37 @@ func helmReleaseLastDeployed(hr *HelmRelease) time.Time {
 	return hr.Info.LastDeployed
 }
 
+// tagFluxHelmReleases marks page entries whose (install namespace, release
+// name) identity matches a Flux HelmRelease CR from fluxIndex (keys built via
+// WorkspaceHelmKey). Tagged entries are shallow-copied first: fast-path
+// entries that failed to decode are pointers into the shared stub cache and
+// must never be mutated (concurrent requests read them).
+func tagFluxHelmReleases(page []*HelmRelease, fluxIndex map[string]*FluxReleaseInfo) {
+	if len(fluxIndex) == 0 {
+		return
+	}
+	for i, hr := range page {
+		if hr.Argo != nil {
+			continue // Argo entries are not real helm releases
+		}
+		if info, ok := fluxIndex[WorkspaceHelmKey(hr.Namespace, hr.Name)]; ok {
+			tagged := *hr
+			tagged.Flux = info
+			page[i] = &tagged
+		}
+	}
+}
+
 // HelmReleaseListPaginated lists helm releases server-side filtered, sorted and
 // sliced. argoItems are Argo-CD-managed charts (resolved by the caller, since
 // they live outside helm) that are merged into the same sorted, paginated and
-// scoped result so users can still upgrade them (MOG-4394). When scope is
-// non-nil the result is restricted to that workspace's resources (resolved by
-// the caller from the Workspace CRD); nil scope means cluster-wide.
-func HelmReleaseListPaginated(data HelmReleaseListPaginatedRequest, scope *HelmWorkspaceScope, argoItems []*HelmRelease) (HelmReleaseListPaginatedResponse, error) {
+// scoped result so users can still upgrade them (MOG-4394). fluxIndex maps
+// WorkspaceHelmKey(targetNamespace, releaseName) of Flux-HelmRelease-managed
+// releases to their parent CR: matching entries are tagged in place (Flux
+// releases are real helm releases, so no extra items are merged). When scope
+// is non-nil the result is restricted to that workspace's resources (resolved
+// by the caller from the Workspace CRD); nil scope means cluster-wide.
+func HelmReleaseListPaginated(data HelmReleaseListPaginatedRequest, scope *HelmWorkspaceScope, argoItems []*HelmRelease, fluxIndex map[string]*FluxReleaseInfo) (HelmReleaseListPaginatedResponse, error) {
 	empty := HelmReleaseListPaginatedResponse{Items: []*HelmRelease{}, TotalCount: 0}
 
 	settings := NewCli()
@@ -1494,7 +1537,7 @@ func HelmReleaseListPaginated(data HelmReleaseListPaginatedRequest, scope *HelmW
 	secretsDriver, ok := actionConfig.Releases.Driver.(*driver.Secrets)
 	if !ok {
 		// Non-secret storage driver: fall back to decoding everything.
-		return helmReleaseListPaginatedFull(actionConfig, data, scope, argoItems)
+		return helmReleaseListPaginatedFull(actionConfig, data, scope, argoItems, fluxIndex)
 	}
 
 	// Phase 1: cheap metadata-only stub index (no gzip blob), merged with the
@@ -1537,6 +1580,8 @@ func HelmReleaseListPaginated(data HelmReleaseListPaginatedRequest, scope *HelmW
 		page[i] = helmReleaseFromRelease(re, repoName)
 	}
 
+	tagFluxHelmReleases(page, fluxIndex)
+
 	return HelmReleaseListPaginatedResponse{Items: page, TotalCount: total}, nil
 }
 
@@ -1544,7 +1589,7 @@ func HelmReleaseListPaginated(data HelmReleaseListPaginatedRequest, scope *HelmW
 // not the secret driver (e.g. configmaps/memory in tests). It decodes every
 // current release up front - the pre-metadata-index behaviour - then sorts,
 // scopes and slices the same way as the fast path.
-func helmReleaseListPaginatedFull(actionConfig *action.Configuration, data HelmReleaseListPaginatedRequest, scope *HelmWorkspaceScope, argoItems []*HelmRelease) (HelmReleaseListPaginatedResponse, error) {
+func helmReleaseListPaginatedFull(actionConfig *action.Configuration, data HelmReleaseListPaginatedRequest, scope *HelmWorkspaceScope, argoItems []*HelmRelease, fluxIndex map[string]*FluxReleaseInfo) (HelmReleaseListPaginatedResponse, error) {
 	empty := HelmReleaseListPaginatedResponse{Items: []*HelmRelease{}, TotalCount: 0}
 
 	releases, err := listCurrentReleases(actionConfig)
@@ -1574,6 +1619,8 @@ func helmReleaseListPaginatedFull(actionConfig *action.Configuration, data HelmR
 			hr.RepoName = strings.Replace(rep.RepoName, "/"+chartName, "", 1)
 		}
 	}
+
+	tagFluxHelmReleases(page, fluxIndex)
 
 	return HelmReleaseListPaginatedResponse{Items: page, TotalCount: total}, nil
 }
@@ -2128,15 +2175,41 @@ func NewArgoHelmRelease(releaseName string, info *ArgoReleaseInfo) *HelmRelease 
 	}
 }
 
-// MarshalJSON emits the default helm-release shape for real releases and the
+// MarshalJSON emits the default helm-release shape for real releases, the
 // "git-ops-argo-cd-application" shape (matching the frontend's
-// ClusterHelmReleaseDto) for Argo-managed entries.
+// ClusterHelmReleaseDto) for Argo-managed entries, and the default shape
+// extended by a "git-ops-flux-helm-release" type marker plus parent
+// HelmRelease CR reference for Flux-managed entries.
 func (h HelmRelease) MarshalJSON() ([]byte, error) {
 	if h.Argo == nil {
 		// alias drops the custom MarshalJSON so we get the default field-tag
 		// encoding (and don't recurse).
 		type alias HelmRelease
-		return json.Marshal(alias(h))
+		raw, err := json.Marshal(alias(h))
+		if err != nil || h.Flux == nil {
+			return raw, err
+		}
+
+		// Flux-managed entries are real helm releases: keep every default
+		// field and only add the type and the parent CR reference (shaped
+		// like the Argo parentApplication so the frontend can address the
+		// owning CR for GitOps actions).
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, err
+		}
+		m["type"] = "git-ops-flux-helm-release"
+		m["data"] = map[string]any{
+			"parentApplication": map[string]any{
+				"kind":         "HelmRelease",
+				"plural":       "helmreleases",
+				"apiVersion":   "helm.toolkit.fluxcd.io/v2",
+				"namespaced":   true,
+				"resourceName": h.Flux.ParentName,
+				"namespace":    h.Flux.ParentNamespace,
+			},
+		}
+		return json.Marshal(m)
 	}
 
 	a := h.Argo

--- a/src/helm/pagination_test.go
+++ b/src/helm/pagination_test.go
@@ -258,4 +258,60 @@ func TestHelmReleaseMarshalJSON(t *testing.T) {
 		_, hasType := got["type"]
 		assert.False(t, hasType) // no argo "type" marker on real releases
 	})
+
+	t.Run("flux-tagged release keeps the default shape plus type and parent CR", func(t *testing.T) {
+		re := &HelmRelease{
+			Name:      "podinfo",
+			Namespace: "apps",
+			RepoName:  "repo",
+			Flux:      &FluxReleaseInfo{ParentName: "podinfo", ParentNamespace: "flux-system"},
+		}
+		raw, err := json.Marshal(re)
+		assert.NoError(t, err)
+
+		var got map[string]any
+		assert.NoError(t, json.Unmarshal(raw, &got))
+
+		// Real release data stays intact (no duplicate entry, just a tag).
+		assert.Equal(t, "podinfo", got["name"])
+		assert.Equal(t, "apps", got["namespace"])
+		assert.Equal(t, "repo", got["repoName"])
+		assert.Equal(t, "git-ops-flux-helm-release", got["type"])
+
+		data := got["data"].(map[string]any)
+		parent := data["parentApplication"].(map[string]any)
+		assert.Equal(t, "HelmRelease", parent["kind"])
+		assert.Equal(t, "helmreleases", parent["plural"])
+		assert.Equal(t, "helm.toolkit.fluxcd.io/v2", parent["apiVersion"])
+		assert.Equal(t, true, parent["namespaced"])
+		assert.Equal(t, "podinfo", parent["resourceName"])
+		assert.Equal(t, "flux-system", parent["namespace"])
+	})
+}
+
+// tagFluxHelmReleases tags only matching real releases and never mutates the
+// original entries (fast-path stubs are shared across requests).
+func TestTagFluxHelmReleases(t *testing.T) {
+	fluxIndex := map[string]*FluxReleaseInfo{
+		WorkspaceHelmKey("apps", "podinfo"): {ParentName: "podinfo", ParentNamespace: "flux-system"},
+	}
+
+	original := &HelmRelease{Name: "podinfo", Namespace: "apps"}
+	other := &HelmRelease{Name: "other", Namespace: "apps"}
+	argo := NewArgoHelmRelease("podinfo", &ArgoReleaseInfo{ParentNamespace: "argocd", DestNamespace: "apps"})
+	page := []*HelmRelease{original, other, argo}
+
+	tagFluxHelmReleases(page, fluxIndex)
+
+	assert.NotNil(t, page[0].Flux)
+	assert.Equal(t, "podinfo", page[0].Flux.ParentName)
+	assert.Equal(t, "flux-system", page[0].Flux.ParentNamespace)
+	assert.NotSame(t, original, page[0]) // shallow copy, shared entry untouched
+	assert.Nil(t, original.Flux)
+
+	assert.Nil(t, page[1].Flux) // no matching CR
+	assert.Same(t, other, page[1])
+
+	assert.Nil(t, page[2].Flux) // argo entries are never flux-tagged
+	assert.Same(t, argo, page[2])
 }

--- a/src/reconciler/workspaces.go
+++ b/src/reconciler/workspaces.go
@@ -109,6 +109,10 @@ func (d *reconcilerModule) verifyWorkspaceIntegrity(ctx context.Context, obj *un
 		case "argocd":
 			// No integrity checks for ArgoCD resources yet, as they don't have any cluster-level representation.
 			continue
+		case "flux":
+			// No integrity checks for Flux resources yet (id is "<Kind>/<name>",
+			// namespace is the CR's namespace).
+			continue
 		default:
 			resourceErr := ReconcileResult{}
 			resourceErr.Err = fmt.Errorf("Workspace contains a resource with the invalid type: %#v", resource.Type)
@@ -138,4 +142,3 @@ func (d *reconcilerModule) verifyWorkspaceIntegrity(ctx context.Context, obj *un
 	}
 	return results
 }
-


### PR DESCRIPTION
## Flux GitOps Phase 2 — Teil 2/4 (unabhängig mergebar)

**Neues Package `src/flux/`** (Spiegel von `src/argocd/`, aber ohne Token/Server-Discovery — alles über den Dynamic Client):

- Fünf Socket-Commands: `cluster/flux-reconcile`, `-reconcile-with-source` (Source zuerst, dann Objekt, gleicher Token), `-suspend`, `-resume` (+ sofortiges Reconcile), `-force` (nur HelmRelease: forceAt+resetAt+requestedAt)
- **Korrekte Audit-Attribution**: Payload-Keys `kind`/`namespace`/`name` top-level, damit Einträge dem CR zugeordnet werden statt im `_cluster`-Bucket zu landen
- 9 Unit-Tests für Kind→GVR- und sourceRef-Auflösung
- Das bestehende `describe`-Pattern exponiert die neuen Commands automatisch → Capability-Handshake der API funktioniert ohne Zusatzarbeit

**Plattform-Integration:**

- Workspace-Typ `"flux"` im Reconciler akzeptiert (CRD-Doku + YAML regeneriert); Helm-Scoping für Flux-Workspace-Resources (id `<Kind>/<name>`)
- **Helm-Release-Tagging**: Flux-HelmReleases sind echte Helm-Releases — bestehende Listeneinträge werden getaggt (`type: git-ops-flux-helm-release` + Parent-Referenz), nie dupliziert; Fehler werden wie beim Argo-Merge nur geloggt
- AI-Tools: `AllowedFluxReleases` analog `AllowedArgoCDApps`, gematcht über die Flux-Ownership-Labels

`gofmt`, `go build ./...`, `go vet ./src/...`, `go test` (flux/helm/ai) grün. Vorbestehend rot (nicht angefasst): `go vet ./test/...` wegen `watcher_test.go`-Referenz auf entfernte Funktion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)