### PR TITLE
feat(storage): expose helper pod status in storage/v2/info

### DIFF
--- a/src/services/storagehelper.go
+++ b/src/services/storagehelper.go
@@ -207,16 +207,21 @@ func findStorageHelperPod(pods []v1.Pod, pvcName string) *v1.Pod {
 	return nil
 }
 
-// helperMountedFor reports whether at least one pod referencing the PVC in the
-// pre-built namespace pod index carries the helper label (storage/v2/info's
-// helperMounted field).
-func helperMountedFor(index namespacePodIndex, pvcName string) bool {
+// helperPodFor returns the first helper-labeled pod referencing the PVC in the
+// pre-built namespace pod index, nil when none exists. Feeds storage/v2/info's
+// helperMounted flag and helperStatus field from the one scan the index holds.
+func helperPodFor(index namespacePodIndex, pvcName string) *v1.Pod {
 	for _, podIdx := range index.podsPerClaim[pvcName] {
 		if isStorageHelperPod(&index.pods[podIdx]) {
-			return true
+			return &index.pods[podIdx]
 		}
 	}
-	return false
+	return nil
+}
+
+// helperMountedFor reports whether a helper pod references the PVC.
+func helperMountedFor(index namespacePodIndex, pvcName string) bool {
+	return helperPodFor(index, pvcName) != nil
 }
 
 // storageHelperStatus maps a helper pod's state onto the wire status.
@@ -230,6 +235,30 @@ func storageHelperStatus(pod *v1.Pod) string {
 		}
 	}
 	return StorageHelperStatusStarting
+}
+
+// storageHelperWaitingReason derives why a helper pod is not (yet) running:
+// the first container's Waiting state (e.g. "ContainerCreating" while kubelet
+// retries a FailedMount) is preferred; a Pending pod with no container status
+// yet falls back to its PodScheduled/ContainersReady condition. Both empty
+// when the pod runs fine.
+func storageHelperWaitingReason(pod *v1.Pod) (reason string, message string) {
+	if len(pod.Status.ContainerStatuses) > 0 {
+		if waiting := pod.Status.ContainerStatuses[0].State.Waiting; waiting != nil {
+			return waiting.Reason, waiting.Message
+		}
+		return "", ""
+	}
+	if pod.Status.Phase == v1.PodPending {
+		for _, conditionType := range []v1.PodConditionType{v1.PodScheduled, v1.ContainersReady} {
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == conditionType && condition.Status != v1.ConditionTrue && condition.Reason != "" {
+					return condition.Reason, condition.Message
+				}
+			}
+		}
+	}
+	return "", ""
 }
 
 // ── mount / unmount ──────────────────────────────────────────────────────────

--- a/src/services/storagehelper_test.go
+++ b/src/services/storagehelper_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/json"
 	"regexp"
 	"strings"
 	"testing"
@@ -187,6 +188,111 @@ func TestPendingHelperPodYieldsPodNotReady(t *testing.T) {
 	}
 	if !helperMountedFor(idx, "my-pvc") {
 		t.Fatal("expected helperMounted=true for the pending helper pod")
+	}
+}
+
+// A helper pod stuck in ContainerCreating (e.g. kubelet FailedMount on a dead
+// NFS server) must surface as helperStatus with that waiting reason, so the UI
+// can replace the static "Mounting…" text with the live state.
+func TestBuildHelperStatusContainerCreating(t *testing.T) {
+	pod := helperPod("test-ns", "mo-storage-helper-my-pvc", "my-pvc")
+	pod.Status.Phase = v1.PodPending
+	pod.Status.ContainerStatuses = []v1.ContainerStatus{
+		{
+			Name:  storageHelperContainerName,
+			Ready: false,
+			State: v1.ContainerState{
+				Waiting: &v1.ContainerStateWaiting{
+					Reason:  "ContainerCreating",
+					Message: "",
+				},
+			},
+		},
+	}
+
+	idx := buildTestIndex(pod)
+	found := helperPodFor(idx, "my-pvc")
+	if found == nil {
+		t.Fatal("expected helperPodFor to find the helper pod")
+	}
+
+	status := buildHelperStatus(found, "test-ns", false)
+	if status.PodName != "mo-storage-helper-my-pvc" {
+		t.Fatalf("unexpected podName %q", status.PodName)
+	}
+	if status.Phase != string(v1.PodPending) {
+		t.Fatalf("expected phase Pending, got %q", status.Phase)
+	}
+	if status.Ready {
+		t.Fatal("a ContainerCreating helper pod must not be ready")
+	}
+	if status.Reason != "ContainerCreating" {
+		t.Fatalf("expected reason ContainerCreating, got %q", status.Reason)
+	}
+	if status.Events != nil {
+		t.Fatal("events must not be fetched without withEvents")
+	}
+}
+
+// A Pending helper pod without container statuses falls back to the failing
+// pod condition (unschedulable etc.) for reason/message.
+func TestBuildHelperStatusPendingConditionFallback(t *testing.T) {
+	pod := helperPod("test-ns", "mo-storage-helper-my-pvc", "my-pvc")
+	pod.Status.Phase = v1.PodPending
+	pod.Status.ContainerStatuses = nil
+	pod.Status.Conditions = []v1.PodCondition{
+		{
+			Type:    v1.PodScheduled,
+			Status:  v1.ConditionFalse,
+			Reason:  "Unschedulable",
+			Message: "0/3 nodes are available",
+		},
+	}
+
+	status := buildHelperStatus(&pod, "test-ns", false)
+	if status.Reason != "Unschedulable" || status.Message != "0/3 nodes are available" {
+		t.Fatalf("expected condition fallback, got reason %q message %q", status.Reason, status.Message)
+	}
+}
+
+// A running, ready helper pod reports ready=true with empty reason/message.
+func TestBuildHelperStatusRunning(t *testing.T) {
+	pod := helperPod("test-ns", "mo-storage-helper-my-pvc", "my-pvc")
+
+	status := buildHelperStatus(&pod, "test-ns", false)
+	if !status.Ready || status.Phase != string(v1.PodRunning) {
+		t.Fatalf("expected ready running status, got %+v", status)
+	}
+	if status.Reason != "" || status.Message != "" {
+		t.Fatalf("expected empty reason/message while running, got %q / %q", status.Reason, status.Message)
+	}
+}
+
+// Without a helper pod the item's helperStatus stays nil and the JSON field is
+// omitted entirely (the frozen wire contract).
+func TestHelperStatusOmittedWithoutHelperPod(t *testing.T) {
+	now := time.Now()
+	idx := buildTestIndex(makePvcPod("app", now, v1.PodRunning, "my-pvc", []testMount{{container: "app", ready: true}}))
+	if helperPodFor(idx, "my-pvc") != nil {
+		t.Fatal("expected no helper pod for a pvc mounted only by regular pods")
+	}
+
+	item := StorageV2InfoItem{Namespace: "test-ns", PvcName: "my-pvc"}
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if strings.Contains(string(encoded), "helperStatus") {
+		t.Fatalf("helperStatus must be omitted when nil, got %s", encoded)
+	}
+
+	item.HelperStatus = &StorageV2HelperStatus{PodName: "mo-storage-helper-my-pvc", Phase: "Pending", Reason: "ContainerCreating"}
+	encoded, err = json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"helperStatus":{"podName":"mo-storage-helper-my-pvc","phase":"Pending","ready":false,"reason":"ContainerCreating","message":""}`) {
+		t.Fatalf("unexpected helperStatus encoding: %s", encoded)
 	}
 }
 

--- a/src/services/storageinfo.go
+++ b/src/services/storageinfo.go
@@ -44,22 +44,36 @@ type StorageV2Event struct {
 	LastTimestamp string `json:"lastTimestamp"`
 }
 
+// StorageV2HelperStatus reports the live state of the helper pod mounting a
+// PVC — present on an item only while such a pod exists, so the UI can show
+// why a mount hangs (e.g. FailedMount events, ContainerCreating) instead of a
+// static "Mounting…" text.
+type StorageV2HelperStatus struct {
+	PodName string           `json:"podName"`
+	Phase   string           `json:"phase"`
+	Ready   bool             `json:"ready"`
+	Reason  string           `json:"reason"`
+	Message string           `json:"message"`
+	Events  []StorageV2Event `json:"events,omitempty"`
+}
+
 type StorageV2InfoItem struct {
-	Namespace        string               `json:"namespace"`
-	PvcName          string               `json:"pvcName"`
-	Phase            string               `json:"phase"`
-	RequestedBytes   int64                `json:"requestedBytes"`
-	CapacityBytes    int64                `json:"capacityBytes"`
-	StorageClassName string               `json:"storageClassName"`
-	AccessModes      []string             `json:"accessModes"`
-	VolumeName       string               `json:"volumeName"`
-	VolumeMode       string               `json:"volumeMode"`
-	Provisioner      string               `json:"provisioner"`
-	MountedBy        []StorageV2MountedBy `json:"mountedBy"`
-	Browsable        bool                 `json:"browsable"`
-	BrowsableReason  string               `json:"browsableReason"`
-	HelperMounted    bool                 `json:"helperMounted"`
-	Events           []StorageV2Event     `json:"events,omitempty"`
+	Namespace        string                 `json:"namespace"`
+	PvcName          string                 `json:"pvcName"`
+	Phase            string                 `json:"phase"`
+	RequestedBytes   int64                  `json:"requestedBytes"`
+	CapacityBytes    int64                  `json:"capacityBytes"`
+	StorageClassName string                 `json:"storageClassName"`
+	AccessModes      []string               `json:"accessModes"`
+	VolumeName       string                 `json:"volumeName"`
+	VolumeMode       string                 `json:"volumeMode"`
+	Provisioner      string                 `json:"provisioner"`
+	MountedBy        []StorageV2MountedBy   `json:"mountedBy"`
+	Browsable        bool                   `json:"browsable"`
+	BrowsableReason  string                 `json:"browsableReason"`
+	HelperMounted    bool                   `json:"helperMounted"`
+	HelperStatus     *StorageV2HelperStatus `json:"helperStatus,omitempty"`
+	Events           []StorageV2Event       `json:"events,omitempty"`
 }
 
 type StorageV2InfoResponse struct {
@@ -162,8 +176,12 @@ func StorageV2Info(request StorageV2InfoRequest) (StorageV2InfoResponse, error) 
 		index := podIndexes[item.Namespace]
 		infoItem.MountedBy, infoItem.Browsable, infoItem.BrowsableReason = computeMounts(index, item.PvcName)
 		// the helper pod itself shows up in mountedBy naturally (controllerKind
-		// "Pod"); this flag just tells the UI that one of them is ours
-		infoItem.HelperMounted = helperMountedFor(index, item.PvcName)
+		// "Pod"); this flag just tells the UI that one of them is ours, and
+		// helperStatus carries its live state while it exists
+		if helper := helperPodFor(index, item.PvcName); helper != nil {
+			infoItem.HelperMounted = true
+			infoItem.HelperStatus = buildHelperStatus(helper, item.Namespace, request.WithEvents)
+		}
 
 		if request.WithEvents {
 			pvName := ""
@@ -339,6 +357,35 @@ func getPv(name string) *v1.PersistentVolume {
 		return nil
 	}
 	return pv
+}
+
+// storageHelperEventLimit caps the events embedded in helperStatus — the UI
+// needs the recent mount failures (e.g. FailedMount), not the full history.
+const storageHelperEventLimit = 10
+
+// buildHelperStatus maps the helper pod's live state onto the wire shape.
+// Events are fetched only for withEvents requests (the single-item detail
+// call the UI polls), newest first, capped at storageHelperEventLimit.
+func buildHelperStatus(pod *v1.Pod, namespace string, withEvents bool) *StorageV2HelperStatus {
+	reason, message := storageHelperWaitingReason(pod)
+	status := &StorageV2HelperStatus{
+		PodName: pod.Name,
+		Phase:   string(pod.Status.Phase),
+		Ready:   storageHelperStatus(pod) == StorageHelperStatusReady,
+		Reason:  reason,
+		Message: message,
+	}
+	if withEvents {
+		events := listEventsFor(namespace, pod.Name, "Pod")
+		sort.SliceStable(events, func(i, j int) bool {
+			return events[i].LastTimestamp > events[j].LastTimestamp
+		})
+		if len(events) > storageHelperEventLimit {
+			events = events[:storageHelperEventLimit]
+		}
+		status.Events = events
+	}
+	return status
 }
 
 // collectPvcEvents lists the events for the PVC and (when bound) its PV,


### PR DESCRIPTION
`storage/v2/info` items now carry `helperStatus` (podName, phase, ready, waiting reason such as `ContainerCreating`, message, and on `withEvents` up to 10 pod events newest-first) whenever a storage helper pod references the PVC. Reuses the existing helper-pod lookup — no extra pod scan. Additive; 4 new unit tests; build/vet/test green.

Lets the UI show live mount progress and kubelet `FailedMount` messages instead of a silent timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)