### PR TITLE
fix(cluster): report node Ready condition in node stats

### DIFF
--- a/src/core/kubernetes.go
+++ b/src/core/kubernetes.go
@@ -323,9 +323,21 @@ func (self *moKubernetes) GetNodeStats() ([]dtos.NodeStat, error) {
 			self.logger.Warn("failed to get machines stats for node", "node", node.Name, "error", err)
 		}
 
+		// A node that stops heartbeating (powered off, network partition) keeps
+		// its object and its bound pods, so neither the node list nor the pod
+		// count reveals it is gone — only the Ready condition does.
+		ready := false
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady {
+				ready = condition.Status == corev1.ConditionTrue
+				break
+			}
+		}
+
 		nodeStat := dtos.NodeStat{
 			Name:                   node.Name,
 			MaschineId:             node.Status.NodeInfo.MachineID,
+			Ready:                  ready,
 			CpuInCores:             cpu,
 			CpuInCoresUtilized:     utilizedCores,
 			CpuInCoresRequested:    requestCpuCores,

--- a/src/dtos/nodestatsdto.go
+++ b/src/dtos/nodestatsdto.go
@@ -3,8 +3,13 @@ package dtos
 import "mogenius-operator/src/structs"
 
 type NodeStat struct {
-	Name                   string                `json:"name" validate:"required"`
-	MaschineId             string                `json:"maschineId" validate:"required"`
+	Name       string `json:"name" validate:"required"`
+	MaschineId string `json:"maschineId" validate:"required"`
+	// Ready mirrors the node's Ready condition: true only for status "True".
+	// "False" (kubelet reports unhealthy) and "Unknown" (node unreachable, e.g.
+	// powered off) both map to false. Deliberately no `required` tag — that
+	// would reject the zero value, which is exactly the NotReady case.
+	Ready                  bool                  `json:"ready"`
 	CpuInCores             int64                 `json:"cpuInCores" validate:"required"`
 	CpuInCoresUtilized     float64               `json:"cpuInCoresUtilized" validate:"required"`
 	CpuInCoresRequested    float64               `json:"cpuInCoresRequested" validate:"required"`


### PR DESCRIPTION
`dtos.NodeStat` transportierte bisher **kein** Readiness-Signal, obwohl es die Node-Liste der Cluster-Übersicht und die Kapazitäts-Summen speist. Jeder Consumer musste raten.

Ein Node, der aufhört zu heartbeaten (ausgeschaltet, Netzwerk-Partition), behält sein Objekt und seine gebundenen Pods — DaemonSets und Static Pods dauerhaft. Weder die Node-Liste noch die Pod-Zahl verrät also, dass er weg ist. Nur die Ready-Condition tut das.

## Änderung

`Ready bool` in `NodeStat`, in `GetNodeStats()` aus `node.Status.Conditions` befüllt. `true` ausschließlich bei `ConditionTrue`; sowohl `"False"` (Kubelet meldet sich unhealthy) als auch `"Unknown"` (Node nicht erreichbar) werden zu `false`.

Das Feld trägt bewusst **kein** `validate:"required"`: der Validator lehnt damit den Zero-Value ab — also genau den NotReady-Fall, den wir melden wollen.

## Kontext

Teil einer Kette über vier Repos:

- mogenius/mo-client-sdk#48 — `ready?: boolean` im DTO (zuerst mergen + publishen)
- `mo-platform-api-service#fix/node-ready-status` — konsumiert es in der Dashboard-Summary
- mogenius/mo-frontend#719 — unabhängig davon, behebt das sichtbare Symptom

🤖 Generated with [Claude Code](https://claude.com/claude-code)