### PR TITLE
fix(storage): portable df and robust parsing for volume stats

### DIFF
--- a/src/kubernetes/utils.go
+++ b/src/kubernetes/utils.go
@@ -66,10 +66,14 @@ func ServiceForNfsVolume(volumeNamespace string, volumeName string) *core.Servic
 	return nil
 }
 
+// dfArgs is the POSIX-portable df invocation (1K blocks, portable layout). GNU's
+// -B1 is rejected by busybox/BSD/uutils df found in arbitrary app containers.
+var dfArgs = []string{"df", "-P", "-k"}
+
 // NfsDiskUsage returns free/used/total bytes of the NFS export directory by
-// executing `df -B1 /exports` inside the NFS server pod – no local mount needed.
+// executing df inside the NFS server pod – no local mount needed.
 func NfsDiskUsage(volumeNamespace string, volumeName string) (free, used, total uint64, err error) {
-	output, execErr := ExecInNfsPod(volumeNamespace, volumeName, []string{"df", "-B1", "/exports"}, nil)
+	output, execErr := ExecInNfsPod(volumeNamespace, volumeName, append(dfArgs, "/exports"), nil)
 	if execErr != nil {
 		return 0, 0, 0, fmt.Errorf("df exec failed: %w", execErr)
 	}
@@ -77,42 +81,56 @@ func NfsDiskUsage(volumeNamespace string, volumeName string) (free, used, total 
 }
 
 // PodDiskUsage returns free/used/total bytes of mountPath by executing
-// `df -B1 <mountPath>` inside the given container.
+// `df -P -k <mountPath>` inside the given container.
 func PodDiskUsage(namespace, podName, container, mountPath string) (free, used, total uint64, err error) {
-	output, execErr := ExecInPod(namespace, podName, container, []string{"df", "-B1", mountPath}, nil)
+	output, execErr := ExecInPod(namespace, podName, container, append(dfArgs, mountPath), nil)
 	if execErr != nil {
 		return 0, 0, 0, fmt.Errorf("df exec failed: %w", execErr)
 	}
 	return parseDfOutput(output)
 }
 
-// parseDfOutput parses `df -B1 <path>` output (header + data line):
-// Filesystem     1-blocks      Used Available Use% Mounted on
-// overlay        5368709120  102400  5266309120   2% /exports
+// parseDfOutput parses `df -P -k <path>` output (header + data line, 1K blocks):
+// Filesystem     1024-blocks   Used Available Capacity Mounted on
+// overlay        5242880        100   5142780       1% /exports
 func parseDfOutput(output string) (free, used, total uint64, err error) {
+	const blockSize = 1024
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	if len(lines) < 2 {
 		return 0, 0, 0, fmt.Errorf("unexpected df output: %q", output)
 	}
 	fields := strings.Fields(lines[len(lines)-1])
-	if len(fields) < 4 {
+
+	// Anchor on the capacity column ("20%") instead of fixed positions: long
+	// device names (NFS exports) make some df builds wrap the name onto its own
+	// line, which shifts every column of the data line by one.
+	capacityIdx := -1
+	for i, f := range fields {
+		if strings.HasSuffix(f, "%") {
+			if _, perr := strconv.ParseUint(strings.TrimSuffix(f, "%"), 10, 64); perr == nil {
+				capacityIdx = i
+				break
+			}
+		}
+	}
+	if capacityIdx < 3 {
 		return 0, 0, 0, fmt.Errorf("unexpected df output format: %q", lines[len(lines)-1])
 	}
 
-	total, err = strconv.ParseUint(fields[1], 10, 64)
+	total, err = strconv.ParseUint(fields[capacityIdx-3], 10, 64)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("parse total: %w", err)
 	}
-	used, err = strconv.ParseUint(fields[2], 10, 64)
+	used, err = strconv.ParseUint(fields[capacityIdx-2], 10, 64)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("parse used: %w", err)
 	}
-	free, err = strconv.ParseUint(fields[3], 10, 64)
+	free, err = strconv.ParseUint(fields[capacityIdx-1], 10, 64)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("parse free: %w", err)
 	}
 
-	return free, used, total, nil
+	return free * blockSize, used * blockSize, total * blockSize, nil
 }
 
 // ExecInNfsPod executes a command inside the NFS server pod for the given volume and

--- a/src/kubernetes/utils_test.go
+++ b/src/kubernetes/utils_test.go
@@ -5,27 +5,52 @@ import (
 )
 
 func TestParseDfOutput(t *testing.T) {
-	t.Run("parses regular df -B1 output", func(t *testing.T) {
-		output := "Filesystem     1-blocks      Used Available Use% Mounted on\n" +
-			"overlay        5368709120  102400  5266309120   2% /exports\n"
+	t.Run("parses POSIX df -P -k output in 1K blocks", func(t *testing.T) {
+		output := "Filesystem     1024-blocks   Used Available Capacity Mounted on\n" +
+			"overlay        5242880        100   5142780       1% /exports\n"
 		free, used, total, err := parseDfOutput(output)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if total != 5368709120 || used != 102400 || free != 5266309120 {
+		if total != 5242880*1024 || used != 100*1024 || free != 5142780*1024 {
+			t.Fatalf("unexpected values: free=%d used=%d total=%d", free, used, total)
+		}
+	})
+
+	t.Run("parses busybox df -P -k header variant", func(t *testing.T) {
+		output := "Filesystem           1K-blocks      Used Available Use% Mounted on\n" +
+			"/dev/sda1              1000000    250000    750000  25% /data\n"
+		free, used, total, err := parseDfOutput(output)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if total != 1000000*1024 || used != 250000*1024 || free != 750000*1024 {
 			t.Fatalf("unexpected values: free=%d used=%d total=%d", free, used, total)
 		}
 	})
 
 	t.Run("uses the last line of multi-line output", func(t *testing.T) {
-		output := "Filesystem     1-blocks      Used Available Use% Mounted on\n" +
+		output := "Filesystem     1024-blocks   Used Available Capacity Mounted on\n" +
 			"tmpfs          999  1  998   1% /other\n" +
 			"/dev/sda1      1000  200  800   20% /data\n"
 		free, used, total, err := parseDfOutput(output)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if total != 1000 || used != 200 || free != 800 {
+		if total != 1000*1024 || used != 200*1024 || free != 800*1024 {
+			t.Fatalf("unexpected values: free=%d used=%d total=%d", free, used, total)
+		}
+	})
+
+	t.Run("handles a wrapped long device name (numbers on their own line)", func(t *testing.T) {
+		output := "Filesystem     1K-blocks    Used Available Use% Mounted on\n" +
+			"192.168.1.10:/srv/nfs/default-data-tandoor-postgresql-0-pvc-a1242d44\n" +
+			"                 8000000 1600000   6400000  20% /var/lib/postgresql\n"
+		free, used, total, err := parseDfOutput(output)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if total != 8000000*1024 || used != 1600000*1024 || free != 6400000*1024 {
 			t.Fatalf("unexpected values: free=%d used=%d total=%d", free, used, total)
 		}
 	})


### PR DESCRIPTION
Two fixes for the storage v2 paths seen on DEV:

**Stats (`storage/v2/stats`)**
- `df: Unknown option 'B1'` — `-B1` is GNU-only; busybox/uutils `df` reject it → POSIX `df -P -k` (×1024)
- `parse free: parsing "20%"` — long NFS device names wrap the data line → parser anchors on the `NN%` capacity column
- 4 new parser tests (busybox header, wrapped line)

**Uploads (`files/v2/upload`)**
- The announce + `START_UPLOAD`/`END_UPLOAD` framing was only handled by jobClient-0; the API picks a random connection → `No handler for pattern 'files/v2/upload'` on every other one. Now every job client runs the same read loop with its own `uploadReceiver` state machine (`socketapi_upload.go`, 7 tests). Protocol bytes/acks unchanged; legacy `files/upload` still intercepted.

Pairs with the API PR that sends announce and binary frames over the same connection. `go build`/`vet`/`test ./src/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)