### PR TITLE
feat(storage): helper mounter pod for unmounted PVCs

### DIFF
--- a/src/cmd/cluster.go
+++ b/src/cmd/cluster.go
@@ -274,6 +274,9 @@ func startClusterSystems(logManagerModule logging.SlogManager, configModule *con
 	systems.podStatsCollector.Run()
 	logStep("Pod stats collector started")
 
+	services.StartStorageHelperReaper()
+	logStep("Storage helper reaper started")
+
 	systems.nodeMetricsCollector.Orchestrate()
 	logStep("Node metrics collector started")
 

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -384,6 +384,28 @@ func LoadConfigDeclarations(configModule *config.Config) {
 		},
 	})
 	configModule.Declare(config.ConfigDeclaration{
+		Key:          "MO_STORAGE_HELPER_TTL",
+		DefaultValue: new("15m"),
+		Description:  new("idle TTL after which an unused storage helper pod (PVC browsing) is deleted, as Go duration"),
+		Envs:         []string{"storage_helper_ttl"},
+		Validate: func(value string) error {
+			ttl, err := time.ParseDuration(value)
+			if err != nil {
+				return fmt.Errorf("'MO_STORAGE_HELPER_TTL' needs to be a Go duration (e.g. 15m): %s", err.Error())
+			}
+			if ttl <= 0 {
+				return fmt.Errorf("'MO_STORAGE_HELPER_TTL' needs to be positive")
+			}
+			return nil
+		},
+	})
+	configModule.Declare(config.ConfigDeclaration{
+		Key:          "MO_STORAGE_HELPER_IMAGE",
+		DefaultValue: new("busybox:1.37"),
+		Description:  new("image of the ephemeral storage helper pod that mounts a PVC for browsing"),
+		Envs:         []string{"storage_helper_image"},
+	})
+	configModule.Declare(config.ConfigDeclaration{
 		Key:          "MO_ENABLE_POD_STATS_COLLECTOR",
 		DefaultValue: new("true"),
 		Description:  new("enable collection of pod stats"),

--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -2796,6 +2796,29 @@ func (self *socketApi) registerPatterns() {
 				return services.StorageV2Stats(request.Namespace, request.PvcName)
 			},
 		)
+
+		// storage/v2/mount: ensure an ephemeral helper pod mounts the PVC so the
+		// exec-based file operations work on an otherwise unmounted volume.
+		// Idempotent: an existing helper pod is reported with its current state.
+		RegisterPatternHandler(
+			PatternHandle{self, "storage/v2/mount"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (services.StorageV2MountResponse, error) {
+				response, err := services.StorageV2Mount(request.Namespace, request.PvcName)
+				return store.AddToAuditLog(datagram, self.logger, response, err, nil, nil)
+			},
+		)
+
+		// storage/v2/unmount: delete the helper pod for the PVC. Idempotent:
+		// true even when no helper pod exists.
+		RegisterPatternHandler(
+			PatternHandle{self, "storage/v2/unmount"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (bool, error) {
+				err := services.StorageV2Unmount(request.Namespace, request.PvcName)
+				return store.AddToAuditLog(datagram, self.logger, err == nil, err, nil, nil)
+			},
+		)
 	}
 
 	{

--- a/src/services/pvcmounts.go
+++ b/src/services/pvcmounts.go
@@ -106,7 +106,13 @@ func cachedProbe(probe probeFn) probeFn {
 // Returns one of the ErrPvc* sentinel errors when no usable candidate exists.
 func ResolvePvcTarget(namespace, pvcName string) (PvcMountTarget, error) {
 	pods := store.GetPods(namespace)
-	return resolvePvcTargetFrom(pods, namespace, pvcName, cachedProbe(defaultExecProbe))
+	target, err := resolvePvcTargetFrom(pods, namespace, pvcName, cachedProbe(defaultExecProbe))
+	if err == nil {
+		// single funnel of all files/v2 and storage/v2/stats calls: keep the
+		// idle-TTL reaper away from helper pods that are actively used
+		touchStorageHelperIfTarget(pods, target)
+	}
+	return target, err
 }
 
 // resolvePvcTargetFrom is the pure core of ResolvePvcTarget, split out so

--- a/src/services/storagehelper.go
+++ b/src/services/storagehelper.go
@@ -1,0 +1,439 @@
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	mokubernetes "mogenius-operator/src/kubernetes"
+	"mogenius-operator/src/shutdown"
+	"mogenius-operator/src/store"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// Storage helper pods: operator-managed ephemeral busybox pods that mount an
+// otherwise unmounted PVC at /data, so the existing exec-based file operations
+// (files/v2/*, storage/v2/stats) have a pod to run in. Created on demand via
+// storage/v2/mount, removed via storage/v2/unmount or by the idle reaper.
+
+const (
+	// StorageHelperLabelKey marks helper pods. Identification is this label
+	// plus spec.volumes[].persistentVolumeClaim.claimName — never the pod
+	// name, and never a pvc-name label value (63-char label limit).
+	StorageHelperLabelKey   = "mogenius.io/storage-helper"
+	StorageHelperLabelValue = "true"
+
+	storageHelperNamePrefix    = "mo-storage-helper-"
+	storageHelperContainerName = "helper"
+	storageHelperMountPath     = "/data"
+
+	// Fallback defaults; overridable via MO_STORAGE_HELPER_TTL and
+	// MO_STORAGE_HELPER_IMAGE (declared in cmd.go).
+	defaultStorageHelperTTL   = 15 * time.Minute
+	defaultStorageHelperImage = "busybox:1.37"
+
+	// storageHelperReapInterval is how often the reaper scans for idle pods.
+	storageHelperReapInterval = 60 * time.Second
+)
+
+// Wire statuses of the storage/v2/mount response.
+const (
+	StorageHelperStatusStarting = "STARTING"
+	StorageHelperStatusReady    = "READY"
+)
+
+type StorageV2MountResponse struct {
+	PodName string `json:"podName"`
+	Status  string `json:"status"`
+}
+
+// ── pod naming ────────────────────────────────────────────────────────────────
+
+// StorageHelperPodName derives the helper pod name for a PVC:
+// "mo-storage-helper-<pvcName>" kept within the 63-char DNS-1123 label limit.
+// When the pvc name must be truncated or sanitized, a short sha256 suffix of
+// the ORIGINAL name keeps two long/odd pvc names from colliding.
+func StorageHelperPodName(pvcName string) string {
+	maxMiddle := validation.DNS1123LabelMaxLength - len(storageHelperNamePrefix)
+
+	middle := sanitizeNameSegment(pvcName)
+	if middle == pvcName && len(middle) <= maxMiddle {
+		return storageHelperNamePrefix + middle
+	}
+
+	hash := sha256.Sum256([]byte(pvcName))
+	suffix := hex.EncodeToString(hash[:])[:10]
+	if len(middle) > maxMiddle-len(suffix)-1 {
+		middle = middle[:maxMiddle-len(suffix)-1]
+	}
+	middle = strings.TrimRight(middle, "-")
+	if middle == "" {
+		return storageHelperNamePrefix + suffix
+	}
+	return storageHelperNamePrefix + middle + "-" + suffix
+}
+
+// sanitizeNameSegment lowercases s and replaces everything outside
+// [a-z0-9-] with '-', trimming leading/trailing dashes.
+func sanitizeNameSegment(s string) string {
+	s = strings.ToLower(s)
+	var builder strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			builder.WriteRune(r)
+		} else {
+			builder.WriteByte('-')
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+// ── config accessors (fall back to constants when config is not set up) ──────
+
+func storageHelperTTL() time.Duration {
+	if config != nil {
+		if value, err := config.TryGet("MO_STORAGE_HELPER_TTL"); err == nil {
+			if ttl, parseErr := time.ParseDuration(value); parseErr == nil && ttl > 0 {
+				return ttl
+			}
+		}
+	}
+	return defaultStorageHelperTTL
+}
+
+func storageHelperImage() string {
+	if config != nil {
+		if value, err := config.TryGet("MO_STORAGE_HELPER_IMAGE"); err == nil && value != "" {
+			return value
+		}
+	}
+	return defaultStorageHelperImage
+}
+
+// ── pod spec ──────────────────────────────────────────────────────────────────
+
+// buildStorageHelperPod builds the plain v1 Pod that mounts the PVC at /data.
+// Runs as root (busybox default) but unprivileged: allowPrivilegeEscalation
+// false, no host mounts. Capabilities are deliberately NOT dropped — the file
+// operations exec chown/chmod as uid 0, which needs CAP_CHOWN/CAP_FOWNER from
+// the default capability set.
+func buildStorageHelperPod(namespace, pvcName string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      StorageHelperPodName(pvcName),
+			Namespace: namespace,
+			Labels: map[string]string{
+				StorageHelperLabelKey:          StorageHelperLabelValue,
+				"app.kubernetes.io/managed-by": "mogenius-k8s-manager",
+			},
+		},
+		Spec: v1.PodSpec{
+			// RWO note: the UI only offers mounting for NOT_MOUNTED PVCs, so an
+			// RWO volume attached elsewhere is not expected here. No node
+			// affinity logic in v1 — the scheduler places pods for unattached
+			// volumes; a pod stuck Pending simply reports STARTING and the idle
+			// reaper removes it after the TTL.
+			RestartPolicy:                 v1.RestartPolicyAlways,
+			TerminationGracePeriodSeconds: new(int64(5)),
+			Volumes: []v1.Volume{
+				{
+					Name: "data",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:    storageHelperContainerName,
+					Image:   storageHelperImage(),
+					Command: []string{"sh", "-c", "trap 'exit 0' TERM; while true; do sleep 3600 & wait $!; done"},
+					VolumeMounts: []v1.VolumeMount{
+						{Name: "data", MountPath: storageHelperMountPath},
+					},
+					SecurityContext: &v1.SecurityContext{
+						Privileged:               new(false),
+						AllowPrivilegeEscalation: new(false),
+					},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("10m"),
+							v1.ResourceMemory: resource.MustParse("16Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// ── helper pod detection ──────────────────────────────────────────────────────
+
+// isStorageHelperPod reports whether the pod carries the helper label.
+func isStorageHelperPod(pod *v1.Pod) bool {
+	return pod.Labels[StorageHelperLabelKey] == StorageHelperLabelValue
+}
+
+// podClaimsPvc reports whether the pod references the claim in spec.volumes.
+func podClaimsPvc(pod *v1.Pod, pvcName string) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvcName {
+			return true
+		}
+	}
+	return false
+}
+
+// findStorageHelperPod returns the first helper pod claiming the PVC, nil when
+// none exists. Identification via label + claimName, not via the pod name.
+func findStorageHelperPod(pods []v1.Pod, pvcName string) *v1.Pod {
+	for i := range pods {
+		if isStorageHelperPod(&pods[i]) && podClaimsPvc(&pods[i], pvcName) {
+			return &pods[i]
+		}
+	}
+	return nil
+}
+
+// helperMountedFor reports whether at least one pod referencing the PVC in the
+// pre-built namespace pod index carries the helper label (storage/v2/info's
+// helperMounted field).
+func helperMountedFor(index namespacePodIndex, pvcName string) bool {
+	for _, podIdx := range index.podsPerClaim[pvcName] {
+		if isStorageHelperPod(&index.pods[podIdx]) {
+			return true
+		}
+	}
+	return false
+}
+
+// storageHelperStatus maps a helper pod's state onto the wire status.
+func storageHelperStatus(pod *v1.Pod) string {
+	if pod.Status.Phase != v1.PodRunning {
+		return StorageHelperStatusStarting
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == storageHelperContainerName && status.Ready {
+			return StorageHelperStatusReady
+		}
+	}
+	return StorageHelperStatusStarting
+}
+
+// ── mount / unmount ──────────────────────────────────────────────────────────
+
+// StorageV2Mount ensures a helper pod exists for the PVC (idempotent): an
+// existing helper pod is reported with its current state, otherwise the pod is
+// created and reported as STARTING.
+func StorageV2Mount(namespace, pvcName string) (StorageV2MountResponse, error) {
+	// existing helper pod: store first, live fallback by derived name
+	if existing := findStorageHelperPod(store.GetPods(namespace), pvcName); existing != nil {
+		helperTracker.touch(namespace, existing.Name)
+		return StorageV2MountResponse{PodName: existing.Name, Status: storageHelperStatus(existing)}, nil
+	}
+
+	podName := StorageHelperPodName(pvcName)
+	podClient := clientProvider.K8sClientSet().CoreV1().Pods(namespace)
+	if live, err := podClient.Get(context.Background(), podName, metav1.GetOptions{}); err == nil {
+		if isStorageHelperPod(live) && podClaimsPvc(live, pvcName) {
+			helperTracker.touch(namespace, live.Name)
+			return StorageV2MountResponse{PodName: live.Name, Status: storageHelperStatus(live)}, nil
+		}
+		// name collision with a foreign pod — refuse instead of adopting it
+		return StorageV2MountResponse{}, fmt.Errorf("pod %s/%s already exists and is not a mogenius storage helper", namespace, podName)
+	}
+
+	pod := buildStorageHelperPod(namespace, pvcName)
+	_, err := podClient.Create(context.Background(), pod, mokubernetes.MoCreateOptions(config))
+	switch {
+	case err == nil:
+		serviceLogger.Info("created storage helper pod", "namespace", namespace, "pvc", pvcName, "pod", podName)
+	case apierrors.IsAlreadyExists(err):
+		// concurrent mount request already created it — idempotent success
+	default:
+		return StorageV2MountResponse{}, fmt.Errorf("failed to create storage helper pod %s/%s: %w", namespace, podName, err)
+	}
+
+	helperTracker.touch(namespace, podName)
+	return StorageV2MountResponse{PodName: podName, Status: StorageHelperStatusStarting}, nil
+}
+
+// StorageV2Unmount deletes the helper pod(s) for the PVC. Idempotent: no
+// helper pod is not an error.
+func StorageV2Unmount(namespace, pvcName string) error {
+	podClient := clientProvider.K8sClientSet().CoreV1().Pods(namespace)
+
+	// candidates: helper pods from the store plus the derived name (covers a
+	// store that lags right after creation)
+	names := map[string]bool{StorageHelperPodName(pvcName): true}
+	for _, pod := range store.GetPods(namespace) {
+		if isStorageHelperPod(&pod) && podClaimsPvc(&pod, pvcName) {
+			names[pod.Name] = true
+		}
+	}
+
+	for name := range names {
+		err := podClient.Delete(context.Background(), name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete storage helper pod %s/%s: %w", namespace, name, err)
+		}
+		if err == nil {
+			serviceLogger.Info("deleted storage helper pod", "namespace", namespace, "pvc", pvcName, "pod", name)
+		}
+		helperTracker.forget(namespace, name)
+	}
+	return nil
+}
+
+// ── activity tracking ─────────────────────────────────────────────────────────
+
+// storageHelperTracker remembers the last activity time per helper pod. Purely
+// in-memory: after an operator restart a pod's activity clock starts at its
+// first sighting by the reaper.
+type storageHelperTracker struct {
+	mu   sync.Mutex
+	last map[string]time.Time
+	now  func() time.Time
+}
+
+func newStorageHelperTracker(now func() time.Time) *storageHelperTracker {
+	return &storageHelperTracker{last: map[string]time.Time{}, now: now}
+}
+
+var helperTracker = newStorageHelperTracker(time.Now)
+
+func trackerKey(namespace, podName string) string {
+	return namespace + "/" + podName
+}
+
+func (t *storageHelperTracker) touch(namespace, podName string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.last[trackerKey(namespace, podName)] = t.now()
+}
+
+func (t *storageHelperTracker) forget(namespace, podName string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.last, trackerKey(namespace, podName))
+}
+
+// selectIdle returns the pods idle longer than ttl and prunes tracker entries
+// whose pods are gone. A pod unknown to the tracker (operator restarted) gets
+// its first sighting as activity start and is never selected on that sweep.
+func (t *storageHelperTracker) selectIdle(pods []v1.Pod, ttl time.Duration) []v1.Pod {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+	seen := map[string]bool{}
+	var idle []v1.Pod
+	for i := range pods {
+		key := trackerKey(pods[i].Namespace, pods[i].Name)
+		seen[key] = true
+		lastActivity, known := t.last[key]
+		if !known {
+			t.last[key] = now
+			continue
+		}
+		if now.Sub(lastActivity) > ttl {
+			idle = append(idle, pods[i])
+		}
+	}
+
+	// prune entries for pods that no longer exist
+	for key := range t.last {
+		if !seen[key] {
+			delete(t.last, key)
+		}
+	}
+	return idle
+}
+
+// touchStorageHelperIfTarget marks activity when the resolved exec target is a
+// helper pod. Called from ResolvePvcTarget, the single funnel every files/v2
+// operation and storage/v2/stats call goes through.
+func touchStorageHelperIfTarget(pods []v1.Pod, target PvcMountTarget) {
+	for i := range pods {
+		if pods[i].Name == target.PodName && pods[i].Namespace == target.Namespace {
+			if isStorageHelperPod(&pods[i]) {
+				helperTracker.touch(target.Namespace, target.PodName)
+			}
+			return
+		}
+	}
+}
+
+// ── idle reaper ───────────────────────────────────────────────────────────────
+
+// StartStorageHelperReaper starts the background loop that deletes helper pods
+// idle longer than the TTL. Started once from cmd.startClusterSystems.
+func StartStorageHelperReaper() {
+	stop := make(chan struct{})
+	shutdown.Add(func() { close(stop) })
+
+	go func() {
+		ticker := time.NewTicker(storageHelperReapInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				reapIdleStorageHelpers()
+			}
+		}
+	}()
+}
+
+// listStorageHelperPods lists all helper pods cluster-wide, store-backed with
+// a live label-selector fallback when the store yields nothing.
+func listStorageHelperPods() []v1.Pod {
+	var helpers []v1.Pod
+	pods := store.GetPods("*")
+	for i := range pods {
+		if isStorageHelperPod(&pods[i]) {
+			helpers = append(helpers, pods[i])
+		}
+	}
+	if pods != nil {
+		return helpers
+	}
+
+	// live fallback (store error, e.g. right after a store wipe)
+	list, err := clientProvider.K8sClientSet().CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+		LabelSelector: StorageHelperLabelKey + "=" + StorageHelperLabelValue,
+	})
+	if err != nil {
+		serviceLogger.Warn("storage helper reaper: failed to list helper pods", "error", err)
+		return nil
+	}
+	return list.Items
+}
+
+func reapIdleStorageHelpers() {
+	idle := helperTracker.selectIdle(listStorageHelperPods(), storageHelperTTL())
+	for _, pod := range idle {
+		err := clientProvider.K8sClientSet().CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			serviceLogger.Warn("storage helper reaper: failed to delete idle helper pod",
+				"namespace", pod.Namespace, "pod", pod.Name, "error", err)
+			continue
+		}
+		serviceLogger.Info("storage helper reaper: deleted idle helper pod",
+			"namespace", pod.Namespace, "pod", pod.Name, "ttl", storageHelperTTL().String())
+		helperTracker.forget(pod.Namespace, pod.Name)
+	}
+}

--- a/src/services/storagehelper_test.go
+++ b/src/services/storagehelper_test.go
@@ -1,0 +1,227 @@
+package services
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+var dns1123Label = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+func TestStorageHelperPodName(t *testing.T) {
+	t.Run("short valid pvc name passes through", func(t *testing.T) {
+		got := StorageHelperPodName("my-pvc")
+		if got != "mo-storage-helper-my-pvc" {
+			t.Fatalf("expected mo-storage-helper-my-pvc, got %q", got)
+		}
+	})
+
+	t.Run("long names are truncated with a hash and do not collide", func(t *testing.T) {
+		base := strings.Repeat("a", 60)
+		nameA := StorageHelperPodName(base + "-one")
+		nameB := StorageHelperPodName(base + "-two")
+		if nameA == nameB {
+			t.Fatalf("two long pvc names collided: %q", nameA)
+		}
+		for _, name := range []string{nameA, nameB} {
+			if len(name) > 63 {
+				t.Fatalf("pod name exceeds 63 chars (%d): %q", len(name), name)
+			}
+			if !dns1123Label.MatchString(name) {
+				t.Fatalf("pod name is not a valid DNS-1123 label: %q", name)
+			}
+			if !strings.HasPrefix(name, "mo-storage-helper-") {
+				t.Fatalf("pod name lost its prefix: %q", name)
+			}
+		}
+	})
+
+	t.Run("sanitized names get a hash so distinct pvcs stay distinct", func(t *testing.T) {
+		nameDot := StorageHelperPodName("data.set")
+		nameDash := StorageHelperPodName("data-set")
+		if nameDot == nameDash {
+			t.Fatalf("sanitization collided %q with %q", "data.set", "data-set")
+		}
+		if !dns1123Label.MatchString(nameDot) || len(nameDot) > 63 {
+			t.Fatalf("sanitized name invalid: %q", nameDot)
+		}
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		long := strings.Repeat("x", 100)
+		if StorageHelperPodName(long) != StorageHelperPodName(long) {
+			t.Fatal("pod name derivation is not deterministic")
+		}
+	})
+}
+
+// helperPod builds an in-memory helper pod (label + pvc volume) for tests.
+func helperPod(namespace, name, claimName string) v1.Pod {
+	pod := makePvcPod(name, time.Now(), v1.PodRunning, claimName, []testMount{{container: storageHelperContainerName, ready: true}})
+	pod.Namespace = namespace
+	pod.Labels = map[string]string{StorageHelperLabelKey: StorageHelperLabelValue}
+	return pod
+}
+
+func TestStorageHelperTrackerSelectIdle(t *testing.T) {
+	now := time.Now()
+	clock := now
+	tracker := newStorageHelperTracker(func() time.Time { return clock })
+	ttl := 15 * time.Minute
+
+	pods := []v1.Pod{helperPod("ns", "helper-a", "pvc-a"), helperPod("ns", "helper-b", "pvc-b")}
+
+	t.Run("unknown pods get first-seen and are not reaped yet", func(t *testing.T) {
+		if idle := tracker.selectIdle(pods, ttl); len(idle) != 0 {
+			t.Fatalf("expected no idle pods on first sighting, got %d", len(idle))
+		}
+	})
+
+	t.Run("pods idle beyond the ttl are selected", func(t *testing.T) {
+		clock = now.Add(16 * time.Minute)
+		idle := tracker.selectIdle(pods, ttl)
+		if len(idle) != 2 {
+			t.Fatalf("expected both pods idle, got %d", len(idle))
+		}
+	})
+
+	t.Run("touched pods are kept alive", func(t *testing.T) {
+		tracker.touch("ns", "helper-a")
+		idle := tracker.selectIdle(pods, ttl)
+		if len(idle) != 1 || idle[0].Name != "helper-b" {
+			t.Fatalf("expected only helper-b idle, got %+v", idle)
+		}
+	})
+
+	t.Run("entries of vanished pods are pruned", func(t *testing.T) {
+		remaining := []v1.Pod{pods[0]}
+		tracker.selectIdle(remaining, ttl)
+		tracker.mu.Lock()
+		_, stillTracked := tracker.last[trackerKey("ns", "helper-b")]
+		tracker.mu.Unlock()
+		if stillTracked {
+			t.Fatal("expected vanished pod helper-b to be pruned from the tracker")
+		}
+	})
+}
+
+func TestTouchStorageHelperIfTarget(t *testing.T) {
+	clock := time.Now()
+	original := helperTracker
+	helperTracker = newStorageHelperTracker(func() time.Time { return clock })
+	defer func() { helperTracker = original }()
+
+	helper := helperPod("test-ns", "helper", "my-pvc")
+	regular := makePvcPod("regular", time.Now(), v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}})
+	pods := []v1.Pod{helper, regular}
+
+	touchStorageHelperIfTarget(pods, PvcMountTarget{Namespace: "test-ns", PodName: "regular", ContainerName: "app"})
+	if len(helperTracker.last) != 0 {
+		t.Fatal("resolving a regular pod must not touch the tracker")
+	}
+
+	touchStorageHelperIfTarget(pods, PvcMountTarget{Namespace: "test-ns", PodName: "helper", ContainerName: storageHelperContainerName})
+	if _, ok := helperTracker.last[trackerKey("test-ns", "helper")]; !ok {
+		t.Fatal("resolving the helper pod must touch the tracker")
+	}
+}
+
+func buildTestIndex(pods ...v1.Pod) namespacePodIndex {
+	idx := namespacePodIndex{pods: pods, podsPerClaim: map[string][]int{}}
+	for i := range pods {
+		for _, volume := range pods[i].Spec.Volumes {
+			if volume.PersistentVolumeClaim != nil {
+				claim := volume.PersistentVolumeClaim.ClaimName
+				idx.podsPerClaim[claim] = append(idx.podsPerClaim[claim], i)
+			}
+		}
+	}
+	return idx
+}
+
+func TestHelperMountedFor(t *testing.T) {
+	now := time.Now()
+
+	t.Run("helper-labeled pod mounting the pvc sets the flag", func(t *testing.T) {
+		idx := buildTestIndex(helperPod("test-ns", "helper", "my-pvc"))
+		if !helperMountedFor(idx, "my-pvc") {
+			t.Fatal("expected helperMounted=true")
+		}
+	})
+
+	t.Run("regular pods do not set the flag", func(t *testing.T) {
+		idx := buildTestIndex(makePvcPod("app", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}}))
+		if helperMountedFor(idx, "my-pvc") {
+			t.Fatal("expected helperMounted=false")
+		}
+	})
+
+	t.Run("helper pod on another pvc does not set the flag", func(t *testing.T) {
+		idx := buildTestIndex(helperPod("test-ns", "helper", "other-pvc"))
+		if helperMountedFor(idx, "my-pvc") {
+			t.Fatal("expected helperMounted=false for a helper on a different pvc")
+		}
+	})
+}
+
+// A helper pod that exists but is still Pending must render the item as
+// browsable=false with POD_NOT_READY (not NOT_MOUNTED), so the UI shows the
+// mount as in progress instead of offering the mount button again.
+func TestPendingHelperPodYieldsPodNotReady(t *testing.T) {
+	pending := makePvcPod("mo-storage-helper-my-pvc", time.Now(), v1.PodPending, "my-pvc", []testMount{{container: storageHelperContainerName, ready: false}})
+	pending.Labels = map[string]string{StorageHelperLabelKey: StorageHelperLabelValue}
+	idx := buildTestIndex(pending)
+
+	mounts, browsable, reason := computeMounts(idx, "my-pvc")
+	if browsable {
+		t.Fatal("pending helper pod must not be browsable")
+	}
+	if reason != BrowsableReasonPodNotReady {
+		t.Fatalf("expected POD_NOT_READY, got %q", reason)
+	}
+	if len(mounts) != 1 || mounts[0].ControllerKind != "Pod" {
+		t.Fatalf("expected helper pod in mountedBy with controllerKind Pod, got %+v", mounts)
+	}
+	if !helperMountedFor(idx, "my-pvc") {
+		t.Fatal("expected helperMounted=true for the pending helper pod")
+	}
+}
+
+func TestStorageHelperPodSpec(t *testing.T) {
+	pod := buildStorageHelperPod("test-ns", "my-pvc")
+
+	if pod.Name != "mo-storage-helper-my-pvc" || pod.Namespace != "test-ns" {
+		t.Fatalf("unexpected metadata: %s/%s", pod.Namespace, pod.Name)
+	}
+	if !isStorageHelperPod(pod) {
+		t.Fatal("built pod must carry the helper label")
+	}
+	if !podClaimsPvc(pod, "my-pvc") {
+		t.Fatal("built pod must claim the pvc")
+	}
+	if pod.Spec.TerminationGracePeriodSeconds == nil || *pod.Spec.TerminationGracePeriodSeconds != 5 {
+		t.Fatal("expected terminationGracePeriodSeconds 5")
+	}
+
+	container := pod.Spec.Containers[0]
+	if container.Image != defaultStorageHelperImage {
+		t.Fatalf("expected pinned default image %q, got %q", defaultStorageHelperImage, container.Image)
+	}
+	if len(container.VolumeMounts) != 1 || container.VolumeMounts[0].MountPath != storageHelperMountPath || container.VolumeMounts[0].SubPath != "" {
+		t.Fatalf("expected a single non-subPath mount at %s, got %+v", storageHelperMountPath, container.VolumeMounts)
+	}
+	securityContext := container.SecurityContext
+	if securityContext == nil || securityContext.AllowPrivilegeEscalation == nil || *securityContext.AllowPrivilegeEscalation {
+		t.Fatal("expected allowPrivilegeEscalation=false")
+	}
+	if securityContext.Privileged == nil || *securityContext.Privileged {
+		t.Fatal("expected privileged=false")
+	}
+	// chown/chmod as uid 0 need CAP_CHOWN/CAP_FOWNER from the default set
+	if securityContext.Capabilities != nil {
+		t.Fatal("capabilities must not be restricted (default set required for chown/chmod as root)")
+	}
+}

--- a/src/services/storageinfo.go
+++ b/src/services/storageinfo.go
@@ -58,6 +58,7 @@ type StorageV2InfoItem struct {
 	MountedBy        []StorageV2MountedBy `json:"mountedBy"`
 	Browsable        bool                 `json:"browsable"`
 	BrowsableReason  string               `json:"browsableReason"`
+	HelperMounted    bool                 `json:"helperMounted"`
 	Events           []StorageV2Event     `json:"events,omitempty"`
 }
 
@@ -160,6 +161,9 @@ func StorageV2Info(request StorageV2InfoRequest) (StorageV2InfoResponse, error) 
 
 		index := podIndexes[item.Namespace]
 		infoItem.MountedBy, infoItem.Browsable, infoItem.BrowsableReason = computeMounts(index, item.PvcName)
+		// the helper pod itself shows up in mountedBy naturally (controllerKind
+		// "Pod"); this flag just tells the UI that one of them is ours
+		infoItem.HelperMounted = helperMountedFor(index, item.PvcName)
 
 		if request.WithEvents {
 			pvName := ""


### PR DESCRIPTION
- `storage/v2/mount` → spawns/returns `mo-storage-helper-<pvc>` (busybox:1.37, root but unprivileged, no priv-escalation, 10m/16Mi–100m/64Mi, PVC at /data); idempotent, refuses to adopt foreign pods
- `storage/v2/unmount` → deletes the helper (idempotent)
- Idle reaper (60s tick): deletes helpers idle > `MO_STORAGE_HELPER_TTL` (default 15m); activity tracked centrally in the PVC resolver; image overridable via `MO_STORAGE_HELPER_IMAGE`
- `storage/v2/info` items now carry `helperMounted`; Pending helper reports `POD_NOT_READY` (tested)

Additive only. `go build`/`vet`/`test` green (known pre-existing test/helm + test/kubernetes failures unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)