### PR TITLE
Fix/operator crash

### DIFF
--- a/src/ai/ai_websocket_connection.go
+++ b/src/ai/ai_websocket_connection.go
@@ -161,11 +161,14 @@ func (self *aiWebsocketConnection) LiveStreamAiManagerChatRequest(request ChatRe
 		chatChannel.WorkspaceGrant = grantSpec
 	}
 
+	var chatWg sync.WaitGroup
+
 	defer func() {
 		logger.Info("AI Chat WebSocket connection closed")
-		cancel() // cancel context first so Chat goroutine exits via ctx.Done() before channels close
-		close(inputChan)
-		close(outputChan)
+		cancel()          // signal Chat goroutine to exit via ctx.Done()
+		close(inputChan)  // unblock any input-waiting select in runChatSession
+		chatWg.Wait()     // wait for Chat goroutine to stop sending on outputChan
+		close(outputChan) // safe to close now
 	}()
 
 	// Read from output channel and write to WebSocket
@@ -190,8 +193,9 @@ func (self *aiWebsocketConnection) LiveStreamAiManagerChatRequest(request ChatRe
 	}()
 
 	// Run Chat with the channels
+	chatWg.Add(1)
 	go func() {
-		//defer close(outputChan)
+		defer chatWg.Done()
 		err := self.aiManager.Chat(ctx, chatChannel)
 		if err != nil {
 			logger.Error("ChatTest error", "error", err)

--- a/src/ai/aimanager_chat.go
+++ b/src/ai/aimanager_chat.go
@@ -51,6 +51,7 @@ func (ai *aiManager) Chat(ctx context.Context, ioChannel IOChatChannel) error {
 	// every message (the budget may free up mid-session via a reset).
 	if ai.isModelBudgetExceeded(rc) {
 		emitChatError(ctx, ioChannel, ai.modelBudgetError(rc))
+		return nil
 	}
 
 	// Connect to configured MCP servers


### PR DESCRIPTION
```
panic: send on closed channel

goroutine 55064 [running]:
mogenius-operator/src/ai.(*aiManager).runChatTurn(0xc01835a41c0, {0x3e19f20, 0xc01914345b0}, {0x3e05490, _}, _, {_, _, _}, {0xc018b1fd110, ...}, ...)
	mogenius-operator/src/ai/chat_loop.go:101 +0xa92
mogenius-operator/src/ai.(*aiManager).runChatSession(0xc01835a41c0, {0x3e19f20, 0xc01914345b0}, {0x3e05490, 0xc018fb0d318}, 0xc0188b9fc00, {0xc0184228600, 0x1824}, {0xc018b1fd110, 0xc018b1fdd50, ...})
	mogenius-operator/src/ai/chat_loop.go:220 +0x7ac
mogenius-operator/src/ai.(*aiManager).Chat(0xc01835a41c0, {0x3e19f20, 0xc01914345b0}, {0xc018b1fd110, 0xc018b1fdd50, 0xc0183b80d88, {0x0, 0x0}, 0x1, 0x0, ...})
	mogenius-operator/src/ai/aimanager_chat.go:110 +0x945
mogenius-operator/src/ai.(*aiWebsocketConnection).LiveStreamAiManagerChatRequest.func5()
	mogenius-operator/src/ai/ai_websocket_connection.go:195 +0x7e
created by mogenius-operator/src/ai.(*aiWebsocketConnection).LiveStreamAiManagerChatRequest in goroutine 55056
	mogenius-operator/src/ai/ai_websocket_connection.go:193 +0x736
```