### PR TITLE
feat: report the status a failed request deserves

### DIFF
--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -304,16 +304,21 @@ func registerPatternHandlerInternal[RequestType any, ResponseType any](
 	assert.Assert(handle.Pattern != "", "Pattern has to be defined")
 
 	type Result struct {
-		Status  string       `json:"status"` // success, error
-		Message string       `json:"message,omitempty"`
-		Data    ResponseType `json:"data"`
+		Status  string `json:"status"` // success, error
+		Message string `json:"message,omitempty"`
+		// StatusCode is the HTTP status the error deserves, so the platform does
+		// not have to infer one from the message text. Omitted on success, and
+		// omitted by older operators -- consumers must keep their fallback.
+		StatusCode int          `json:"statusCode,omitempty"`
+		Data       ResponseType `json:"data"`
 	}
 
 	buildResponse := func(result any, err error) Result {
 		if err != nil {
 			return Result{
-				Status:  "error",
-				Message: err.Error(),
+				Status:     "error",
+				Message:    err.Error(),
+				StatusCode: utils.HttpStatusForError(err),
 			}
 		}
 		if str, ok := result.(string); ok {

--- a/src/utils/errorstatus.go
+++ b/src/utils/errorstatus.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// HttpStatusForError reports which HTTP status an error deserves, so the socket
+// response can carry it instead of leaving the platform to guess from prose.
+//
+// The Kubernetes API already answers this precisely: a StatusError knows its own
+// code, and apierrors recognises the wrapped forms. Everything else falls back
+// to 400, which is what every error used to be reported as — so an unmapped
+// error is no worse off than before.
+//
+// Deliberately never returns 401. The platform's frontend refreshes the access
+// token and replays the request on 401, so reporting a cluster RBAC denial that
+// way would cost a pointless retry and, on a failed refresh, log the user out.
+// An RBAC denial is 403, which is also what Kubernetes itself calls it.
+func HttpStatusForError(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	// Reason first, code second. A StatusError's reason is more precise than its
+	// number: NewServerTimeout carries code 500, but "try again" is a gateway
+	// timeout to our callers, not an internal error.
+	switch {
+	case apierrors.IsNotFound(err):
+		return http.StatusNotFound
+	case apierrors.IsAlreadyExists(err), apierrors.IsConflict(err):
+		return http.StatusConflict
+	case apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
+		// IsUnauthorized included on purpose: see the note above, a denial from
+		// the cluster is reported as 403 rather than 401.
+		return http.StatusForbidden
+	case apierrors.IsInvalid(err), apierrors.IsBadRequest(err):
+		return http.StatusBadRequest
+	case apierrors.IsTimeout(err), apierrors.IsServerTimeout(err), errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout
+	case apierrors.IsTooManyRequests(err):
+		return http.StatusTooManyRequests
+	case apierrors.IsServiceUnavailable(err):
+		return http.StatusServiceUnavailable
+	case apierrors.IsNotAcceptable(err), apierrors.IsUnsupportedMediaType(err):
+		return http.StatusBadRequest
+	case errors.Is(err, context.Canceled):
+		// The caller went away; nothing failed on this side.
+		return http.StatusRequestTimeout
+	}
+
+	// No recognised reason: forward the API server's own code, which covers the
+	// statuses not enumerated above. Only real error codes -- anything else
+	// would turn a failure into a success-looking status.
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		if code := int(statusErr.ErrStatus.Code); code >= 400 && code <= 599 {
+			if code == http.StatusUnauthorized {
+				return http.StatusForbidden
+			}
+			return code
+		}
+	}
+
+	// Non-Kubernetes errors: helm, git, our own validation. They were all 400
+	// before and stay 400, which keeps this change additive.
+	return http.StatusBadRequest
+}

--- a/src/utils/errorstatus_test.go
+++ b/src/utils/errorstatus_test.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestHttpStatusForError(t *testing.T) {
+	secrets := schema.GroupResource{Group: "", Resource: "secrets"}
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil has no status", nil, 0},
+		{"not found", apierrors.NewNotFound(secrets, "write-token"), http.StatusNotFound},
+		{"already exists", apierrors.NewAlreadyExists(secrets, "write-token"), http.StatusConflict},
+		{"conflict", apierrors.NewConflict(secrets, "write-token", errors.New("changed")), http.StatusConflict},
+		{"forbidden", apierrors.NewForbidden(secrets, "write-token", errors.New("rbac")), http.StatusForbidden},
+		{"bad request", apierrors.NewBadRequest("nope"), http.StatusBadRequest},
+		{"server timeout", apierrors.NewServerTimeout(secrets, "get", 1), http.StatusGatewayTimeout},
+		{"too many requests", apierrors.NewTooManyRequestsError("slow down"), http.StatusTooManyRequests},
+		{"service unavailable", apierrors.NewServiceUnavailable("no backend"), http.StatusServiceUnavailable},
+		{"deadline exceeded", context.DeadlineExceeded, http.StatusGatewayTimeout},
+		{"canceled", context.Canceled, http.StatusRequestTimeout},
+		{"a plain error stays a bad request", errors.New("helm: chart not loadable"), http.StatusBadRequest},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := HttpStatusForError(test.err); got != test.want {
+				t.Fatalf("HttpStatusForError(%v) = %d, want %d", test.err, got, test.want)
+			}
+		})
+	}
+}
+
+// Wrapped errors are the normal case: handlers add context with %w before
+// returning, and a mapping that only recognised bare errors would report almost
+// everything as 400.
+func TestHttpStatusForWrappedError(t *testing.T) {
+	secrets := schema.GroupResource{Group: "", Resource: "secrets"}
+	wrapped := fmt.Errorf("failed to read the write credential: %w", apierrors.NewNotFound(secrets, "write-token"))
+
+	if got := HttpStatusForError(wrapped); got != http.StatusNotFound {
+		t.Fatalf("wrapped NotFound = %d, want %d", got, http.StatusNotFound)
+	}
+}
+
+// The platform's frontend refreshes the token and replays the request on 401, so
+// a cluster denial must never be reported that way.
+func TestUnauthorizedIsReportedAsForbidden(t *testing.T) {
+	if got := HttpStatusForError(apierrors.NewUnauthorized("token expired")); got != http.StatusForbidden {
+		t.Fatalf("Unauthorized = %d, want %d", got, http.StatusForbidden)
+	}
+
+	statusErr := &apierrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusUnauthorized, Message: "nope"}}
+	if got := HttpStatusForError(statusErr); got != http.StatusForbidden {
+		t.Fatalf("StatusError 401 = %d, want %d", got, http.StatusForbidden)
+	}
+}
+
+// A StatusError knows its own code; anything in the error range is forwarded
+// rather than squeezed into the handful of cases enumerated above.
+func TestStatusErrorCodeIsForwarded(t *testing.T) {
+	for _, code := range []int32{http.StatusNotFound, http.StatusGone, http.StatusInternalServerError, 418} {
+		statusErr := &apierrors.StatusError{ErrStatus: metav1.Status{Code: code}}
+		if got := HttpStatusForError(statusErr); got != int(code) {
+			t.Fatalf("StatusError %d = %d, want %d", code, got, code)
+		}
+	}
+}
+
+// A code outside the error range would turn a failure into a success-looking
+// status, so it falls through to the default instead.
+func TestNonErrorStatusCodeFallsBack(t *testing.T) {
+	statusErr := &apierrors.StatusError{ErrStatus: metav1.Status{Code: 0, Message: "no code"}}
+	if got := HttpStatusForError(statusErr); got != http.StatusBadRequest {
+		t.Fatalf("StatusError without a code = %d, want %d", got, http.StatusBadRequest)
+	}
+}


### PR DESCRIPTION
Socket responses carry `status: "error"` plus `err.Error()` and nothing else, so the platform has to guess an HTTP status by pattern-matching the message text. That works until Kubernetes rewords something. The operator already knows the answer precisely, so it should say it.

## Change

`buildResponse` in `socketapi.go` — the single place every handler error passes through — now sets `statusCode`:

```go
return Result{
    Status:     "error",
    Message:    err.Error(),
    StatusCode: utils.HttpStatusForError(err),
}
```

`utils.HttpStatusForError` reads the error rather than its text: `apierrors.IsNotFound` and friends recognise wrapped errors, and a `StatusError` carries the API server's own code.

| error | status |
|---|---|
| `IsNotFound` | 404 |
| `IsAlreadyExists`, `IsConflict` | 409 |
| `IsForbidden`, `IsUnauthorized` | 403 |
| `IsInvalid`, `IsBadRequest` | 400 |
| `IsTimeout`, `IsServerTimeout`, `context.DeadlineExceeded` | 504 |
| `IsTooManyRequests` | 429 |
| `IsServiceUnavailable` | 503 |
| `context.Canceled` | 408 |
| any other `StatusError` | its own code, if 4xx/5xx |
| anything else (helm, git, our validation) | 400 |

## Two decisions worth reviewing

**Reason before code.** `NewServerTimeout` carries code 500, but "the operation could not be completed, please try again" is a gateway timeout to a caller, not an internal error. So the reason checks run first and the raw code is only forwarded when no reason matches. My first version had this the other way round and the test caught it.

**Never 401.** The platform's frontend refreshes the access token and replays the request on any 401 (`auth.interceptor.ts`), so reporting a cluster RBAC denial that way would cost a pointless retry and, if the refresh fails, log the user out. `IsUnauthorized` and a raw 401 both become 403 — which is also what Kubernetes calls that case. Two tests pin this.

## Compatibility

Additive. The field is `omitempty` and absent on success. Consumers must keep a fallback for operators that predate it — the platform side does exactly that (mogenius/mo-platform-api-service#430: reported status preferred, message heuristic only when absent), so an old operator loses nothing and a new one is authoritative.

Anything unrecognised still maps to 400, which is what every error was reported as before this PR.

## Verified

`go build ./...` and the full `go test ./src/...` pass; 5 new tests in `src/utils` cover each mapping, wrapped errors, the no-401 rule, code forwarding for statuses without a dedicated case, and a code outside the error range falling back rather than turning a failure into a success-looking status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)