### PR TITLE
feat(storage): generic PVC exec substrate + storage/files v2 patterns

### DIFF
--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -807,6 +807,126 @@ func (self *socketApi) registerPatterns() {
 		},
 	)
 
+	// files/v2/*: file operations on any PVC mounted by a running pod,
+	// executed in that pod (no mogenius NFS server required). The binary
+	// upload counterpart (files/v2/upload) is handled in the job client
+	// read loop next to the legacy files/upload framing.
+	{
+		type Request struct {
+			Folder dtos.PvcFileRequestDto `json:"folder" validate:"required"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "files/v2/list"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) ([]dtos.PersistentFileDto, error) {
+				return services.ListV2(request.Folder)
+			},
+		)
+	}
+
+	RegisterPatternHandler(
+		PatternHandle{self, "files/v2/info"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request dtos.PvcFileRequestDto) (dtos.PersistentFileDto, error) {
+			return services.InfoV2(request)
+		},
+	)
+
+	{
+		type Request struct {
+			Folder dtos.PvcFileRequestDto `json:"folder" validate:"required"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "files/v2/create-folder"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (bool, error) {
+				err := services.CreateFolderV2(request.Folder)
+				return store.AddToAuditLog(datagram, self.logger, err == nil, err, nil, nil)
+			},
+		)
+	}
+
+	{
+		type Request struct {
+			File    dtos.PvcFileRequestDto `json:"file" validate:"required"`
+			NewName string                 `json:"newName" validate:"required"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "files/v2/rename"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (bool, error) {
+				err := services.RenameV2(request.File, request.NewName)
+				return store.AddToAuditLog(datagram, self.logger, err == nil, err, nil, nil)
+			},
+		)
+	}
+
+	{
+		type Request struct {
+			File dtos.PvcFileRequestDto `json:"file" validate:"required"`
+			Uid  string                 `json:"uid" validate:"required"`
+			Gid  string                 `json:"gid" validate:"required"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "files/v2/chown"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (bool, error) {
+				err := services.ChownV2(request.File, request.Uid, request.Gid)
+				return store.AddToAuditLog(datagram, self.logger, err == nil, err, nil, nil)
+			},
+		)
+	}
+
+	{
+		type Request struct {
+			File dtos.PvcFileRequestDto `json:"file" validate:"required"`
+			Mode string                 `json:"mode" validate:"required"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "files/v2/chmod"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (bool, error) {
+				err := services.ChmodV2(request.File, request.Mode)
+				return store.AddToAuditLog(datagram, self.logger, err == nil, err, nil, nil)
+			},
+		)
+	}
+
+	{
+		type Request struct {
+			File dtos.PvcFileRequestDto `json:"file" validate:"required"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "files/v2/delete"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (bool, error) {
+				err := services.DeleteV2(request.File)
+				return store.AddToAuditLog(datagram, self.logger, err == nil, err, nil, nil)
+			},
+		)
+	}
+
+	{
+		type Request struct {
+			File   dtos.PvcFileRequestDto `json:"file" validate:"required"`
+			PostTo string                 `json:"postTo" validate:"required"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "files/v2/download"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (services.FilesDownloadResponse, error) {
+				return services.DownloadV2(request.File, request.PostTo)
+			},
+		)
+	}
+
 	RegisterPatternHandler(
 		PatternHandle{self, "prometheus/query"},
 		PatternConfig{},
@@ -2651,6 +2771,33 @@ func (self *socketApi) registerPatterns() {
 		},
 	)
 
+	// storage/v2/info: batch PVC info (status, capacity, mounts, browsability)
+	// with one pod scan per distinct namespace in the batch.
+	RegisterPatternHandler(
+		PatternHandle{self, "storage/v2/info"},
+		PatternConfig{},
+		func(datagram structs.Datagram, request services.StorageV2InfoRequest) (services.StorageV2InfoResponse, error) {
+			return services.StorageV2Info(request)
+		},
+	)
+
+	// storage/v2/stats: lazy filesystem usage of one PVC, read via df in a
+	// pod that mounts it.
+	{
+		type Request struct {
+			Namespace string `json:"namespace" validate:"required"`
+			PvcName   string `json:"pvcName" validate:"required"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "storage/v2/stats"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (services.StorageV2StatsResponse, error) {
+				return services.StorageV2Stats(request.Namespace, request.PvcName)
+			},
+		)
+	}
+
 	{
 		type Request struct {
 			Limit         int    `json:"limit" validate:"required"`
@@ -3081,8 +3228,13 @@ func (self *socketApi) sendNoHandlerError(client websocket.WebsocketClient, data
 
 func (self *socketApi) startJobClientReadLoop() {
 	go func() {
+		// One binary upload may be pending at a time: either a legacy
+		// files/upload request or a files/v2/upload request, never both.
+		// The variant that is non-nil decides where END_UPLOAD dispatches.
 		var preparedFileName *string
 		var preparedFileRequest *services.FilesUploadRequest
+		var preparedFileRequestV2 *services.FilesUploadRequestV2
+		var preparedUploadDatagramV2 *structs.Datagram
 		var openFile *os.File
 
 		jobs := make(chan structs.Datagram, messageWorkerCount)
@@ -3122,6 +3274,11 @@ func (self *socketApi) startJobClientReadLoop() {
 					if uploadErr != nil {
 						self.logger.Error("Error uploading file", "error", uploadErr)
 					}
+				} else if preparedFileName != nil && preparedFileRequestV2 != nil {
+					uploadErr = services.UploadedV2(*preparedFileName, *preparedFileRequestV2)
+					if uploadErr != nil {
+						self.logger.Error("Error uploading file", "error", uploadErr)
+					}
 				} else if preparedFileName == nil {
 					uploadErr = fmt.Errorf("upload failed: could not open temporary file")
 				}
@@ -3137,8 +3294,22 @@ func (self *socketApi) startJobClientReadLoop() {
 					go self.JobServerSendData(self.jobClients[0], ack)
 				}
 
+				if preparedFileRequestV2 != nil {
+					// uploads mutate the PVC: audit with the original datagram
+					if preparedUploadDatagramV2 != nil {
+						_, _ = store.AddToAuditLog(*preparedUploadDatagramV2, self.logger, uploadErr == nil, uploadErr, nil, nil)
+					}
+					ack := structs.CreateDatagramAck("ack:files/v2/upload:end", preparedFileRequestV2.Id)
+					if uploadErr != nil {
+						ack.Err = uploadErr.Error()
+					}
+					go self.JobServerSendData(self.jobClients[0], ack)
+				}
+
 				preparedFileName = nil
 				preparedFileRequest = nil
+				preparedFileRequestV2 = nil
+				preparedUploadDatagramV2 = nil
 				continue
 			}
 
@@ -3161,8 +3332,20 @@ func (self *socketApi) startJobClientReadLoop() {
 			// TODO: refactor! @bene
 			if datagram.Pattern == "files/upload" {
 				preparedFileRequest = self.executeBinaryRequestUpload(datagram)
+				preparedFileRequestV2 = nil
+				preparedUploadDatagramV2 = nil
 
 				var ack = structs.CreateDatagramAck("ack:files/upload:datagram", datagram.Id)
+				go self.JobServerSendData(self.jobClients[0], ack)
+				continue
+			}
+
+			if datagram.Pattern == "files/v2/upload" {
+				preparedFileRequestV2 = self.executeBinaryRequestUploadV2(datagram)
+				preparedUploadDatagramV2 = &datagram
+				preparedFileRequest = nil
+
+				var ack = structs.CreateDatagramAck("ack:files/v2/upload:datagram", datagram.Id)
 				go self.JobServerSendData(self.jobClients[0], ack)
 				continue
 			}
@@ -3512,6 +3695,12 @@ func podEventStreamConnection(podLogConnectionRequest xterm.PodEventConnectionRe
 
 func (self *socketApi) executeBinaryRequestUpload(datagram structs.Datagram) *services.FilesUploadRequest {
 	data := services.FilesUploadRequest{}
+	structs.MarshalUnmarshal(&datagram, &data)
+	return &data
+}
+
+func (self *socketApi) executeBinaryRequestUploadV2(datagram structs.Datagram) *services.FilesUploadRequestV2 {
+	data := services.FilesUploadRequestV2{}
 	structs.MarshalUnmarshal(&datagram, &data)
 	return &data
 }

--- a/src/dtos/pvcfilerequestdto.go
+++ b/src/dtos/pvcfilerequestdto.go
@@ -1,0 +1,9 @@
+package dtos
+
+// PvcFileRequestDto addresses a path on any PVC that is mounted by a running
+// pod (files/v2/* patterns). Path is relative to the PVC's mount root.
+type PvcFileRequestDto struct {
+	Namespace string `json:"namespace" validate:"required"`
+	PvcName   string `json:"pvcName" validate:"required"`
+	Path      string `json:"path" validate:"required"`
+}

--- a/src/kubernetes/utils.go
+++ b/src/kubernetes/utils.go
@@ -73,10 +73,23 @@ func NfsDiskUsage(volumeNamespace string, volumeName string) (free, used, total 
 	if execErr != nil {
 		return 0, 0, 0, fmt.Errorf("df exec failed: %w", execErr)
 	}
+	return parseDfOutput(output)
+}
 
-	// df -B1 output (header + data line):
-	// Filesystem     1-blocks      Used Available Use% Mounted on
-	// overlay        5368709120  102400  5266309120   2% /exports
+// PodDiskUsage returns free/used/total bytes of mountPath by executing
+// `df -B1 <mountPath>` inside the given container.
+func PodDiskUsage(namespace, podName, container, mountPath string) (free, used, total uint64, err error) {
+	output, execErr := ExecInPod(namespace, podName, container, []string{"df", "-B1", mountPath}, nil)
+	if execErr != nil {
+		return 0, 0, 0, fmt.Errorf("df exec failed: %w", execErr)
+	}
+	return parseDfOutput(output)
+}
+
+// parseDfOutput parses `df -B1 <path>` output (header + data line):
+// Filesystem     1-blocks      Used Available Use% Mounted on
+// overlay        5368709120  102400  5266309120   2% /exports
+func parseDfOutput(output string) (free, used, total uint64, err error) {
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	if len(lines) < 2 {
 		return 0, 0, 0, fmt.Errorf("unexpected df output: %q", output)
@@ -123,7 +136,27 @@ func ExecInNfsPodToWriter(volumeNamespace, volumeName string, command []string, 
 	return execInNfsPodStream(volumeNamespace, podNames[0], command, stdin, stdout)
 }
 
+// ExecInPod executes a command inside the given container of a pod and returns
+// the buffered stdout. stdin may be nil.
+func ExecInPod(namespace, podName, container string, command []string, stdin io.Reader) (string, error) {
+	var stdout bytes.Buffer
+	err := execInPodStream(namespace, podName, container, command, stdin, &stdout)
+	return stdout.String(), err
+}
+
+// ExecInPodToWriter streams exec stdout of the given container directly into
+// the provided writer. stdin may be nil.
+func ExecInPodToWriter(namespace, podName, container string, command []string, stdin io.Reader, stdout io.Writer) error {
+	return execInPodStream(namespace, podName, container, command, stdin, stdout)
+}
+
+// execInNfsPodStream keeps the legacy NFS entry point; the NFS server pod
+// always runs its single container named "nfs-server".
 func execInNfsPodStream(namespace, podName string, command []string, stdin io.Reader, stdout io.Writer) error {
+	return execInPodStream(namespace, podName, "nfs-server", command, stdin, stdout)
+}
+
+func execInPodStream(namespace, podName, container string, command []string, stdin io.Reader, stdout io.Writer) error {
 	clientset := clientProvider.K8sClientSet()
 	restConfig := clientProvider.ClientConfig()
 
@@ -132,7 +165,7 @@ func execInNfsPodStream(namespace, podName string, command []string, stdin io.Re
 		Name(podName).
 		Namespace(namespace).
 		SubResource("exec").
-		Param("container", "nfs-server").
+		Param("container", container).
 		Param("stdout", "true").
 		Param("stderr", "true").
 		Param("tty", "false")

--- a/src/kubernetes/utils_test.go
+++ b/src/kubernetes/utils_test.go
@@ -1,0 +1,50 @@
+package kubernetes
+
+import (
+	"testing"
+)
+
+func TestParseDfOutput(t *testing.T) {
+	t.Run("parses regular df -B1 output", func(t *testing.T) {
+		output := "Filesystem     1-blocks      Used Available Use% Mounted on\n" +
+			"overlay        5368709120  102400  5266309120   2% /exports\n"
+		free, used, total, err := parseDfOutput(output)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if total != 5368709120 || used != 102400 || free != 5266309120 {
+			t.Fatalf("unexpected values: free=%d used=%d total=%d", free, used, total)
+		}
+	})
+
+	t.Run("uses the last line of multi-line output", func(t *testing.T) {
+		output := "Filesystem     1-blocks      Used Available Use% Mounted on\n" +
+			"tmpfs          999  1  998   1% /other\n" +
+			"/dev/sda1      1000  200  800   20% /data\n"
+		free, used, total, err := parseDfOutput(output)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if total != 1000 || used != 200 || free != 800 {
+			t.Fatalf("unexpected values: free=%d used=%d total=%d", free, used, total)
+		}
+	})
+
+	t.Run("fails on missing data line", func(t *testing.T) {
+		if _, _, _, err := parseDfOutput("Filesystem 1-blocks Used Available Use% Mounted on\n"); err == nil {
+			t.Fatal("expected error for header-only output")
+		}
+	})
+
+	t.Run("fails on too few fields", func(t *testing.T) {
+		if _, _, _, err := parseDfOutput("header\noverlay 123 456\n"); err == nil {
+			t.Fatal("expected error for short data line")
+		}
+	})
+
+	t.Run("fails on non-numeric fields", func(t *testing.T) {
+		if _, _, _, err := parseDfOutput("header\noverlay abc def ghi 2% /exports\n"); err == nil {
+			t.Fatal("expected error for non-numeric values")
+		}
+	})
+}

--- a/src/services/filesservice.go
+++ b/src/services/filesservice.go
@@ -13,19 +13,209 @@ import (
 	"mogenius-operator/src/utils"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 )
 
+// fileExecTarget is the resolved exec substrate for one file operation: the
+// container to exec in and the mount root all request paths resolve against.
+type fileExecTarget struct {
+	Namespace string
+	Pod       string
+	Container string
+	MountRoot string
+}
+
+// resolveNfsFileTarget resolves the legacy NFS exec target: the nfs-server pod
+// of a mogenius volume, always container "nfs-server" with mount root /exports.
+func resolveNfsFileTarget(volumeNamespace, volumeName string) (fileExecTarget, error) {
+	podNames := mokubernetes.AllPodNamesForLabel(volumeNamespace, "app", fmt.Sprintf("%s-%s", utils.NFS_POD_PREFIX, volumeName))
+	if len(podNames) == 0 {
+		return fileExecTarget{}, fmt.Errorf("NFS server pod not found for %s/%s", volumeNamespace, volumeName)
+	}
+	return fileExecTarget{
+		Namespace: volumeNamespace,
+		Pod:       podNames[0],
+		Container: "nfs-server",
+		MountRoot: "/exports",
+	}, nil
+}
+
+// resolvePvcFileTarget resolves the v2 exec target: any running pod that
+// mounts the PVC without subPath, chosen by ResolvePvcTarget.
+func resolvePvcFileTarget(namespace, pvcName string) (fileExecTarget, error) {
+	target, err := ResolvePvcTarget(namespace, pvcName)
+	if err != nil {
+		return fileExecTarget{}, err
+	}
+	return fileExecTarget{
+		Namespace: target.Namespace,
+		Pod:       target.PodName,
+		Container: target.ContainerName,
+		MountRoot: target.MountPath,
+	}, nil
+}
+
+// ── legacy NFS entry points (deprecated patterns files/*) ─────────────────────
+
 func List(folder dtos.PersistentFileRequestDto) ([]dtos.PersistentFileDto, error) {
-	containerPath, err := resolveNfs(&folder)
+	target, err := resolveNfsFileTarget(folder.VolumeNamespace, folder.VolumeName)
+	if err != nil {
+		return nil, err
+	}
+	return listImpl(target, folder.Path)
+}
+
+func Info(r dtos.PersistentFileRequestDto) (dtos.PersistentFileDto, error) {
+	target, err := resolveNfsFileTarget(r.VolumeNamespace, r.VolumeName)
+	if err != nil {
+		return dtos.PersistentFileDto{}, err
+	}
+	return infoImpl(target, r.Path)
+}
+
+func Download(pfile dtos.PersistentFileRequestDto, postTo string) (FilesDownloadResponse, error) {
+	target, err := resolveNfsFileTarget(pfile.VolumeNamespace, pfile.VolumeName)
+	if err != nil {
+		return FilesDownloadResponse{Error: err.Error()}, err
+	}
+	return downloadImpl(target, pfile.Path, postTo)
+}
+
+func Uploaded(tempZipFileSrc string, fileReq FilesUploadRequest) error {
+	target, err := resolveNfsFileTarget(fileReq.File.VolumeNamespace, fileReq.File.VolumeName)
+	if err != nil {
+		return fmt.Errorf("error verifying file %s: %w", fileReq.File.Path, err)
+	}
+	return uploadedImpl(target, tempZipFileSrc, fileReq.File.Path, fileReq.SizeInBytes)
+}
+
+func CreateFolder(folder dtos.PersistentFileRequestDto) error {
+	target, err := resolveNfsFileTarget(folder.VolumeNamespace, folder.VolumeName)
+	if err != nil {
+		return err
+	}
+	return createFolderImpl(target, folder.Path)
+}
+
+func Rename(file dtos.PersistentFileRequestDto, newName string) error {
+	target, err := resolveNfsFileTarget(file.VolumeNamespace, file.VolumeName)
+	if err != nil {
+		return err
+	}
+	return renameImpl(target, file.Path, newName)
+}
+
+func Chown(file dtos.PersistentFileRequestDto, uidString string, gidString string) error {
+	target, err := resolveNfsFileTarget(file.VolumeNamespace, file.VolumeName)
+	if err != nil {
+		return err
+	}
+	return chownImpl(target, file.Path, uidString, gidString)
+}
+
+func Chmod(file dtos.PersistentFileRequestDto, mode string) error {
+	target, err := resolveNfsFileTarget(file.VolumeNamespace, file.VolumeName)
+	if err != nil {
+		return err
+	}
+	return chmodImpl(target, file.Path, mode)
+}
+
+func Delete(file dtos.PersistentFileRequestDto) error {
+	target, err := resolveNfsFileTarget(file.VolumeNamespace, file.VolumeName)
+	if err != nil {
+		return err
+	}
+	return deleteImpl(target, file.Path)
+}
+
+// ── v2 entry points (files/v2/* patterns, any mounted PVC) ────────────────────
+
+func ListV2(folder dtos.PvcFileRequestDto) ([]dtos.PersistentFileDto, error) {
+	target, err := resolvePvcFileTarget(folder.Namespace, folder.PvcName)
+	if err != nil {
+		return nil, err
+	}
+	return listImpl(target, folder.Path)
+}
+
+func InfoV2(r dtos.PvcFileRequestDto) (dtos.PersistentFileDto, error) {
+	target, err := resolvePvcFileTarget(r.Namespace, r.PvcName)
+	if err != nil {
+		return dtos.PersistentFileDto{}, err
+	}
+	return infoImpl(target, r.Path)
+}
+
+func DownloadV2(pfile dtos.PvcFileRequestDto, postTo string) (FilesDownloadResponse, error) {
+	target, err := resolvePvcFileTarget(pfile.Namespace, pfile.PvcName)
+	if err != nil {
+		return FilesDownloadResponse{Error: err.Error()}, err
+	}
+	return downloadImpl(target, pfile.Path, postTo)
+}
+
+func UploadedV2(tempZipFileSrc string, fileReq FilesUploadRequestV2) error {
+	target, err := resolvePvcFileTarget(fileReq.File.Namespace, fileReq.File.PvcName)
+	if err != nil {
+		return fmt.Errorf("error verifying file %s: %w", fileReq.File.Path, err)
+	}
+	return uploadedImpl(target, tempZipFileSrc, fileReq.File.Path, fileReq.SizeInBytes)
+}
+
+func CreateFolderV2(folder dtos.PvcFileRequestDto) error {
+	target, err := resolvePvcFileTarget(folder.Namespace, folder.PvcName)
+	if err != nil {
+		return err
+	}
+	return createFolderImpl(target, folder.Path)
+}
+
+func RenameV2(file dtos.PvcFileRequestDto, newName string) error {
+	target, err := resolvePvcFileTarget(file.Namespace, file.PvcName)
+	if err != nil {
+		return err
+	}
+	return renameImpl(target, file.Path, newName)
+}
+
+func ChownV2(file dtos.PvcFileRequestDto, uidString string, gidString string) error {
+	target, err := resolvePvcFileTarget(file.Namespace, file.PvcName)
+	if err != nil {
+		return err
+	}
+	return chownImpl(target, file.Path, uidString, gidString)
+}
+
+func ChmodV2(file dtos.PvcFileRequestDto, mode string) error {
+	target, err := resolvePvcFileTarget(file.Namespace, file.PvcName)
+	if err != nil {
+		return err
+	}
+	return chmodImpl(target, file.Path, mode)
+}
+
+func DeleteV2(file dtos.PvcFileRequestDto) error {
+	target, err := resolvePvcFileTarget(file.Namespace, file.PvcName)
+	if err != nil {
+		return err
+	}
+	return deleteImpl(target, file.Path)
+}
+
+// ── target-based implementations ──────────────────────────────────────────────
+
+func listImpl(target fileExecTarget, requestPath string) ([]dtos.PersistentFileDto, error) {
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
 		return nil, err
 	}
 
-	output, err := mokubernetes.ExecInNfsPod(
-		folder.VolumeNamespace, folder.VolumeName,
+	output, err := mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
 		[]string{
 			"find", containerPath,
 			"-maxdepth", "1", "-mindepth", "1",
@@ -55,33 +245,33 @@ func List(folder dtos.PersistentFileRequestDto) ([]dtos.PersistentFileDto, error
 	return result, nil
 }
 
-func Info(r dtos.PersistentFileRequestDto) (dtos.PersistentFileDto, error) {
-	containerPath, err := resolveNfs(&r)
+func infoImpl(target fileExecTarget, requestPath string) (dtos.PersistentFileDto, error) {
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
 		return dtos.PersistentFileDto{}, err
 	}
 
-	output, err := mokubernetes.ExecInNfsPod(
-		r.VolumeNamespace, r.VolumeName,
+	output, err := mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
 		[]string{"stat", "-c", "%n\t%F\t%s\t%u\t%g\t%a\t%Y", containerPath},
 		nil,
 	)
 	if err != nil {
 		return dtos.PersistentFileDto{}, err
 	}
-	return parseStatLine("/exports", strings.TrimSpace(output))
+	return parseStatLine(target.MountRoot, strings.TrimSpace(output))
 }
 
-func Download(pfile dtos.PersistentFileRequestDto, postTo string) (FilesDownloadResponse, error) {
+func downloadImpl(target fileExecTarget, requestPath string, postTo string) (FilesDownloadResponse, error) {
 	result := FilesDownloadResponse{}
 
-	containerPath, err := resolveNfs(&pfile)
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
 		result.Error = err.Error()
 		return result, err
 	}
 
-	info, err := Info(pfile)
+	info, err := infoImpl(target, requestPath)
 	if err != nil {
 		result.Error = err.Error()
 		return result, err
@@ -104,14 +294,14 @@ func Download(pfile dtos.PersistentFileRequestDto, postTo string) (FilesDownload
 	}
 
 	if info.Type == "directory" {
-		err = mokubernetes.ExecInNfsPodToWriter(
-			pfile.VolumeNamespace, pfile.VolumeName,
+		err = mokubernetes.ExecInPodToWriter(
+			target.Namespace, target.Pod, target.Container,
 			[]string{"tar", "czf", "-", "-C", path.Dir(containerPath), path.Base(containerPath)},
 			nil, w,
 		)
 	} else {
-		err = mokubernetes.ExecInNfsPodToWriter(
-			pfile.VolumeNamespace, pfile.VolumeName,
+		err = mokubernetes.ExecInPodToWriter(
+			target.Namespace, target.Pod, target.Container,
 			[]string{"cat", containerPath},
 			nil, w,
 		)
@@ -149,62 +339,63 @@ func Download(pfile dtos.PersistentFileRequestDto, postTo string) (FilesDownload
 	return result, nil
 }
 
-func Uploaded(tempZipFileSrc string, fileReq FilesUploadRequest) error {
-	containerPath, err := resolveNfs(&fileReq.File)
+func uploadedImpl(target fileExecTarget, tempZipFileSrc string, requestPath string, sizeInBytes int64) error {
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
-		return fmt.Errorf("error verifying file %s: %w", fileReq.File.Path, err)
+		return fmt.Errorf("error verifying file %s: %w", requestPath, err)
 	}
 	serviceLogger.Info(
 		"verified file",
-		"VolumeName", fileReq.File.VolumeName,
+		"pod", target.Pod,
+		"container", target.Container,
 		"targetDestination", containerPath,
-		"size", utils.BytesToHumanReadable(fileReq.SizeInBytes),
-		"path", fileReq.File.Path,
+		"size", utils.BytesToHumanReadable(sizeInBytes),
+		"path", requestPath,
 	)
 
-	// Convert zip → tar in-memory, then stream into the NFS pod via exec stdin.
+	// Convert zip → tar in-memory, then stream into the target pod via exec stdin.
 	tarBuf, err := zipToTar(tempZipFileSrc)
 	if err != nil {
-		return fmt.Errorf("error converting zip to tar for %s: %w", fileReq.File.Path, err)
+		return fmt.Errorf("error converting zip to tar for %s: %w", requestPath, err)
 	}
 
-	_, err = mokubernetes.ExecInNfsPod(
-		fileReq.File.VolumeNamespace, fileReq.File.VolumeName,
+	_, err = mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
 		[]string{"sh", "-c", fmt.Sprintf("mkdir -p '%s' && tar xf - -C '%s'", containerPath, containerPath)},
 		tarBuf,
 	)
 	return err
 }
 
-func CreateFolder(folder dtos.PersistentFileRequestDto) error {
-	containerPath, err := resolveNfs(&folder)
+func createFolderImpl(target fileExecTarget, requestPath string) error {
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
 		return err
 	}
-	_, err = mokubernetes.ExecInNfsPod(
-		folder.VolumeNamespace, folder.VolumeName,
+	_, err = mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
 		[]string{"mkdir", "-p", containerPath},
 		nil,
 	)
 	return err
 }
 
-func Rename(file dtos.PersistentFileRequestDto, newName string) error {
-	containerPath, err := resolveNfs(&file)
+func renameImpl(target fileExecTarget, requestPath string, newName string) error {
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
 		return err
 	}
 	newPath := path.Join(path.Dir(containerPath), newName)
-	_, err = mokubernetes.ExecInNfsPod(
-		file.VolumeNamespace, file.VolumeName,
+	_, err = mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
 		[]string{"mv", containerPath, newPath},
 		nil,
 	)
 	return err
 }
 
-func Chown(file dtos.PersistentFileRequestDto, uidString string, gidString string) error {
-	containerPath, err := resolveNfs(&file)
+func chownImpl(target fileExecTarget, requestPath string, uidString string, gidString string) error {
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
 		return err
 	}
@@ -222,16 +413,16 @@ func Chown(file dtos.PersistentFileRequestDto, uidString string, gidString strin
 		return fmt.Errorf("gid/uid > 0 and < 2^32")
 	}
 
-	_, err = mokubernetes.ExecInNfsPod(
-		file.VolumeNamespace, file.VolumeName,
+	_, err = mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
 		[]string{"chown", fmt.Sprintf("%s:%s", uidString, gidString), containerPath},
 		nil,
 	)
 	return err
 }
 
-func Chmod(file dtos.PersistentFileRequestDto, mode string) error {
-	containerPath, err := resolveNfs(&file)
+func chmodImpl(target fileExecTarget, requestPath string, mode string) error {
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
 		return err
 	}
@@ -241,21 +432,21 @@ func Chmod(file dtos.PersistentFileRequestDto, mode string) error {
 		return fmt.Errorf("failed to parse oct permissions: %s %w", mod, err)
 	}
 
-	_, err = mokubernetes.ExecInNfsPod(
-		file.VolumeNamespace, file.VolumeName,
+	_, err = mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
 		[]string{"chmod", mod, containerPath},
 		nil,
 	)
 	return err
 }
 
-func Delete(file dtos.PersistentFileRequestDto) error {
-	containerPath, err := resolveNfs(&file)
+func deleteImpl(target fileExecTarget, requestPath string) error {
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
 		return err
 	}
-	_, err = mokubernetes.ExecInNfsPod(
-		file.VolumeNamespace, file.VolumeName,
+	_, err = mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
 		[]string{"rm", "-rf", containerPath},
 		nil,
 	)
@@ -275,29 +466,44 @@ type FilesUploadRequest struct {
 	Id          string                        `json:"id"`
 }
 
+type FilesUploadRequestV2 struct {
+	File        dtos.PvcFileRequestDto `json:"file"`
+	SizeInBytes int64                  `json:"sizeInBytes"`
+	Id          string                 `json:"id"`
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-// resolveNfs validates the request path and returns the absolute path inside the
-// NFS container (/exports/...).
-func resolveNfs(data *dtos.PersistentFileRequestDto) (string, error) {
-	if data.Path == "" {
+// resolvePath validates the request path and returns the absolute path inside
+// the container, rooted at mountRoot. Legacy NFS callers pass "/exports".
+func resolvePath(mountRoot, requestPath string) (string, error) {
+	if requestPath == "" {
 		return "", fmt.Errorf("path cannot be empty. Must at least contain '/'")
 	}
-	if strings.Contains(data.Path, "..") {
+	if strings.Contains(requestPath, "..") {
 		return "", fmt.Errorf("path cannot contain '..'")
 	}
-	if strings.Contains(data.Path, "./") {
+	if strings.Contains(requestPath, "./") {
 		return "", fmt.Errorf("path cannot contain './'")
 	}
-	if strings.Contains(data.Path, "~") {
+	if strings.Contains(requestPath, "~") {
 		return "", fmt.Errorf("path cannot contain '~'")
 	}
 
-	relPath := strings.TrimPrefix(data.Path, "/")
+	relPath := strings.TrimPrefix(requestPath, "/")
 	if relPath == "" {
-		return "/exports", nil
+		return mountRoot, nil
 	}
-	return "/exports/" + relPath, nil
+	joined := mountRoot + "/" + relPath
+
+	// Defense in depth on top of the rejections above: the cleaned result must
+	// stay inside mountRoot. The uncleaned join is returned so legacy paths
+	// stay byte-for-byte identical (e.g. trailing slashes survive).
+	cleanedRoot := filepath.Clean(mountRoot)
+	if cleaned := filepath.Clean(joined); cleaned != cleanedRoot && !strings.HasPrefix(cleaned, cleanedRoot+"/") {
+		return "", fmt.Errorf("path escapes mount root")
+	}
+	return joined, nil
 }
 
 // parseStatLine parses one line of `stat -c '%n\t%F\t%s\t%u\t%g\t%a\t%Y'` output.

--- a/src/services/filesservice_test.go
+++ b/src/services/filesservice_test.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestResolvePath(t *testing.T) {
+	t.Run("rejects empty path", func(t *testing.T) {
+		if _, err := resolvePath("/exports", ""); err == nil {
+			t.Fatal("expected error for empty path")
+		}
+	})
+
+	t.Run("rejects traversal attempts", func(t *testing.T) {
+		for _, p := range []string{"/..", "/../etc", "/foo/../bar", "/foo/./bar", "./foo", "/~root", "~"} {
+			if _, err := resolvePath("/exports", p); err == nil {
+				t.Fatalf("expected error for path %q", p)
+			}
+		}
+	})
+
+	t.Run("root path resolves to mount root", func(t *testing.T) {
+		got, err := resolvePath("/exports", "/")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/exports" {
+			t.Fatalf("expected /exports, got %q", got)
+		}
+	})
+
+	t.Run("nested path joins below mount root", func(t *testing.T) {
+		got, err := resolvePath("/exports", "/foo/bar.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/exports/foo/bar.txt" {
+			t.Fatalf("expected /exports/foo/bar.txt, got %q", got)
+		}
+	})
+
+	t.Run("path without leading slash joins as well", func(t *testing.T) {
+		got, err := resolvePath("/exports", "foo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/exports/foo" {
+			t.Fatalf("expected /exports/foo, got %q", got)
+		}
+	})
+
+	t.Run("trailing slash is preserved for legacy compatibility", func(t *testing.T) {
+		got, err := resolvePath("/exports", "/foo/")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/exports/foo/" {
+			t.Fatalf("expected /exports/foo/, got %q", got)
+		}
+	})
+
+	t.Run("works against arbitrary mount roots", func(t *testing.T) {
+		got, err := resolvePath("/var/lib/data", "/sub/dir")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/var/lib/data/sub/dir" {
+			t.Fatalf("expected /var/lib/data/sub/dir, got %q", got)
+		}
+	})
+}

--- a/src/services/pvcmounts.go
+++ b/src/services/pvcmounts.go
@@ -1,0 +1,218 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	mokubernetes "mogenius-operator/src/kubernetes"
+	"mogenius-operator/src/store"
+	"sort"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// Typed sentinel errors so callers (socket handlers, storage/v2/info) can map
+// a failed resolution to a stable browsableReason on the wire.
+var (
+	ErrPvcNotMounted    = errors.New("pvc is not mounted by any pod")
+	ErrPvcSubPathOnly   = errors.New("pvc is only mounted via subPath mounts")
+	ErrPvcNoExecTooling = errors.New("no mounting container has the required exec tooling")
+	ErrPvcPodNotReady   = errors.New("no pod mounting the pvc is running and ready")
+)
+
+// Browsable reason strings of the storage/v2 wire contract.
+const (
+	BrowsableReasonNotMounted    = "NOT_MOUNTED"
+	BrowsableReasonSubPathOnly   = "SUBPATH_ONLY"
+	BrowsableReasonNoExecTooling = "NO_EXEC_TOOLING"
+	BrowsableReasonPodNotReady   = "POD_NOT_READY"
+)
+
+// BrowsableReasonForError maps a resolver sentinel error onto its wire reason.
+// Unknown errors map to an empty string.
+func BrowsableReasonForError(err error) string {
+	switch {
+	case errors.Is(err, ErrPvcNotMounted):
+		return BrowsableReasonNotMounted
+	case errors.Is(err, ErrPvcSubPathOnly):
+		return BrowsableReasonSubPathOnly
+	case errors.Is(err, ErrPvcNoExecTooling):
+		return BrowsableReasonNoExecTooling
+	case errors.Is(err, ErrPvcPodNotReady):
+		return BrowsableReasonPodNotReady
+	default:
+		return ""
+	}
+}
+
+// PvcMountTarget identifies one container that mounts a PVC without subPath,
+// usable as an exec substrate for file operations on that PVC.
+type PvcMountTarget struct {
+	Namespace     string
+	PodName       string
+	ContainerName string
+	MountPath     string
+}
+
+// probeFn checks whether the given container has minimal exec tooling by
+// running `stat -c %F <mountPath>` in it. Injectable for tests.
+type probeFn func(namespace, podName, containerName, mountPath string) error
+
+func defaultExecProbe(namespace, podName, containerName, mountPath string) error {
+	_, err := mokubernetes.ExecInPod(namespace, podName, containerName, []string{"stat", "-c", "%F", mountPath}, nil)
+	return err
+}
+
+// probeCache remembers capability-probe outcomes per (namespace, pod,
+// container) for a short time so repeated file operations on the same PVC do
+// not re-exec the probe on every call.
+type probeCacheEntry struct {
+	err error
+	at  time.Time
+}
+
+const probeCacheTTL = 60 * time.Second
+
+var (
+	probeCacheMu sync.Mutex
+	probeCache   = map[string]probeCacheEntry{}
+)
+
+// cachedProbe wraps probe with the ~60s (namespace, pod, container) cache.
+func cachedProbe(probe probeFn) probeFn {
+	return func(namespace, podName, containerName, mountPath string) error {
+		key := namespace + "/" + podName + "/" + containerName
+		probeCacheMu.Lock()
+		if entry, ok := probeCache[key]; ok && time.Since(entry.at) < probeCacheTTL {
+			probeCacheMu.Unlock()
+			return entry.err
+		}
+		probeCacheMu.Unlock()
+
+		err := probe(namespace, podName, containerName, mountPath)
+
+		probeCacheMu.Lock()
+		probeCache[key] = probeCacheEntry{err: err, at: time.Now()}
+		probeCacheMu.Unlock()
+		return err
+	}
+}
+
+// ResolvePvcTarget picks the container to exec file operations for the given
+// PVC in: a running pod that mounts the PVC without subPath, whose container
+// is ready and passes the exec-tooling probe. Candidates are tried in a
+// deterministic order (pod creationTimestamp, pod name, container name).
+// Returns one of the ErrPvc* sentinel errors when no usable candidate exists.
+func ResolvePvcTarget(namespace, pvcName string) (PvcMountTarget, error) {
+	pods := store.GetPods(namespace)
+	return resolvePvcTargetFrom(pods, namespace, pvcName, cachedProbe(defaultExecProbe))
+}
+
+// resolvePvcTargetFrom is the pure core of ResolvePvcTarget, split out so
+// tests can feed in-memory pods and a stubbed probe.
+func resolvePvcTargetFrom(pods []v1.Pod, namespace, pvcName string, probe probeFn) (PvcMountTarget, error) {
+	candidates, structuralErr := pvcMountCandidates(pods, namespace, pvcName)
+	if structuralErr != nil {
+		return PvcMountTarget{}, structuralErr
+	}
+
+	for _, candidate := range candidates {
+		if err := probe(candidate.Namespace, candidate.PodName, candidate.ContainerName, candidate.MountPath); err != nil {
+			serviceLogger.Debug("pvc exec probe failed, trying next candidate",
+				"namespace", candidate.Namespace, "pod", candidate.PodName, "container", candidate.ContainerName, "error", err)
+			continue
+		}
+		return candidate, nil
+	}
+
+	return PvcMountTarget{}, fmt.Errorf("%w: %s/%s", ErrPvcNoExecTooling, namespace, pvcName)
+}
+
+// pvcMountCandidates returns all structurally usable exec candidates for the
+// PVC, sorted deterministically. When none exist it returns the structural
+// sentinel error describing why (NOT_MOUNTED / SUBPATH_ONLY / POD_NOT_READY).
+func pvcMountCandidates(pods []v1.Pod, namespace, pvcName string) ([]PvcMountTarget, error) {
+	mounted := false
+	nonSubPathMount := false
+
+	type sortableCandidate struct {
+		target  PvcMountTarget
+		created time.Time
+	}
+	var candidates []sortableCandidate
+
+	for i := range pods {
+		pod := &pods[i]
+
+		// volume names in this pod backed by the requested claim
+		volumeNames := map[string]bool{}
+		for _, volume := range pod.Spec.Volumes {
+			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvcName {
+				volumeNames[volume.Name] = true
+			}
+		}
+		if len(volumeNames) == 0 {
+			continue
+		}
+
+		readyByContainer := map[string]bool{}
+		for _, status := range pod.Status.ContainerStatuses {
+			readyByContainer[status.Name] = status.Ready
+		}
+
+		// Spec.Containers only: init and ephemeral containers are no exec substrate.
+		for _, container := range pod.Spec.Containers {
+			for _, mount := range container.VolumeMounts {
+				if !volumeNames[mount.Name] {
+					continue
+				}
+				mounted = true
+				if mount.SubPath != "" || mount.SubPathExpr != "" {
+					continue
+				}
+				nonSubPathMount = true
+				if pod.Status.Phase != v1.PodRunning || !readyByContainer[container.Name] {
+					continue
+				}
+				candidates = append(candidates, sortableCandidate{
+					target: PvcMountTarget{
+						Namespace:     pod.Namespace,
+						PodName:       pod.Name,
+						ContainerName: container.Name,
+						MountPath:     mount.MountPath,
+					},
+					created: pod.CreationTimestamp.Time,
+				})
+			}
+		}
+	}
+
+	if len(candidates) == 0 {
+		switch {
+		case !mounted:
+			return nil, fmt.Errorf("%w: %s/%s", ErrPvcNotMounted, namespace, pvcName)
+		case !nonSubPathMount:
+			return nil, fmt.Errorf("%w: %s/%s", ErrPvcSubPathOnly, namespace, pvcName)
+		default:
+			return nil, fmt.Errorf("%w: %s/%s", ErrPvcPodNotReady, namespace, pvcName)
+		}
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+		if !a.created.Equal(b.created) {
+			return a.created.Before(b.created)
+		}
+		if a.target.PodName != b.target.PodName {
+			return a.target.PodName < b.target.PodName
+		}
+		return a.target.ContainerName < b.target.ContainerName
+	})
+
+	result := make([]PvcMountTarget, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, candidate.target)
+	}
+	return result, nil
+}

--- a/src/services/pvcmounts_test.go
+++ b/src/services/pvcmounts_test.go
@@ -1,0 +1,257 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+	// the resolver logs skipped candidates; tests run without Setup()
+	serviceLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type testMount struct {
+	container string
+	subPath   bool
+	ready     bool
+}
+
+// makePvcPod builds an in-memory pod that mounts claimName in the given
+// containers via a single volume named "data".
+func makePvcPod(name string, created time.Time, phase v1.PodPhase, claimName string, mounts []testMount) v1.Pod {
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "test-ns",
+			CreationTimestamp: metav1.NewTime(created),
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "data",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: claimName},
+					},
+				},
+			},
+		},
+		Status: v1.PodStatus{Phase: phase},
+	}
+	for _, mount := range mounts {
+		volumeMount := v1.VolumeMount{Name: "data", MountPath: "/mnt/data"}
+		if mount.subPath {
+			volumeMount.SubPath = "sub"
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+			Name:         mount.container,
+			VolumeMounts: []v1.VolumeMount{volumeMount},
+		})
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, v1.ContainerStatus{
+			Name:  mount.container,
+			Ready: mount.ready,
+		})
+	}
+	return pod
+}
+
+func probeOk(string, string, string, string) error { return nil }
+
+func TestResolvePvcTargetFromStructuralErrors(t *testing.T) {
+	now := time.Now()
+
+	t.Run("no pod mounts the pvc", func(t *testing.T) {
+		pods := []v1.Pod{makePvcPod("a", now, v1.PodRunning, "other-pvc", []testMount{{container: "app", ready: true}})}
+		_, err := resolvePvcTargetFrom(pods, "test-ns", "my-pvc", probeOk)
+		if !errors.Is(err, ErrPvcNotMounted) {
+			t.Fatalf("expected ErrPvcNotMounted, got %v", err)
+		}
+	})
+
+	t.Run("only subPath mounts", func(t *testing.T) {
+		pods := []v1.Pod{makePvcPod("a", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", subPath: true, ready: true}})}
+		_, err := resolvePvcTargetFrom(pods, "test-ns", "my-pvc", probeOk)
+		if !errors.Is(err, ErrPvcSubPathOnly) {
+			t.Fatalf("expected ErrPvcSubPathOnly, got %v", err)
+		}
+	})
+
+	t.Run("pod not running", func(t *testing.T) {
+		pods := []v1.Pod{makePvcPod("a", now, v1.PodPending, "my-pvc", []testMount{{container: "app", ready: false}})}
+		_, err := resolvePvcTargetFrom(pods, "test-ns", "my-pvc", probeOk)
+		if !errors.Is(err, ErrPvcPodNotReady) {
+			t.Fatalf("expected ErrPvcPodNotReady, got %v", err)
+		}
+	})
+
+	t.Run("container not ready", func(t *testing.T) {
+		pods := []v1.Pod{makePvcPod("a", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: false}})}
+		_, err := resolvePvcTargetFrom(pods, "test-ns", "my-pvc", probeOk)
+		if !errors.Is(err, ErrPvcPodNotReady) {
+			t.Fatalf("expected ErrPvcPodNotReady, got %v", err)
+		}
+	})
+}
+
+func TestResolvePvcTargetFromDeterministicOrder(t *testing.T) {
+	now := time.Now()
+
+	t.Run("oldest pod wins", func(t *testing.T) {
+		pods := []v1.Pod{
+			makePvcPod("younger", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}}),
+			makePvcPod("older", now.Add(-time.Hour), v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}}),
+		}
+		target, err := resolvePvcTargetFrom(pods, "test-ns", "my-pvc", probeOk)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if target.PodName != "older" {
+			t.Fatalf("expected pod 'older', got %q", target.PodName)
+		}
+	})
+
+	t.Run("equal timestamps fall back to pod name, then container name", func(t *testing.T) {
+		pods := []v1.Pod{
+			makePvcPod("pod-b", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}}),
+			makePvcPod("pod-a", now, v1.PodRunning, "my-pvc", []testMount{
+				{container: "zeta", ready: true},
+				{container: "alpha", ready: true},
+			}),
+		}
+		target, err := resolvePvcTargetFrom(pods, "test-ns", "my-pvc", probeOk)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if target.PodName != "pod-a" || target.ContainerName != "alpha" {
+			t.Fatalf("expected pod-a/alpha, got %s/%s", target.PodName, target.ContainerName)
+		}
+		if target.MountPath != "/mnt/data" {
+			t.Fatalf("expected mount path /mnt/data, got %q", target.MountPath)
+		}
+	})
+}
+
+func TestResolvePvcTargetFromProbe(t *testing.T) {
+	now := time.Now()
+
+	t.Run("failing probe skips to the next candidate", func(t *testing.T) {
+		pods := []v1.Pod{
+			makePvcPod("first", now.Add(-time.Hour), v1.PodRunning, "my-pvc", []testMount{{container: "distroless", ready: true}}),
+			makePvcPod("second", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}}),
+		}
+		probe := func(_, pod, container, _ string) error {
+			if container == "distroless" {
+				return fmt.Errorf("exec failed: executable file not found")
+			}
+			return nil
+		}
+		target, err := resolvePvcTargetFrom(pods, "test-ns", "my-pvc", probe)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if target.PodName != "second" || target.ContainerName != "app" {
+			t.Fatalf("expected second/app, got %s/%s", target.PodName, target.ContainerName)
+		}
+	})
+
+	t.Run("all probes failing yields ErrPvcNoExecTooling", func(t *testing.T) {
+		pods := []v1.Pod{
+			makePvcPod("a", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}}),
+		}
+		probe := func(string, string, string, string) error { return fmt.Errorf("no tooling") }
+		_, err := resolvePvcTargetFrom(pods, "test-ns", "my-pvc", probe)
+		if !errors.Is(err, ErrPvcNoExecTooling) {
+			t.Fatalf("expected ErrPvcNoExecTooling, got %v", err)
+		}
+	})
+}
+
+func TestBrowsableReasonForError(t *testing.T) {
+	cases := map[string]struct {
+		err    error
+		reason string
+	}{
+		"not mounted":     {fmt.Errorf("wrap: %w", ErrPvcNotMounted), BrowsableReasonNotMounted},
+		"subpath only":    {ErrPvcSubPathOnly, BrowsableReasonSubPathOnly},
+		"no exec tooling": {ErrPvcNoExecTooling, BrowsableReasonNoExecTooling},
+		"pod not ready":   {ErrPvcPodNotReady, BrowsableReasonPodNotReady},
+		"unknown":         {errors.New("boom"), ""},
+	}
+	for name, c := range cases {
+		if got := BrowsableReasonForError(c.err); got != c.reason {
+			t.Errorf("%s: expected %q, got %q", name, c.reason, got)
+		}
+	}
+}
+
+func TestComputeMountsStructural(t *testing.T) {
+	now := time.Now()
+
+	index := func(pods ...v1.Pod) namespacePodIndex {
+		idx := namespacePodIndex{pods: pods, podsPerClaim: map[string][]int{}}
+		for i := range pods {
+			for _, volume := range pods[i].Spec.Volumes {
+				if volume.PersistentVolumeClaim != nil {
+					claim := volume.PersistentVolumeClaim.ClaimName
+					idx.podsPerClaim[claim] = append(idx.podsPerClaim[claim], i)
+				}
+			}
+		}
+		return idx
+	}
+
+	t.Run("running ready non-subPath mount is browsable", func(t *testing.T) {
+		idx := index(makePvcPod("a", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}}))
+		mounts, browsable, reason := computeMounts(idx, "my-pvc")
+		if !browsable || reason != "" {
+			t.Fatalf("expected browsable with empty reason, got browsable=%v reason=%q", browsable, reason)
+		}
+		if len(mounts) != 1 || mounts[0].PodName != "a" || mounts[0].ControllerKind != "Pod" || mounts[0].ControllerName != "a" {
+			t.Fatalf("unexpected mounts: %+v", mounts)
+		}
+	})
+
+	t.Run("no mounts", func(t *testing.T) {
+		idx := index(makePvcPod("a", now, v1.PodRunning, "other", []testMount{{container: "app", ready: true}}))
+		mounts, browsable, reason := computeMounts(idx, "my-pvc")
+		if browsable || reason != BrowsableReasonNotMounted || len(mounts) != 0 {
+			t.Fatalf("expected NOT_MOUNTED, got browsable=%v reason=%q mounts=%d", browsable, reason, len(mounts))
+		}
+	})
+
+	t.Run("subPath only", func(t *testing.T) {
+		idx := index(makePvcPod("a", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", subPath: true, ready: true}}))
+		mounts, browsable, reason := computeMounts(idx, "my-pvc")
+		if browsable || reason != BrowsableReasonSubPathOnly {
+			t.Fatalf("expected SUBPATH_ONLY, got browsable=%v reason=%q", browsable, reason)
+		}
+		if len(mounts) != 1 || !mounts[0].SubPath {
+			t.Fatalf("expected one subPath mount entry, got %+v", mounts)
+		}
+	})
+
+	t.Run("pod not ready", func(t *testing.T) {
+		idx := index(makePvcPod("a", now, v1.PodPending, "my-pvc", []testMount{{container: "app", ready: false}}))
+		_, browsable, reason := computeMounts(idx, "my-pvc")
+		if browsable || reason != BrowsableReasonPodNotReady {
+			t.Fatalf("expected POD_NOT_READY, got browsable=%v reason=%q", browsable, reason)
+		}
+	})
+
+	t.Run("direct owner is attributed without replicaset walk", func(t *testing.T) {
+		pod := makePvcPod("db-0", now, v1.PodRunning, "my-pvc", []testMount{{container: "db", ready: true}})
+		controller := true
+		pod.OwnerReferences = []metav1.OwnerReference{{Kind: "StatefulSet", Name: "db", Controller: &controller}}
+		idx := index(pod)
+		mounts, _, _ := computeMounts(idx, "my-pvc")
+		if len(mounts) != 1 || mounts[0].ControllerKind != "StatefulSet" || mounts[0].ControllerName != "db" {
+			t.Fatalf("unexpected controller attribution: %+v", mounts)
+		}
+	})
+}

--- a/src/services/storageinfo.go
+++ b/src/services/storageinfo.go
@@ -1,0 +1,375 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	mokubernetes "mogenius-operator/src/kubernetes"
+	"mogenius-operator/src/store"
+	"sort"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PV annotation carrying the provisioner that created the volume.
+const pvProvisionedByAnnotation = "pv.kubernetes.io/provisioned-by"
+
+// ── wire types (storage/v2/info, storage/v2/stats) ────────────────────────────
+
+type StorageV2InfoRequestItem struct {
+	Namespace string `json:"namespace" validate:"required"`
+	PvcName   string `json:"pvcName" validate:"required"`
+}
+
+type StorageV2InfoRequest struct {
+	Items      []StorageV2InfoRequestItem `json:"items" validate:"required"`
+	WithEvents bool                       `json:"withEvents"`
+}
+
+type StorageV2MountedBy struct {
+	PodName        string `json:"podName"`
+	ControllerKind string `json:"controllerKind"`
+	ControllerName string `json:"controllerName"`
+	ContainerName  string `json:"containerName"`
+	MountPath      string `json:"mountPath"`
+	SubPath        bool   `json:"subPath"`
+	Ready          bool   `json:"ready"`
+}
+
+type StorageV2Event struct {
+	Type          string `json:"type"`
+	Reason        string `json:"reason"`
+	Message       string `json:"message"`
+	LastTimestamp string `json:"lastTimestamp"`
+}
+
+type StorageV2InfoItem struct {
+	Namespace        string               `json:"namespace"`
+	PvcName          string               `json:"pvcName"`
+	Phase            string               `json:"phase"`
+	RequestedBytes   int64                `json:"requestedBytes"`
+	CapacityBytes    int64                `json:"capacityBytes"`
+	StorageClassName string               `json:"storageClassName"`
+	AccessModes      []string             `json:"accessModes"`
+	VolumeName       string               `json:"volumeName"`
+	VolumeMode       string               `json:"volumeMode"`
+	Provisioner      string               `json:"provisioner"`
+	MountedBy        []StorageV2MountedBy `json:"mountedBy"`
+	Browsable        bool                 `json:"browsable"`
+	BrowsableReason  string               `json:"browsableReason"`
+	Events           []StorageV2Event     `json:"events,omitempty"`
+}
+
+type StorageV2InfoResponse struct {
+	Items []StorageV2InfoItem `json:"items"`
+}
+
+type StorageV2StatsResponse struct {
+	TotalBytes      uint64 `json:"totalBytes"`
+	UsedBytes       uint64 `json:"usedBytes"`
+	FreeBytes       uint64 `json:"freeBytes"`
+	SourcePod       string `json:"sourcePod"`
+	SourceContainer string `json:"sourceContainer"`
+}
+
+// ── storage/v2/stats ──────────────────────────────────────────────────────────
+
+// StorageV2Stats resolves the exec target for the PVC and reads filesystem
+// usage via `df -B1 <mountPath>` in that container.
+func StorageV2Stats(namespace, pvcName string) (StorageV2StatsResponse, error) {
+	target, err := ResolvePvcTarget(namespace, pvcName)
+	if err != nil {
+		return StorageV2StatsResponse{}, err
+	}
+
+	free, used, total, err := mokubernetes.PodDiskUsage(target.Namespace, target.PodName, target.ContainerName, target.MountPath)
+	if err != nil {
+		return StorageV2StatsResponse{}, err
+	}
+
+	return StorageV2StatsResponse{
+		TotalBytes:      total,
+		UsedBytes:       used,
+		FreeBytes:       free,
+		SourcePod:       target.PodName,
+		SourceContainer: target.ContainerName,
+	}, nil
+}
+
+// ── storage/v2/info ───────────────────────────────────────────────────────────
+
+// pvcPodMounts maps claimName → pods (by index into the namespace pod slice)
+// that reference the claim, built with ONE scan over the namespace's pods.
+type namespacePodIndex struct {
+	pods         []v1.Pod
+	podsPerClaim map[string][]int
+}
+
+func buildNamespacePodIndex(namespace string) namespacePodIndex {
+	pods := store.GetPods(namespace)
+	index := namespacePodIndex{pods: pods, podsPerClaim: map[string][]int{}}
+	for i := range pods {
+		seen := map[string]bool{}
+		for _, volume := range pods[i].Spec.Volumes {
+			if volume.PersistentVolumeClaim == nil {
+				continue
+			}
+			claim := volume.PersistentVolumeClaim.ClaimName
+			if !seen[claim] {
+				seen[claim] = true
+				index.podsPerClaim[claim] = append(index.podsPerClaim[claim], i)
+			}
+		}
+	}
+	return index
+}
+
+// StorageV2Info builds the batch PVC info of the storage/v2/info contract.
+// It scans the pods of every distinct namespace in the batch exactly once.
+func StorageV2Info(request StorageV2InfoRequest) (StorageV2InfoResponse, error) {
+	response := StorageV2InfoResponse{Items: []StorageV2InfoItem{}}
+
+	// one pod scan per distinct namespace
+	podIndexes := map[string]namespacePodIndex{}
+	for _, item := range request.Items {
+		if _, ok := podIndexes[item.Namespace]; !ok {
+			podIndexes[item.Namespace] = buildNamespacePodIndex(item.Namespace)
+		}
+	}
+
+	for _, item := range request.Items {
+		infoItem := StorageV2InfoItem{
+			Namespace:   item.Namespace,
+			PvcName:     item.PvcName,
+			AccessModes: []string{},
+			MountedBy:   []StorageV2MountedBy{},
+		}
+
+		pvc := getPvc(item.Namespace, item.PvcName)
+		var pv *v1.PersistentVolume
+		if pvc != nil {
+			fillPvcFields(&infoItem, pvc)
+			if pvc.Spec.VolumeName != "" {
+				pv = getPv(pvc.Spec.VolumeName)
+				if pv != nil {
+					infoItem.Provisioner = pv.Annotations[pvProvisionedByAnnotation]
+				}
+			}
+		}
+
+		index := podIndexes[item.Namespace]
+		infoItem.MountedBy, infoItem.Browsable, infoItem.BrowsableReason = computeMounts(index, item.PvcName)
+
+		if request.WithEvents {
+			pvName := ""
+			if pv != nil {
+				pvName = pv.Name
+			}
+			infoItem.Events = collectPvcEvents(item.Namespace, item.PvcName, pvName)
+		}
+
+		response.Items = append(response.Items, infoItem)
+	}
+
+	return response, nil
+}
+
+// fillPvcFields copies the PVC-derived fields of the wire contract.
+func fillPvcFields(item *StorageV2InfoItem, pvc *v1.PersistentVolumeClaim) {
+	item.Phase = string(pvc.Status.Phase)
+	item.VolumeName = pvc.Spec.VolumeName
+
+	if requested, ok := pvc.Spec.Resources.Requests[v1.ResourceStorage]; ok {
+		item.RequestedBytes = requested.Value()
+	}
+	if capacity, ok := pvc.Status.Capacity[v1.ResourceStorage]; ok {
+		item.CapacityBytes = capacity.Value()
+	}
+
+	if pvc.Spec.StorageClassName != nil {
+		item.StorageClassName = *pvc.Spec.StorageClassName
+	}
+	if pvc.Spec.VolumeMode != nil {
+		item.VolumeMode = string(*pvc.Spec.VolumeMode)
+	}
+
+	// actual (status) modes once bound, requested (spec) modes before
+	accessModes := pvc.Status.AccessModes
+	if len(accessModes) == 0 {
+		accessModes = pvc.Spec.AccessModes
+	}
+	for _, mode := range accessModes {
+		item.AccessModes = append(item.AccessModes, string(mode))
+	}
+}
+
+// computeMounts builds the mountedBy entries and the structural browsable
+// verdict for one PVC from the pre-built namespace pod index.
+//
+// Browsable is computed structurally only: a running pod with a ready
+// container mounting the PVC without subPath → browsable=true (tentatively).
+// NOT_MOUNTED / SUBPATH_ONLY / POD_NOT_READY are structural reasons.
+// NO_EXEC_TOOLING is deliberately NOT probed here — exec-probing every PVC in
+// a batch listing would be far too expensive; it surfaces only when an actual
+// file operation or stats call fails the probe (via ErrPvcNoExecTooling).
+func computeMounts(index namespacePodIndex, pvcName string) ([]StorageV2MountedBy, bool, string) {
+	mountedBy := []StorageV2MountedBy{}
+	browsable := false
+	anyNonSubPath := false
+
+	for _, podIdx := range index.podsPerClaim[pvcName] {
+		pod := &index.pods[podIdx]
+
+		volumeNames := map[string]bool{}
+		for _, volume := range pod.Spec.Volumes {
+			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvcName {
+				volumeNames[volume.Name] = true
+			}
+		}
+
+		readyByContainer := map[string]bool{}
+		for _, status := range pod.Status.ContainerStatuses {
+			readyByContainer[status.Name] = status.Ready
+		}
+
+		controllerKind, controllerName := controllerForPod(pod)
+
+		for _, container := range pod.Spec.Containers {
+			for _, mount := range container.VolumeMounts {
+				if !volumeNames[mount.Name] {
+					continue
+				}
+				subPath := mount.SubPath != "" || mount.SubPathExpr != ""
+				ready := readyByContainer[container.Name]
+				mountedBy = append(mountedBy, StorageV2MountedBy{
+					PodName:        pod.Name,
+					ControllerKind: controllerKind,
+					ControllerName: controllerName,
+					ContainerName:  container.Name,
+					MountPath:      mount.MountPath,
+					SubPath:        subPath,
+					Ready:          ready,
+				})
+				if !subPath {
+					anyNonSubPath = true
+					if pod.Status.Phase == v1.PodRunning && ready {
+						browsable = true
+					}
+				}
+			}
+		}
+	}
+
+	reason := ""
+	if !browsable {
+		switch {
+		case len(mountedBy) == 0:
+			reason = BrowsableReasonNotMounted
+		case !anyNonSubPath:
+			reason = BrowsableReasonSubPathOnly
+		default:
+			reason = BrowsableReasonPodNotReady
+		}
+	}
+	return mountedBy, browsable, reason
+}
+
+// controllerForPod walks the pod's ownerReferences to the workload the user
+// knows: a ReplicaSet owner is resolved to its own owner (the Deployment)
+// when present; any other owner (StatefulSet, DaemonSet, Job, …) is used
+// directly. A bare pod attributes to itself.
+func controllerForPod(pod *v1.Pod) (kind string, name string) {
+	owner := controllerOwnerRef(pod.OwnerReferences)
+	if owner == nil {
+		return "Pod", pod.Name
+	}
+
+	if owner.Kind == "ReplicaSet" {
+		if replicaSet := store.GetReplicaset(pod.Namespace, owner.Name); replicaSet != nil {
+			if rsOwner := controllerOwnerRef(replicaSet.OwnerReferences); rsOwner != nil {
+				return rsOwner.Kind, rsOwner.Name
+			}
+		}
+	}
+
+	return owner.Kind, owner.Name
+}
+
+// controllerOwnerRef returns the controlling ownerReference, falling back to
+// the first one when none is flagged as controller.
+func controllerOwnerRef(refs []metav1.OwnerReference) *metav1.OwnerReference {
+	for i := range refs {
+		if refs[i].Controller != nil && *refs[i].Controller {
+			return &refs[i]
+		}
+	}
+	if len(refs) > 0 {
+		return &refs[0]
+	}
+	return nil
+}
+
+// getPvc reads the PVC from the store, falling back to the live API when the
+// store has no copy (e.g. right after a store wipe).
+func getPvc(namespace, name string) *v1.PersistentVolumeClaim {
+	if pvc := store.GetPersistentVolumeClaim(namespace, name); pvc != nil {
+		return pvc
+	}
+	pvc, err := clientProvider.K8sClientSet().CoreV1().PersistentVolumeClaims(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		serviceLogger.Warn("failed to get PVC", "namespace", namespace, "name", name, "error", err)
+		return nil
+	}
+	return pvc
+}
+
+// getPv reads the PV from the store, falling back to the live API.
+func getPv(name string) *v1.PersistentVolume {
+	if pv := store.GetPersistentVolume(name); pv != nil {
+		return pv
+	}
+	pv, err := clientProvider.K8sClientSet().CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		serviceLogger.Warn("failed to get PV", "name", name, "error", err)
+		return nil
+	}
+	return pv
+}
+
+// collectPvcEvents lists the events for the PVC and (when bound) its PV,
+// newest first. Queries are namespaced to the PVC's namespace, matching the
+// legacy storagestatus behavior.
+func collectPvcEvents(namespace, pvcName, pvName string) []StorageV2Event {
+	events := []StorageV2Event{}
+	events = append(events, listEventsFor(namespace, pvcName, "PersistentVolumeClaim")...)
+	if pvName != "" {
+		events = append(events, listEventsFor(namespace, pvName, "PersistentVolume")...)
+	}
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].LastTimestamp > events[j].LastTimestamp
+	})
+	return events
+}
+
+func listEventsFor(namespace, name, kind string) []StorageV2Event {
+	fieldSelector := fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=%s", name, kind)
+	eventList, err := clientProvider.K8sClientSet().CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{
+		FieldSelector: fieldSelector,
+	})
+	if err != nil {
+		serviceLogger.Warn("failed to list events", "namespace", namespace, "name", name, "kind", kind, "error", err)
+		return nil
+	}
+
+	result := make([]StorageV2Event, 0, len(eventList.Items))
+	for _, event := range eventList.Items {
+		result = append(result, StorageV2Event{
+			Type:          event.Type,
+			Reason:        event.Reason,
+			Message:       event.Message,
+			LastTimestamp: event.LastTimestamp.Format(time.RFC3339),
+		})
+	}
+	return result
+}

--- a/src/store/store.go
+++ b/src/store/store.go
@@ -1540,6 +1540,22 @@ func GetPods(namespace string) []coreV1.Pod {
 	return pods
 }
 
+func GetPersistentVolumeClaim(namespace string, name string) *coreV1.PersistentVolumeClaim {
+	pvc, err := valkeyclient.GetObjectForKey[coreV1.PersistentVolumeClaim](valkeyClient, VALKEY_RESOURCE_PREFIX, utils.PersistentVolumeClaimResource.ApiVersion, utils.PersistentVolumeClaimResource.Kind, namespace, name)
+	if err != nil || pvc == nil {
+		return nil
+	}
+	return pvc
+}
+
+func GetPersistentVolume(name string) *coreV1.PersistentVolume {
+	pv, err := valkeyclient.GetObjectForKey[coreV1.PersistentVolume](valkeyClient, VALKEY_RESOURCE_PREFIX, utils.PersistentVolumeResource.ApiVersion, utils.PersistentVolumeResource.Kind, "", name)
+	if err != nil || pv == nil {
+		return nil
+	}
+	return pv
+}
+
 func GetReplicaset(namespace string, name string) *v1.ReplicaSet {
 	replicaSet, err := valkeyclient.GetObjectForKey[v1.ReplicaSet](valkeyClient, VALKEY_RESOURCE_PREFIX, utils.ReplicaSetResource.ApiVersion, utils.ReplicaSetResource.Kind, namespace, name)
 	if err != nil || replicaSet == nil {

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -91,6 +91,20 @@ var PodResource = ResourceDescriptor{
 	Namespaced: true,
 }
 
+var PersistentVolumeClaimResource = ResourceDescriptor{
+	Kind:       "PersistentVolumeClaim",
+	Plural:     "persistentvolumeclaims",
+	ApiVersion: "v1",
+	Namespaced: true,
+}
+
+var PersistentVolumeResource = ResourceDescriptor{
+	Kind:       "PersistentVolume",
+	Plural:     "persistentvolumes",
+	ApiVersion: "v1",
+	Namespaced: false,
+}
+
 var IngressClassResource = ResourceDescriptor{
 	Kind:       "IngressClass",
 	Plural:     "ingressclasses",


### PR DESCRIPTION
Additive only — legacy `storage/*`/`files/*` handlers keep working (removal follows after the deprecation window, once no API calls them anymore).

- New patterns: `storage/v2/info` (batch: phase, capacity, storageClass, accessModes, mountedBy incl. controller attribution, browsable/reason), `storage/v2/stats` (df on the mountPath), `files/v2/*` incl. binary upload (`ack:files/v2/upload:*`)
- `pvcmounts.go`: resolves (pod, container, mountPath) for a PVC — running+ready, no subPath, `stat` capability probe with 60s cache (distroless-safe), deterministic ordering
- Exec/file ops generalized (`ExecInPod`, `resolvePath` with escape assertion); NFS path now a thin wrapper
- Unit tests: path traversal, df parsing, candidate selection

`go build`/`go vet`/`go test ./src/...` green; pre-existing `test/helm`+`test/kubernetes` failures unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)