### PR TITLE
feat(ai): probe an ad-hoc model spec, not only the stored one

### DIFF
--- a/src/ai/aimanager.go
+++ b/src/ai/aimanager.go
@@ -274,7 +274,7 @@ type AiManager interface {
 	ResetTokenUsageForModel(modelCrName string) (int64, error)
 	DeleteAllAiData() error
 	GetAvailableModels(request *ModelsRequest) ([]string, error)
-	TestAiModel(name string) (*AiModelTestResult, error)
+	TestAiModel(name string, spec *v1alpha1.AiModelSpec, apiKey string) (*AiModelTestResult, error)
 	Chat(ctx context.Context, ch IOChatChannel) error
 
 	ApproveTask(taskID string, user structs.User) (*AiTask, error)

--- a/src/ai/aimodels.go
+++ b/src/ai/aimodels.go
@@ -246,6 +246,41 @@ func PickDefaultAiModel(models []v1alpha1.AiModel) *v1alpha1.AiModel {
 // resolveAiModel turns one AiModel CR into a usable config, reading the
 // referenced API key Secret. Limits the spec omits fall back to the built-in
 // defaults.
+// resolveAiModelForProbe resolves like resolveAiModel, but a non-empty
+// apiKeyOverride stands in for the Secret lookup. The edit form's test sends
+// a key that exists nowhere yet -- demanding a secretRef for it would force
+// the save the test exists to precede. Only the probe may use this; every
+// run path keeps resolving through the Secret.
+func (ai *aiManager) resolveAiModelForProbe(model *v1alpha1.AiModel, apiKeyOverride string) (*ResolvedModelConfig, error) {
+	if apiKeyOverride == "" {
+		return ai.resolveAiModel(model, "test")
+	}
+
+	// Validation demands a secretRef for key-carrying SDKs; the override IS
+	// the key, so a spec without the ref is complete for this probe.
+	specForValidation := model.Spec
+	if specForValidation.ApiKeySecretRef == nil {
+		specForValidation.ApiKeySecretRef = &v1alpha1.SecretKeyRef{Name: "probe-override"}
+	}
+	if err := ValidateAiModelSpec(specForValidation); err != nil {
+		return nil, fmt.Errorf("AiModel %q has an invalid spec: %w", model.Name, err)
+	}
+	sdk, err := parseSdkType(model.Spec.Sdk)
+	if err != nil {
+		return nil, fmt.Errorf("AiModel %q: %w", model.Name, err)
+	}
+
+	resolved := &ResolvedModelConfig{
+		Source:      "test",
+		ModelCrName: model.Name,
+		Sdk:         sdk,
+		Model:       model.Spec.Model,
+		ApiKey:      apiKeyOverride,
+		BaseUrl:     model.Spec.ApiUrl,
+	}
+	return resolved, nil
+}
+
 func (ai *aiManager) resolveAiModel(model *v1alpha1.AiModel, source string) (*ResolvedModelConfig, error) {
 	if err := ValidateAiModelSpec(model.Spec); err != nil {
 		return nil, fmt.Errorf("AiModel %q has an invalid spec: %w", model.Name, err)

--- a/src/ai/aimodels_probe.go
+++ b/src/ai/aimodels_probe.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"context"
 	"fmt"
+	"mogenius-operator/src/crds/v1alpha1"
 	"strings"
 	"time"
 
@@ -42,22 +43,38 @@ type AiModelTestResult struct {
 // sends a minimal single-turn prompt to the provider. An error return means
 // the request itself was invalid (unknown model); provider/config problems
 // come back as an unsuccessful result.
-func (ai *aiManager) TestAiModel(name string) (*AiModelTestResult, error) {
+// TestAiModel probes a model config against its provider. With spec == nil
+// the stored AiModel is probed; with a spec, THAT config is probed instead --
+// which is the whole point of a test button on an edit form: validating a new
+// url or key before committing it, not after. apiKey overrides whatever the
+// spec's secretRef would resolve to; nothing is persisted either way.
+func (ai *aiManager) TestAiModel(name string, spec *v1alpha1.AiModelSpec, apiKey string) (*AiModelTestResult, error) {
 	ownNamespace, err := ai.config.TryGet("MO_OWN_NAMESPACE")
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve own namespace: %w", err)
 	}
-	model, err := store.GetAiModel(ownNamespace, name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get AiModel %q: %w", name, err)
-	}
-	if model == nil {
-		return nil, fmt.Errorf("AiModel %q not found in namespace %q", name, ownNamespace)
+
+	var model *v1alpha1.AiModel
+	if spec != nil {
+		// A synthetic, never-stored model. Namespace matters: the spec may
+		// still reference the existing key Secret ("keep credential" on the
+		// edit form), and that ref resolves inside the own namespace.
+		model = &v1alpha1.AiModel{Spec: *spec}
+		model.Name = name
+		model.Namespace = ownNamespace
+	} else {
+		model, err = store.GetAiModel(ownNamespace, name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get AiModel %q: %w", name, err)
+		}
+		if model == nil {
+			return nil, fmt.Errorf("AiModel %q not found in namespace %q", name, ownNamespace)
+		}
 	}
 
 	result := &AiModelTestResult{Model: model.Spec.Model, Sdk: model.Spec.Sdk}
 
-	rc, err := ai.resolveAiModel(model, "test")
+	rc, err := ai.resolveAiModelForProbe(model, apiKey)
 	if err != nil {
 		// Unresolvable config (invalid spec, missing Secret/key) is exactly
 		// what the test is for — report it as the outcome.

--- a/src/ai/aimodels_test.go
+++ b/src/ai/aimodels_test.go
@@ -224,3 +224,27 @@ func TestValidateAiModelDefaultUnique(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+// The edit form's test sends a key that exists nowhere yet -- demanding a
+// secretRef for it would force the save the test exists to precede.
+func TestResolveAiModelForProbeWithKeyOverride(t *testing.T) {
+	manager := &aiManager{}
+
+	model := &v1alpha1.AiModel{}
+	model.Name = "unsaved"
+	model.Spec = v1alpha1.AiModelSpec{Sdk: "openai", Model: "gpt-5.5"}
+
+	rc, err := manager.resolveAiModelForProbe(model, "sk-plaintext")
+	if err != nil {
+		t.Fatalf("expected the override to stand in for the secretRef, got: %v", err)
+	}
+	if rc.ApiKey != "sk-plaintext" {
+		t.Fatalf("expected the override key to be used, got %q", rc.ApiKey)
+	}
+
+	// Validation beyond the key still applies: ollama without a url stays invalid.
+	model.Spec = v1alpha1.AiModelSpec{Sdk: "ollama", Model: "qwen3.8:27b"}
+	if _, err := manager.resolveAiModelForProbe(model, "irrelevant"); err == nil {
+		t.Fatalf("expected an invalid spec to be rejected even with a key override")
+	}
+}

--- a/src/core/ai.go
+++ b/src/core/ai.go
@@ -3,6 +3,7 @@ package core
 import (
 	"log/slog"
 	"mogenius-operator/src/ai"
+	"mogenius-operator/src/crds/v1alpha1"
 	"mogenius-operator/src/structs"
 	"mogenius-operator/src/utils"
 )
@@ -19,7 +20,7 @@ type AiApi interface {
 	GetStatus(workspace *string) ai.AiManagerStatus
 	DeleteAllAiData() error
 	GetAvailableModels(request *ai.ModelsRequest) ([]string, error)
-	TestAiModel(name string) (*ai.AiModelTestResult, error)
+	TestAiModel(name string, spec *v1alpha1.AiModelSpec, apiKey string) (*ai.AiModelTestResult, error)
 
 	ApproveTask(taskID string, user structs.User) (*ai.AiTask, error)
 	RejectTask(taskID string, user structs.User, reason string) (*ai.AiTask, error)
@@ -83,8 +84,8 @@ func (ai *aiApi) GetAvailableModels(request *ai.ModelsRequest) ([]string, error)
 	return ai.aiManager.GetAvailableModels(request)
 }
 
-func (self *aiApi) TestAiModel(name string) (*ai.AiModelTestResult, error) {
-	return self.aiManager.TestAiModel(name)
+func (self *aiApi) TestAiModel(name string, spec *v1alpha1.AiModelSpec, apiKey string) (*ai.AiModelTestResult, error) {
+	return self.aiManager.TestAiModel(name, spec, apiKey)
 }
 
 func (self *aiApi) ApproveTask(taskID string, user structs.User) (*ai.AiTask, error) {
@@ -102,4 +103,3 @@ func (self *aiApi) CancelTask(taskID string, user structs.User) (*ai.AiTask, err
 func (self *aiApi) DeleteTask(taskID string, user structs.User) (*ai.AiTask, error) {
 	return self.aiManager.DeleteTask(taskID, user)
 }
-

--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -2201,13 +2201,18 @@ func (self *socketApi) registerPatterns() {
 	{
 		type Request struct {
 			Name string `json:"name" validate:"required"`
+			// Probe THIS config instead of the stored AiModel -- a test button
+			// on an edit form has to validate the form, not the last save.
+			Spec *v1alpha1.AiModelSpec `json:"spec"`
+			// Plaintext key override for the probe; never persisted.
+			ApiKey string `json:"apiKey"`
 		}
 
 		RegisterPatternHandler(
 			PatternHandle{self, "test/aimodel"},
 			PatternConfig{},
 			func(datagram structs.Datagram, request Request) (*ai.AiModelTestResult, error) {
-				return self.aiApi.TestAiModel(request.Name)
+				return self.aiApi.TestAiModel(request.Name, request.Spec, request.ApiKey)
 			},
 		)
 	}


### PR DESCRIPTION
Second link of the test-before-save chain (Bene: *"ich muss erst speichern bevor ich testen kann — so kann ich nicht testen ob die neue URL klappt"*). SDK: mogenius/mo-client-sdk#56; platform-api and frontend PRs follow.

## What changes

`test/aimodel` accepts an optional `spec` (+ plaintext `apiKey`):

- **spec present** → a synthetic, never-stored `AiModel` is probed. The own namespace still applies, so a *kept* `secretRef` ("leave credential unchanged" on the edit form) resolves exactly as before.
- **apiKey present** → it stands in for the Secret lookup entirely (`resolveAiModelForProbe`): the key exists nowhere yet, and demanding a secretRef for it would force the very save the test precedes. Spec validation beyond the key still applies (ollama without apiUrl stays invalid — covered by test). Only the probe can use the override; every run path keeps resolving through the Secret.
- **neither** → stored-model behavior, unchanged.

## Verification

`go build ./...`, `go vet`, `go test ./src/ai ./src/core` green; new test covers the key-override resolution and that non-key validation still rejects.

## Rollout note

An **old operator silently ignores the new fields** and keeps testing the stored CR — the frontend button would then produce misleading results against stale config. The frontend PR notes this; clusters on the dev updater channel pick this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)