### PR TITLE
feat(storage): files/v2/search pattern and createdAt in storage/v2/info

### DIFF
--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -825,6 +825,24 @@ func (self *socketApi) registerPatterns() {
 		)
 	}
 
+	// free-text name search below Folder.Path - one find instead of a client
+	// walking the tree folder by folder
+	{
+		type Request struct {
+			Folder     dtos.PvcFileRequestDto `json:"folder" validate:"required"`
+			Query      string                 `json:"query" validate:"required"`
+			MaxResults int                    `json:"maxResults"`
+		}
+
+		RegisterPatternHandler(
+			PatternHandle{self, "files/v2/search"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request Request) (services.FilesSearchResult, error) {
+				return services.SearchV2(request.Folder, request.Query, request.MaxResults)
+			},
+		)
+	}
+
 	RegisterPatternHandler(
 		PatternHandle{self, "files/v2/info"},
 		PatternConfig{},

--- a/src/services/filesservice.go
+++ b/src/services/filesservice.go
@@ -142,6 +142,14 @@ func ListV2(folder dtos.PvcFileRequestDto) ([]dtos.PersistentFileDto, error) {
 	return listImpl(target, folder.Path)
 }
 
+func SearchV2(folder dtos.PvcFileRequestDto, query string, maxResults int) (FilesSearchResult, error) {
+	target, err := resolvePvcFileTarget(folder.Namespace, folder.PvcName)
+	if err != nil {
+		return FilesSearchResult{}, err
+	}
+	return searchImpl(target, folder.Path, query, maxResults)
+}
+
 func InfoV2(r dtos.PvcFileRequestDto) (dtos.PersistentFileDto, error) {
 	target, err := resolvePvcFileTarget(r.Namespace, r.PvcName)
 	if err != nil {
@@ -208,6 +216,82 @@ func DeleteV2(file dtos.PvcFileRequestDto) error {
 
 // ── target-based implementations ──────────────────────────────────────────────
 
+// statFormat is the tab-separated stat -c format listImpl/infoImpl/searchImpl
+// share; parseStatLine reads it back.
+const statFormat = "%n\t%F\t%s\t%u\t%g\t%a\t%Y"
+
+// filesSearchDefaultMaxResults caps a files/v2/search answer when the caller
+// sends no limit.
+const filesSearchDefaultMaxResults = 500
+
+// FilesSearchResult is the wire shape of files/v2/search.
+type FilesSearchResult struct {
+	Items     []dtos.PersistentFileDto `json:"items"`
+	Truncated bool                     `json:"truncated"`
+}
+
+// searchFindArgs builds the find invocation of a free-text name search below
+// containerPath. The pattern travels as one argv element - there is no shell,
+// so the query cannot inject commands; glob characters in it act as wildcards.
+// lost+found is skipped like the listing does.
+func searchFindArgs(containerPath, query string) []string {
+	return []string{
+		"find", containerPath,
+		"-mindepth", "1",
+		"!", "-name", "lost+found",
+		"!", "-path", "*/lost+found/*",
+		"-iname", "*" + query + "*",
+		"-exec", "stat", "-c", statFormat, "{}", ";",
+	}
+}
+
+// searchImpl runs one find over the subtree below requestPath and returns the
+// matching entries with paths relative to that subtree. Results are capped at
+// maxResults; Truncated tells the caller the list is incomplete.
+func searchImpl(target fileExecTarget, requestPath, query string, maxResults int) (FilesSearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return FilesSearchResult{}, fmt.Errorf("query cannot be empty")
+	}
+	if maxResults <= 0 {
+		maxResults = filesSearchDefaultMaxResults
+	}
+
+	containerPath, err := resolvePath(target.MountRoot, requestPath)
+	if err != nil {
+		return FilesSearchResult{}, err
+	}
+
+	output, err := mokubernetes.ExecInPod(
+		target.Namespace, target.Pod, target.Container,
+		searchFindArgs(containerPath, query),
+		nil,
+	)
+	// find exits non-zero when a subfolder is unreadable but still prints
+	// every match it reached - keep those instead of failing the search
+	if err != nil && strings.TrimSpace(output) == "" {
+		return FilesSearchResult{}, err
+	}
+
+	result := FilesSearchResult{Items: []dtos.PersistentFileDto{}}
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		if line == "" || !strings.Contains(line, "\t") {
+			continue
+		}
+		if len(result.Items) >= maxResults {
+			result.Truncated = true
+			break
+		}
+		item, parseErr := parseStatLine(containerPath, line)
+		if parseErr != nil {
+			serviceLogger.Warn("Search: parseStatLine error", "line", line, "error", parseErr)
+			continue
+		}
+		result.Items = append(result.Items, item)
+	}
+	return result, nil
+}
+
 func listImpl(target fileExecTarget, requestPath string) ([]dtos.PersistentFileDto, error) {
 	containerPath, err := resolvePath(target.MountRoot, requestPath)
 	if err != nil {
@@ -219,7 +303,7 @@ func listImpl(target fileExecTarget, requestPath string) ([]dtos.PersistentFileD
 		[]string{
 			"find", containerPath,
 			"-maxdepth", "1", "-mindepth", "1",
-			"-exec", "stat", "-c", "%n\t%F\t%s\t%u\t%g\t%a\t%Y", "{}", ";",
+			"-exec", "stat", "-c", statFormat, "{}", ";",
 		},
 		nil,
 	)
@@ -253,7 +337,7 @@ func infoImpl(target fileExecTarget, requestPath string) (dtos.PersistentFileDto
 
 	output, err := mokubernetes.ExecInPod(
 		target.Namespace, target.Pod, target.Container,
-		[]string{"stat", "-c", "%n\t%F\t%s\t%u\t%g\t%a\t%Y", containerPath},
+		[]string{"stat", "-c", statFormat, containerPath},
 		nil,
 	)
 	if err != nil {

--- a/src/services/filesservice_test.go
+++ b/src/services/filesservice_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -66,6 +67,48 @@ func TestResolvePath(t *testing.T) {
 		}
 		if got != "/var/lib/data/sub/dir" {
 			t.Fatalf("expected /var/lib/data/sub/dir, got %q", got)
+		}
+	})
+}
+
+func TestSearchFindArgs(t *testing.T) {
+	args := searchFindArgs("/data", "err")
+	joined := strings.Join(args, " ")
+
+	t.Run("matches case-insensitively as substring", func(t *testing.T) {
+		if !strings.Contains(joined, "-iname *err*") {
+			t.Fatalf("expected -iname *err*, got %q", joined)
+		}
+	})
+
+	t.Run("skips lost+found", func(t *testing.T) {
+		if !strings.Contains(joined, "! -name lost+found") || !strings.Contains(joined, "! -path */lost+found/*") {
+			t.Fatalf("expected lost+found exclusion, got %q", joined)
+		}
+	})
+
+	t.Run("keeps the query as one argv element without a shell", func(t *testing.T) {
+		args := searchFindArgs("/data", "a b; rm -rf /")
+		if args[0] != "find" {
+			t.Fatalf("search must exec find directly, got %v", args)
+		}
+		found := false
+		for _, arg := range args {
+			if arg == "*a b; rm -rf /*" {
+				found = true
+			}
+			if arg == "sh" || arg == "/bin/sh" {
+				t.Fatalf("search must not go through a shell: %v", args)
+			}
+		}
+		if !found {
+			t.Fatalf("query not passed verbatim: %v", args)
+		}
+	})
+
+	t.Run("uses the shared stat format", func(t *testing.T) {
+		if !strings.Contains(joined, "-exec stat -c "+statFormat+" {} ;") {
+			t.Fatalf("expected stat exec, got %q", joined)
 		}
 	})
 }

--- a/src/services/storageinfo.go
+++ b/src/services/storageinfo.go
@@ -74,6 +74,8 @@ type StorageV2InfoItem struct {
 	HelperMounted    bool                   `json:"helperMounted"`
 	HelperStatus     *StorageV2HelperStatus `json:"helperStatus,omitempty"`
 	Events           []StorageV2Event       `json:"events,omitempty"`
+	// PVC creationTimestamp as RFC3339, "" when unknown
+	CreatedAt string `json:"createdAt,omitempty"`
 }
 
 type StorageV2InfoResponse struct {
@@ -201,6 +203,9 @@ func StorageV2Info(request StorageV2InfoRequest) (StorageV2InfoResponse, error) 
 func fillPvcFields(item *StorageV2InfoItem, pvc *v1.PersistentVolumeClaim) {
 	item.Phase = string(pvc.Status.Phase)
 	item.VolumeName = pvc.Spec.VolumeName
+	if !pvc.CreationTimestamp.IsZero() {
+		item.CreatedAt = pvc.CreationTimestamp.UTC().Format(time.RFC3339)
+	}
 
 	if requested, ok := pvc.Spec.Resources.Requests[v1.ResourceStorage]; ok {
 		item.RequestedBytes = requested.Value()


### PR DESCRIPTION
## Summary
- new pattern `files/v2/search`: one case-insensitive `find -iname "*query*"` below the requested folder in the mounting pod, `stat` output in the shared format. The query travels as a single argv element (no shell), `lost+found` is skipped, results are capped (default 500) with a `truncated` flag. An unreadable subfolder keeps the matches `find` reached instead of failing the search.
- `StorageV2InfoItem.createdAt` (RFC3339) from the PVC `creationTimestamp`
- list/info/search share one `statFormat` constant

## Test plan
- [x] `go build ./...`, `go vet`
- [x] `TestSearchFindArgs` (pattern, lost+found exclusion, no shell, stat exec), `TestResolvePath`
- [ ] manual: search in a mounted PVC via the frontend

Independent of the API/SDK/frontend PRs - older callers simply never send the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)