### PR TITLE
ci: bump reusable workflows to v1.7.7 and raise the lint timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,12 @@ jobs:
   # random split across the two halved the cache hit rate and made test and lint
   # compile the same dependency tree twice.
   test:
-    uses: mogenius/github-actions/.github/workflows/go-test.yml@b5293d661baea684bc9d1a95b1ecd64ead344b92 # v1.7.4
+    uses: mogenius/github-actions/.github/workflows/go-test.yml@003b4f8d0dc6b7c9f5b5e8f94b722516b6fdd7a8 # v1.7.7
     with:
       path: src
       runner: arc-runner-set-amd64
   lint:
-    uses: mogenius/github-actions/.github/workflows/golangci-lint.yml@b5293d661baea684bc9d1a95b1ecd64ead344b92 # v1.7.4
+    uses: mogenius/github-actions/.github/workflows/golangci-lint.yml@003b4f8d0dc6b7c9f5b5e8f94b722516b6fdd7a8 # v1.7.7
     with:
       args: --config=.golangci.yml ./src
       runner: arc-runner-set-amd64

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -72,7 +72,7 @@ jobs:
   # ============================================================================
   build-operator:
     needs: [prepare]
-    uses: mogenius/github-actions/.github/workflows/build-multiarch.yml@b5293d661baea684bc9d1a95b1ecd64ead344b92 # v1.7.4
+    uses: mogenius/github-actions/.github/workflows/build-multiarch.yml@003b4f8d0dc6b7c9f5b5e8f94b722516b6fdd7a8 # v1.7.7
     secrets: inherit
     with:
       version: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -19,17 +19,17 @@ concurrency:
 
 jobs:
   lint:
-    uses: mogenius/github-actions/.github/workflows/helm-lint.yml@b5293d661baea684bc9d1a95b1ecd64ead344b92 # v1.7.4
+    uses: mogenius/github-actions/.github/workflows/helm-lint.yml@003b4f8d0dc6b7c9f5b5e8f94b722516b6fdd7a8 # v1.7.7
     with:
       path: ./helm/charts/mogenius-operator
 
   tests:
-    uses: mogenius/github-actions/.github/workflows/helm-unittest.yml@b5293d661baea684bc9d1a95b1ecd64ead344b92 # v1.7.4
+    uses: mogenius/github-actions/.github/workflows/helm-unittest.yml@003b4f8d0dc6b7c9f5b5e8f94b722516b6fdd7a8 # v1.7.7
     with:
       path: ./helm/charts/mogenius-operator
 
   template:
-    uses: mogenius/github-actions/.github/workflows/helm-template.yml@b5293d661baea684bc9d1a95b1ecd64ead344b92 # v1.7.4
+    uses: mogenius/github-actions/.github/workflows/helm-template.yml@003b4f8d0dc6b7c9f5b5e8f94b722516b6fdd7a8 # v1.7.7
     with:
       path: ./helm/charts/mogenius-operator
       namespace: mogenius
@@ -38,7 +38,7 @@ jobs:
         global.api_key=mo_customer-api-key
 
   template-advanced:
-    uses: mogenius/github-actions/.github/workflows/helm-template.yml@b5293d661baea684bc9d1a95b1ecd64ead344b92 # v1.7.4
+    uses: mogenius/github-actions/.github/workflows/helm-template.yml@003b4f8d0dc6b7c9f5b5e8f94b722516b6fdd7a8 # v1.7.7
     with:
       path: ./helm/charts/mogenius-operator
       namespace: mogenius

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
   # ============================================================================
   build-operator:
     needs: [prepare]
-    uses: mogenius/github-actions/.github/workflows/build-multiarch.yml@b5293d661baea684bc9d1a95b1ecd64ead344b92 # v1.7.4
+    uses: mogenius/github-actions/.github/workflows/build-multiarch.yml@003b4f8d0dc6b7c9f5b5e8f94b722516b6fdd7a8 # v1.7.7
     secrets: inherit
     with:
       version: ${{ needs.prepare.outputs.version }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 
 run:
-  timeout: 10m
+  timeout: 30m
 
 linters:
   settings:


### PR DESCRIPTION
Follow-up to mogenius/github-actions#32. Fixes `main`, which is currently red.

## Why

The pins were still on **v1.7.4** — that predates the ARC Go cache repair released in v1.7.5, so we never got it. Two things were broken:

- Neither `$GOMODCACHE` nor `$GOCACHE` exists at job start on the ephemeral ARC containers, so `actions/cache` aborted with `Some specified paths were not resolved` and **the Go cache was silently dead on every run**.
- `setup-go` looks up an exact `go.sum` hash with no `restore-keys` fallback, so every Renovate bump rebuilt the whole module graph from scratch.

That combination cost us a runner on #1179: with the cache cold, the lint job spent **27 minutes** rebuilding the dependency tree and then died in `Post Set up Go` while writing the multi-GB cache — `The self-hosted runner lost communication with the server` — even though the lint step itself had already passed. A rerun against a warm cache finished the same commit in **9m8s**.

v1.7.7 also raises the default golangci-lint to **v2.13.1**. v2.12.2 bundles `honnef.co/go/tools v0.7.0`, whose IR builder panics on the Go 1.27 stdlib that `setup-go`'s `stable` channel now resolves to:

```
[runner] Panic: buildir: package "poll": unexpected expr: *ast.KeyValueExpr
```

That is why `main` and every open PR have been red with bogus typecheck findings (`undefined: rand`, `method must have no type parameters`). **This PR is what makes `main` green again** — no Go version bump required.

## The timeout change

`run.timeout` 10m → 30m in `.golangci.yml`. This bump introduces a new cache key prefix (`go-*` instead of setup-go's `setup-go-*`), so nothing matches on the first run and a cold full lint does not fit in 10m. Warm runs stay around 9 minutes; this is a ceiling, not a target.

Expect **this PR's own lint job to be slow** — it is the run that populates the new cache. Everything after it benefits.

## Scope

All eight refs bumped together to keep the pins consistent. Beyond the Go workflows this is near-empty: the three helm workflows are byte-identical between v1.7.4 and v1.7.7, and `build-multiarch` only picks up a `docker/login-action` patch (v4.5.2 → v4.6.0).

## Relation to #1179

#1179 (Go 1.27) pins `golangci_lint_version: v2.13.0` inline as a workaround. Once this lands, that override is redundant — v1.7.7 defaults to v2.13.1. The two PRs touch adjacent lines in `ci.yaml`, so whichever merges second needs a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)