### PR TITLE
fix(storage): handle file uploads on every API connection

### DIFF
--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"bytes"
 	"fmt"
 	"log/slog"
 	"mogenius-operator/src/ai"
@@ -809,8 +808,9 @@ func (self *socketApi) registerPatterns() {
 
 	// files/v2/*: file operations on any PVC mounted by a running pod,
 	// executed in that pod (no mogenius NFS server required). The binary
-	// upload counterpart (files/v2/upload) is handled in the job client
-	// read loop next to the legacy files/upload framing.
+	// upload counterpart (files/v2/upload) is intercepted by the upload
+	// receiver of every job client read loop (see socketapi_upload.go),
+	// next to the legacy files/upload framing.
 	{
 		type Request struct {
 			Folder dtos.PvcFileRequestDto `json:"folder" validate:"required"`
@@ -3176,19 +3176,22 @@ func (self *socketApi) LoadRequest(datagram *structs.Datagram, data any) error {
 }
 
 func (self *socketApi) startMessageHandler() {
-	// Start the main read loop for the first jobClient (includes file upload support)
-	self.startJobClientReadLoop()
-
-	// Start a read loop for each additional jobClient
-	for i := 1; i < len(self.jobClients); i++ {
-		self.startClientReadLoop(self.jobClients[i])
+	// Every job client runs the same loop. The platform api picks one of the
+	// connections at random per request, so each of them has to speak the
+	// binary upload protocol — with its own upload state, because announce,
+	// framing and chunks of one transfer all arrive on the same connection.
+	for _, client := range self.jobClients {
+		self.startClientReadLoop(client)
 	}
 }
 
-// startClientReadLoop starts a message read loop for a non-default WebSocket client.
-// It only dispatches patterns that are explicitly registered for this client.
+// startClientReadLoop starts the message read loop for one job client. Upload
+// announces and framing are intercepted here and acked on the connection they
+// came in on; everything else is dispatched to the registered pattern handlers.
 func (self *socketApi) startClientReadLoop(client websocket.WebsocketClient) {
 	go func() {
+		upload := newUploadReceiver(self.logger)
+
 		jobs := make(chan structs.Datagram, messageWorkerCount)
 		defer close(jobs) // signals workers to exit when the read loop ends
 
@@ -3199,11 +3202,18 @@ func (self *socketApi) startClientReadLoop(client websocket.WebsocketClient) {
 		for !client.IsTerminated() {
 			_, message, err := client.ReadMessage()
 			if err != nil {
-				self.logger.Error("failed to read message from websocket connection", "error", err)
-				time.Sleep(time.Second)
+				self.logger.Error("failed to read message from websocket connection", "client", self.clientName(client), "error", err)
+				time.Sleep(time.Second) // wait before next attempt to read
 				continue
 			}
 			if len(message) == 0 {
+				continue
+			}
+
+			if acks, consumed := upload.frame(message); consumed {
+				for _, ack := range acks {
+					go self.JobServerSendData(client, ack)
+				}
 				continue
 			}
 
@@ -3215,17 +3225,23 @@ func (self *socketApi) startClientReadLoop(client websocket.WebsocketClient) {
 
 			datagram.DisplayReceiveSummary(self.logger)
 
+			if ack, ok := upload.announce(datagram); ok {
+				go self.JobServerSendData(client, ack)
+				continue
+			}
+
 			// Blocks when all workers are busy. This backpressures the read
 			// loop instead of spawning unbounded goroutines.
 			jobs <- datagram
 		}
-		self.logger.Debug("client messagehandler finished as the websocket client was terminated")
+		self.logger.Debug("messagehandler finished as the websocket client was terminated", "client", self.clientName(client))
 	}()
 }
 
 // dispatchClientMessages runs one worker that looks up the handler for each
 // incoming datagram and either executes it or replies with a no-handler error.
-// Exits when jobs is closed.
+// Handlers registered without a client serve every connection; a handler bound
+// to a client only serves that one. Exits when jobs is closed.
 func (self *socketApi) dispatchClientMessages(client websocket.WebsocketClient, jobs <-chan structs.Datagram) {
 	for datagram := range jobs {
 		self.patternHandlerLock.RLock()
@@ -3235,20 +3251,15 @@ func (self *socketApi) dispatchClientMessages(client websocket.WebsocketClient, 
 		if exists && (handler.Client == nil || handler.Client == client) {
 			self.handlePatternRequest(datagram, client)
 		} else {
-			self.sendNoHandlerError(client, datagram, true)
+			self.sendNoHandlerError(client, datagram)
 		}
 	}
 }
 
 // sendNoHandlerError writes a structured error datagram back to the client
-// for an unrecognized pattern. perClient indicates whether the warning log
-// should mention the specific client (used by the per-client read loop).
-func (self *socketApi) sendNoHandlerError(client websocket.WebsocketClient, datagram structs.Datagram, perClient bool) {
-	if perClient {
-		self.logger.Warn("no handler for pattern found on client", "pattern", datagram.Pattern, "client", self.clientName(client))
-	} else {
-		self.logger.Warn("no handler for pattern found", "pattern", datagram.Pattern)
-	}
+// for an unrecognized pattern.
+func (self *socketApi) sendNoHandlerError(client websocket.WebsocketClient, datagram structs.Datagram) {
+	self.logger.Warn("no handler for pattern found on client", "pattern", datagram.Pattern, "client", self.clientName(client))
 
 	result := structs.Datagram{
 		Id:      datagram.Id,
@@ -3265,152 +3276,6 @@ func (self *socketApi) sendNoHandlerError(client websocket.WebsocketClient, data
 	}
 
 	self.JobServerSendData(client, result)
-}
-
-func (self *socketApi) startJobClientReadLoop() {
-	go func() {
-		// One binary upload may be pending at a time: either a legacy
-		// files/upload request or a files/v2/upload request, never both.
-		// The variant that is non-nil decides where END_UPLOAD dispatches.
-		var preparedFileName *string
-		var preparedFileRequest *services.FilesUploadRequest
-		var preparedFileRequestV2 *services.FilesUploadRequestV2
-		var preparedUploadDatagramV2 *structs.Datagram
-		var openFile *os.File
-
-		jobs := make(chan structs.Datagram, messageWorkerCount)
-		defer close(jobs)
-
-		for range messageWorkerCount {
-			go self.dispatchJobClientMessages(jobs)
-		}
-
-		for !self.jobClients[0].IsTerminated() {
-			_, message, err := self.jobClients[0].ReadMessage()
-			if err != nil {
-				self.logger.Error("failed to read message from websocket connection", "error", err)
-				time.Sleep(time.Second) // wait before next attempt to read
-				continue
-			}
-			if len(message) == 0 {
-				continue
-			}
-			if bytes.HasPrefix(message, []byte("######START_UPLOAD######;")) {
-				preparedFileName = new(fmt.Sprintf("/tmp/%s.zip", utils.NanoId()))
-				openFile, err = os.OpenFile(*preparedFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-				if err != nil {
-					self.logger.Error("Cannot open uploadfile", "filename", *preparedFileName, "error", err)
-					preparedFileName = nil
-					openFile = nil
-				}
-				continue
-			}
-			if bytes.HasPrefix(message, []byte("######END_UPLOAD######;")) {
-				if openFile != nil {
-					_ = openFile.Close()
-				}
-				var uploadErr error
-				if preparedFileName != nil && preparedFileRequest != nil {
-					uploadErr = services.Uploaded(*preparedFileName, *preparedFileRequest)
-					if uploadErr != nil {
-						self.logger.Error("Error uploading file", "error", uploadErr)
-					}
-				} else if preparedFileName != nil && preparedFileRequestV2 != nil {
-					uploadErr = services.UploadedV2(*preparedFileName, *preparedFileRequestV2)
-					if uploadErr != nil {
-						self.logger.Error("Error uploading file", "error", uploadErr)
-					}
-				} else if preparedFileName == nil {
-					uploadErr = fmt.Errorf("upload failed: could not open temporary file")
-				}
-				if preparedFileName != nil {
-					_ = os.Remove(*preparedFileName)
-				}
-
-				if preparedFileRequest != nil {
-					ack := structs.CreateDatagramAck("ack:files/upload:end", preparedFileRequest.Id)
-					if uploadErr != nil {
-						ack.Err = uploadErr.Error()
-					}
-					go self.JobServerSendData(self.jobClients[0], ack)
-				}
-
-				if preparedFileRequestV2 != nil {
-					// uploads mutate the PVC: audit with the original datagram
-					if preparedUploadDatagramV2 != nil {
-						_, _ = store.AddToAuditLog(*preparedUploadDatagramV2, self.logger, uploadErr == nil, uploadErr, nil, nil)
-					}
-					ack := structs.CreateDatagramAck("ack:files/v2/upload:end", preparedFileRequestV2.Id)
-					if uploadErr != nil {
-						ack.Err = uploadErr.Error()
-					}
-					go self.JobServerSendData(self.jobClients[0], ack)
-				}
-
-				preparedFileName = nil
-				preparedFileRequest = nil
-				preparedFileRequestV2 = nil
-				preparedUploadDatagramV2 = nil
-				continue
-			}
-
-			if preparedFileName != nil {
-				_, err := openFile.Write(message)
-				if err != nil {
-					self.logger.Error("Error writing to file", "error", err)
-				}
-				continue
-			}
-
-			datagram, err := self.ParseDatagram(message)
-			if err != nil {
-				self.logger.Error("failed to parse datagram", "error", err)
-				continue
-			}
-
-			datagram.DisplayReceiveSummary(self.logger)
-
-			// TODO: refactor! @bene
-			if datagram.Pattern == "files/upload" {
-				preparedFileRequest = self.executeBinaryRequestUpload(datagram)
-				preparedFileRequestV2 = nil
-				preparedUploadDatagramV2 = nil
-
-				var ack = structs.CreateDatagramAck("ack:files/upload:datagram", datagram.Id)
-				go self.JobServerSendData(self.jobClients[0], ack)
-				continue
-			}
-
-			if datagram.Pattern == "files/v2/upload" {
-				preparedFileRequestV2 = self.executeBinaryRequestUploadV2(datagram)
-				preparedUploadDatagramV2 = &datagram
-				preparedFileRequest = nil
-
-				var ack = structs.CreateDatagramAck("ack:files/v2/upload:datagram", datagram.Id)
-				go self.JobServerSendData(self.jobClients[0], ack)
-				continue
-			}
-
-			// Blocks when all workers are busy (backpressures the read loop
-			// instead of spawning unbounded goroutines).
-			jobs <- datagram
-		}
-		self.logger.Debug("api messagehandler finished as the websocket client was terminated")
-	}()
-}
-
-// dispatchJobClientMessages runs one worker for the default jobClient read
-// loop. Looks up the handler for each incoming datagram and either executes
-// it or replies with a no-handler error. Exits when jobs is closed.
-func (self *socketApi) dispatchJobClientMessages(jobs <-chan structs.Datagram) {
-	client := self.jobClients[0]
-	for datagram := range jobs {
-		if self.patternHandlerExists(datagram.Pattern) {
-			self.handlePatternRequest(datagram, client)
-		} else {
-			self.sendNoHandlerError(client, datagram, false)
-		}
-	}
 }
 
 // clientName returns a human-readable label for the given client, used in logs.
@@ -3560,11 +3425,6 @@ func (self *socketApi) logPattern(executionTime time.Duration, sendTime time.Dur
 		utils.BytesToHumanReadable(size),
 		datagram.User.Email,
 	)
-}
-
-func (self *socketApi) patternHandlerExists(pattern string) bool {
-	_, ok := self.patternHandler[pattern]
-	return ok
 }
 
 func (self *socketApi) ParseDatagram(data []byte) (structs.Datagram, error) {
@@ -3732,18 +3592,6 @@ func podEventStreamConnection(podLogConnectionRequest xterm.PodEventConnectionRe
 		podLogConnectionRequest.Namespace,
 		podLogConnectionRequest.Controller,
 	)
-}
-
-func (self *socketApi) executeBinaryRequestUpload(datagram structs.Datagram) *services.FilesUploadRequest {
-	data := services.FilesUploadRequest{}
-	structs.MarshalUnmarshal(&datagram, &data)
-	return &data
-}
-
-func (self *socketApi) executeBinaryRequestUploadV2(datagram structs.Datagram) *services.FilesUploadRequestV2 {
-	data := services.FilesUploadRequestV2{}
-	structs.MarshalUnmarshal(&datagram, &data)
-	return &data
 }
 
 func (self *socketApi) NormalizePatternName(pattern string) string {

--- a/src/core/socketapi_upload.go
+++ b/src/core/socketapi_upload.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"mogenius-operator/src/services"
+	"mogenius-operator/src/store"
+	"mogenius-operator/src/structs"
+	"mogenius-operator/src/utils"
+	"os"
+	"path/filepath"
+)
+
+// Wire protocol the platform api speaks for one binary upload on a job client
+// connection: an announce datagram (files/upload or files/v2/upload), then the
+// START marker, the raw chunks and the END marker. Every marker and ack name
+// has to stay byte-for-byte identical to what the api sends and expects.
+const (
+	uploadFrameStart = "######START_UPLOAD######;"
+	uploadFrameEnd   = "######END_UPLOAD######;"
+
+	patternFilesUpload   = "files/upload"
+	patternFilesUploadV2 = "files/v2/upload"
+
+	ackFilesUploadDatagram   = "ack:files/upload:datagram"
+	ackFilesUploadEnd        = "ack:files/upload:end"
+	ackFilesUploadV2Datagram = "ack:files/v2/upload:datagram"
+	ackFilesUploadV2End      = "ack:files/v2/upload:end"
+)
+
+// uploadReceiver holds the one binary upload that may be in flight on a single
+// websocket connection. The api picks a connection per request at random, so
+// every job client read loop owns its own receiver: announce, framing and
+// chunks of one transfer arrive on the same connection and must never be
+// paired across connections.
+//
+// Either a legacy files/upload request or a files/v2/upload request is
+// pending, never both; the non-nil one decides where END dispatches.
+type uploadReceiver struct {
+	logger *slog.Logger
+
+	fileName  *string
+	file      *os.File
+	request   *services.FilesUploadRequest
+	requestV2 *services.FilesUploadRequestV2
+	// the original v2 announce, kept for the audit log entry written on END
+	datagramV2 *structs.Datagram
+
+	// tempDir hosts the spooled zip. The completion callbacks are fields so
+	// the state machine can be exercised without a cluster.
+	tempDir    string
+	uploaded   func(tempZip string, request services.FilesUploadRequest) error
+	uploadedV2 func(tempZip string, request services.FilesUploadRequestV2) error
+	audit      func(datagram structs.Datagram, err error)
+}
+
+func newUploadReceiver(logger *slog.Logger) *uploadReceiver {
+	return &uploadReceiver{
+		logger:     logger,
+		tempDir:    "/tmp",
+		uploaded:   services.Uploaded,
+		uploadedV2: services.UploadedV2,
+		audit: func(datagram structs.Datagram, err error) {
+			// uploads mutate the PVC: audit with the original datagram
+			_, _ = store.AddToAuditLog(datagram, logger, err == nil, err, nil, nil)
+		},
+	}
+}
+
+// announce intercepts an upload announce. It returns the ack for the api and
+// true when the datagram was one; any other datagram returns false and goes
+// through the regular pattern dispatch.
+func (self *uploadReceiver) announce(datagram structs.Datagram) (structs.Datagram, bool) {
+	switch datagram.Pattern {
+	case patternFilesUpload:
+		request := services.FilesUploadRequest{}
+		structs.MarshalUnmarshal(&datagram, &request)
+		self.request = &request
+		self.requestV2 = nil
+		self.datagramV2 = nil
+		return structs.CreateDatagramAck(ackFilesUploadDatagram, datagram.Id), true
+	case patternFilesUploadV2:
+		request := services.FilesUploadRequestV2{}
+		structs.MarshalUnmarshal(&datagram, &request)
+		self.requestV2 = &request
+		self.datagramV2 = &datagram
+		self.request = nil
+		return structs.CreateDatagramAck(ackFilesUploadV2Datagram, datagram.Id), true
+	}
+	return structs.Datagram{}, false
+}
+
+// frame consumes the START/END markers and the raw chunks between them. It
+// returns the acks to send (only END produces any) and true when the message
+// belonged to the upload protocol; false hands the message on as a datagram.
+func (self *uploadReceiver) frame(message []byte) ([]structs.Datagram, bool) {
+	if bytes.HasPrefix(message, []byte(uploadFrameStart)) {
+		self.open()
+		return nil, true
+	}
+	if bytes.HasPrefix(message, []byte(uploadFrameEnd)) {
+		return self.finish(), true
+	}
+	if self.fileName != nil {
+		if _, err := self.file.Write(message); err != nil {
+			self.logger.Error("Error writing to file", "error", err)
+		}
+		return nil, true
+	}
+	return nil, false
+}
+
+func (self *uploadReceiver) open() {
+	// a START while a spool file is still open means the previous transfer
+	// never saw its END; drop it instead of leaking the descriptor
+	if self.file != nil {
+		_ = self.file.Close()
+		_ = os.Remove(*self.fileName)
+	}
+
+	fileName := filepath.Join(self.tempDir, fmt.Sprintf("%s.zip", utils.NanoId()))
+	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		self.logger.Error("Cannot open uploadfile", "filename", fileName, "error", err)
+		self.fileName = nil
+		self.file = nil
+		return
+	}
+	self.fileName = &fileName
+	self.file = file
+}
+
+func (self *uploadReceiver) finish() []structs.Datagram {
+	if self.file != nil {
+		_ = self.file.Close()
+	}
+
+	var uploadErr error
+	switch {
+	case self.fileName != nil && self.request != nil:
+		uploadErr = self.uploaded(*self.fileName, *self.request)
+	case self.fileName != nil && self.requestV2 != nil:
+		uploadErr = self.uploadedV2(*self.fileName, *self.requestV2)
+	case self.fileName == nil:
+		uploadErr = fmt.Errorf("upload failed: could not open temporary file")
+	}
+	if uploadErr != nil {
+		self.logger.Error("Error uploading file", "error", uploadErr)
+	}
+
+	if self.fileName != nil {
+		_ = os.Remove(*self.fileName)
+	}
+
+	acks := []structs.Datagram{}
+	if self.request != nil {
+		ack := structs.CreateDatagramAck(ackFilesUploadEnd, self.request.Id)
+		if uploadErr != nil {
+			ack.Err = uploadErr.Error()
+		}
+		acks = append(acks, ack)
+	}
+	if self.requestV2 != nil {
+		if self.datagramV2 != nil {
+			self.audit(*self.datagramV2, uploadErr)
+		}
+		ack := structs.CreateDatagramAck(ackFilesUploadV2End, self.requestV2.Id)
+		if uploadErr != nil {
+			ack.Err = uploadErr.Error()
+		}
+		acks = append(acks, ack)
+	}
+
+	self.fileName = nil
+	self.file = nil
+	self.request = nil
+	self.requestV2 = nil
+	self.datagramV2 = nil
+	return acks
+}

--- a/src/core/socketapi_upload_test.go
+++ b/src/core/socketapi_upload_test.go
@@ -1,0 +1,248 @@
+package core
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"mogenius-operator/src/services"
+	"mogenius-operator/src/structs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// testUploadReceiver records the completion callbacks instead of touching a
+// cluster, and spools into the test's temp dir.
+type testUploadReceiver struct {
+	*uploadReceiver
+	legacyCalls []services.FilesUploadRequest
+	v2Calls     []services.FilesUploadRequestV2
+	spooled     []string
+	audits      []error
+	uploadErr   error
+}
+
+func newTestUploadReceiver(t *testing.T) *testUploadReceiver {
+	t.Helper()
+	r := &testUploadReceiver{
+		uploadReceiver: newUploadReceiver(slog.New(slog.NewTextHandler(io.Discard, nil))),
+	}
+	r.tempDir = t.TempDir()
+	r.uploaded = func(tempZip string, request services.FilesUploadRequest) error {
+		r.legacyCalls = append(r.legacyCalls, request)
+		r.spooled = append(r.spooled, readFile(t, tempZip))
+		return r.uploadErr
+	}
+	r.uploadedV2 = func(tempZip string, request services.FilesUploadRequestV2) error {
+		r.v2Calls = append(r.v2Calls, request)
+		r.spooled = append(r.spooled, readFile(t, tempZip))
+		return r.uploadErr
+	}
+	r.audit = func(datagram structs.Datagram, err error) {
+		r.audits = append(r.audits, err)
+	}
+	return r
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("spool file %s not readable: %v", path, err)
+	}
+	return string(content)
+}
+
+func announceV2(id string, transferId string) structs.Datagram {
+	return structs.Datagram{
+		Id:      id,
+		Pattern: patternFilesUploadV2,
+		Payload: map[string]any{
+			"file":        map[string]any{"namespace": "ns", "pvcName": "data", "path": "/"},
+			"sizeInBytes": 11,
+			"id":          transferId,
+		},
+	}
+}
+
+func announceLegacy(id string, transferId string) structs.Datagram {
+	return structs.Datagram{
+		Id:      id,
+		Pattern: patternFilesUpload,
+		Payload: map[string]any{
+			"file":        map[string]any{"volumeNamespace": "ns", "volumeName": "vol", "path": "/"},
+			"sizeInBytes": 11,
+			"id":          transferId,
+		},
+	}
+}
+
+func spoolEntries(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("temp dir not readable: %v", err)
+	}
+	return len(entries)
+}
+
+func TestUploadReceiverV2Flow(t *testing.T) {
+	r := newTestUploadReceiver(t)
+
+	ack, ok := r.announce(announceV2("dg-1", "transfer-1"))
+	if !ok {
+		t.Fatal("files/v2/upload announce was not intercepted")
+	}
+	if ack.Pattern != ackFilesUploadV2Datagram || ack.Id != "dg-1" {
+		t.Fatalf("announce ack = %q/%q, want %q/dg-1", ack.Pattern, ack.Id, ackFilesUploadV2Datagram)
+	}
+
+	if acks, consumed := r.frame([]byte(uploadFrameStart)); !consumed || len(acks) != 0 {
+		t.Fatalf("START: consumed=%v acks=%d, want consumed and no acks", consumed, len(acks))
+	}
+	for _, chunk := range []string{"hello ", "world"} {
+		if acks, consumed := r.frame([]byte(chunk)); !consumed || len(acks) != 0 {
+			t.Fatalf("chunk %q: consumed=%v acks=%d, want consumed and no acks", chunk, consumed, len(acks))
+		}
+	}
+	acks, consumed := r.frame([]byte(uploadFrameEnd))
+	if !consumed || len(acks) != 1 {
+		t.Fatalf("END: consumed=%v acks=%d, want consumed and one ack", consumed, len(acks))
+	}
+	if acks[0].Pattern != ackFilesUploadV2End || acks[0].Id != "transfer-1" || acks[0].Err != "" {
+		t.Fatalf("end ack = %+v, want %s for transfer-1 without error", acks[0], ackFilesUploadV2End)
+	}
+
+	if len(r.v2Calls) != 1 || r.v2Calls[0].Id != "transfer-1" || r.v2Calls[0].File.PvcName != "data" {
+		t.Fatalf("uploadedV2 calls = %+v, want one for transfer-1 on pvc data", r.v2Calls)
+	}
+	if len(r.legacyCalls) != 0 {
+		t.Fatalf("legacy upload must not run for a v2 announce, got %+v", r.legacyCalls)
+	}
+	if r.spooled[0] != "hello world" {
+		t.Fatalf("spooled content = %q, want chunks concatenated in order", r.spooled[0])
+	}
+	if len(r.audits) != 1 || r.audits[0] != nil {
+		t.Fatalf("audit calls = %v, want exactly one success entry", r.audits)
+	}
+	if n := spoolEntries(t, r.tempDir); n != 0 {
+		t.Fatalf("%d spool files left behind, want none", n)
+	}
+
+	// state is reset: a stray chunk is regular traffic again
+	if _, consumed := r.frame([]byte(`{"id":"x"}`)); consumed {
+		t.Fatal("receiver still consumed messages after END")
+	}
+}
+
+func TestUploadReceiverLegacyFlow(t *testing.T) {
+	r := newTestUploadReceiver(t)
+
+	ack, ok := r.announce(announceLegacy("dg-2", "transfer-2"))
+	if !ok || ack.Pattern != ackFilesUploadDatagram || ack.Id != "dg-2" {
+		t.Fatalf("legacy announce: ok=%v ack=%+v, want %s for dg-2", ok, ack, ackFilesUploadDatagram)
+	}
+
+	r.frame([]byte(uploadFrameStart))
+	r.frame([]byte("legacy bytes"))
+	acks, _ := r.frame([]byte(uploadFrameEnd))
+
+	if len(acks) != 1 || acks[0].Pattern != ackFilesUploadEnd || acks[0].Id != "transfer-2" {
+		t.Fatalf("end acks = %+v, want one %s for transfer-2", acks, ackFilesUploadEnd)
+	}
+	if len(r.legacyCalls) != 1 || r.legacyCalls[0].File.VolumeName != "vol" || r.spooled[0] != "legacy bytes" {
+		t.Fatalf("legacy upload = %+v / %q, want one call for volume vol with the spooled bytes", r.legacyCalls, r.spooled)
+	}
+	if len(r.v2Calls) != 0 || len(r.audits) != 0 {
+		t.Fatalf("v2 upload/audit must not run for a legacy announce (v2=%d audits=%d)", len(r.v2Calls), len(r.audits))
+	}
+}
+
+func TestUploadReceiverUploadErrorEndsUpInAck(t *testing.T) {
+	r := newTestUploadReceiver(t)
+	r.uploadErr = errors.New("pvc is not mounted")
+
+	r.announce(announceV2("dg-3", "transfer-3"))
+	r.frame([]byte(uploadFrameStart))
+	r.frame([]byte("x"))
+	acks, _ := r.frame([]byte(uploadFrameEnd))
+
+	if len(acks) != 1 || acks[0].Err != "pvc is not mounted" {
+		t.Fatalf("end acks = %+v, want the upload error in ack.Err", acks)
+	}
+	if len(r.audits) != 1 || r.audits[0] == nil {
+		t.Fatalf("audit calls = %v, want one failure entry", r.audits)
+	}
+}
+
+func TestUploadReceiverUnwritableSpoolReportsError(t *testing.T) {
+	r := newTestUploadReceiver(t)
+	r.tempDir = filepath.Join(r.tempDir, "does", "not", "exist")
+
+	r.announce(announceV2("dg-4", "transfer-4"))
+	if _, consumed := r.frame([]byte(uploadFrameStart)); !consumed {
+		t.Fatal("START must be consumed even when the spool file cannot be opened")
+	}
+	acks, _ := r.frame([]byte(uploadFrameEnd))
+
+	if len(acks) != 1 || acks[0].Id != "transfer-4" || acks[0].Err != "upload failed: could not open temporary file" {
+		t.Fatalf("end acks = %+v, want an ack for transfer-4 carrying the open error", acks)
+	}
+	if len(r.v2Calls) != 0 {
+		t.Fatalf("uploadedV2 must not run without a spool file, got %+v", r.v2Calls)
+	}
+}
+
+func TestUploadReceiverFramesWithoutAnnounceSendNoAck(t *testing.T) {
+	r := newTestUploadReceiver(t)
+
+	r.frame([]byte(uploadFrameStart))
+	r.frame([]byte("orphan"))
+	acks, consumed := r.frame([]byte(uploadFrameEnd))
+
+	if !consumed || len(acks) != 0 {
+		t.Fatalf("END without announce: consumed=%v acks=%+v, want consumed and no acks", consumed, acks)
+	}
+	if len(r.legacyCalls)+len(r.v2Calls) != 0 {
+		t.Fatal("no upload may run without an announce")
+	}
+	if n := spoolEntries(t, r.tempDir); n != 0 {
+		t.Fatalf("%d spool files left behind, want none", n)
+	}
+}
+
+// Each connection owns its receiver: an announce on one connection must not
+// be completed by frames on another. That was the shape of the original bug.
+func TestUploadReceiverStateIsPerConnection(t *testing.T) {
+	a := newTestUploadReceiver(t)
+	b := newTestUploadReceiver(t)
+
+	a.announce(announceV2("dg-5", "transfer-5"))
+
+	b.frame([]byte(uploadFrameStart))
+	b.frame([]byte("wrong socket"))
+	if acks, _ := b.frame([]byte(uploadFrameEnd)); len(acks) != 0 {
+		t.Fatalf("connection b acked a transfer announced on connection a: %+v", acks)
+	}
+	if len(b.v2Calls) != 0 {
+		t.Fatal("connection b ran an upload announced on connection a")
+	}
+
+	a.frame([]byte(uploadFrameStart))
+	a.frame([]byte("right socket"))
+	acks, _ := a.frame([]byte(uploadFrameEnd))
+	if len(acks) != 1 || acks[0].Id != "transfer-5" || a.spooled[0] != "right socket" {
+		t.Fatalf("connection a: acks=%+v spooled=%v, want its own transfer completed", acks, a.spooled)
+	}
+}
+
+func TestUploadReceiverIgnoresRegularTraffic(t *testing.T) {
+	r := newTestUploadReceiver(t)
+
+	if _, ok := r.announce(structs.Datagram{Id: "dg-6", Pattern: "files/v2/list"}); ok {
+		t.Fatal("a non-upload pattern was intercepted as announce")
+	}
+	if _, consumed := r.frame([]byte(`{"id":"dg-6","pattern":"files/v2/list"}`)); consumed {
+		t.Fatal("a datagram was consumed as upload chunk while no upload is in flight")
+	}
+}


### PR DESCRIPTION
Follow-up to #1213 — this commit was pushed to that branch after it had already been merged, so it never reached `main` (visible on DEV: `no handler for pattern found on client {"client":"jobClient-2","pattern":"files/v2/upload"}` → 424 banner although everything is deployed).

- The upload announce + `START_UPLOAD`/`END_UPLOAD` framing was only handled by jobClient-0; the API picks a random connection → uploads (incl. "Create file") fail on every other one
- Every job client now runs the same read loop with its own `uploadReceiver` state machine (`socketapi_upload.go`, 7 tests); protocol bytes/acks unchanged, legacy `files/upload` still intercepted

Pairs with API #473 (already deployed). `go build`/`test ./src/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)