### PR TITLE
fix(storage): ignore terminating pods for mount state and exec targets

### DIFF
--- a/src/services/pvcmounts.go
+++ b/src/services/pvcmounts.go
@@ -151,6 +151,12 @@ func pvcMountCandidates(pods []v1.Pod, namespace, pvcName string) ([]PvcMountTar
 	for i := range pods {
 		pod := &pods[i]
 
+		// terminating pods vanish within their grace period - exec'ing into them
+		// would race the kubelet, and after an unmount the UI must see NOT_MOUNTED
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
 		// volume names in this pod backed by the requested claim
 		volumeNames := map[string]bool{}
 		for _, volume := range pod.Spec.Volumes {

--- a/src/services/pvcmounts_test.go
+++ b/src/services/pvcmounts_test.go
@@ -63,6 +63,20 @@ func makePvcPod(name string, created time.Time, phase v1.PodPhase, claimName str
 
 func probeOk(string, string, string, string) error { return nil }
 
+func TestPvcMountCandidatesSkipTerminatingPods(t *testing.T) {
+	now := time.Now()
+	terminating := makePvcPod("helper", now, v1.PodRunning, "pvc", []testMount{{container: "helper", ready: true}})
+	deleted := metav1.NewTime(now)
+	terminating.DeletionTimestamp = &deleted
+
+	// an unmounted helper still lingers in the store during its grace period;
+	// the UI must already see NOT_MOUNTED instead of a browsable volume
+	_, err := pvcMountCandidates([]v1.Pod{terminating}, "test-ns", "pvc")
+	if !errors.Is(err, ErrPvcNotMounted) {
+		t.Fatalf("expected ErrPvcNotMounted for a terminating pod, got %v", err)
+	}
+}
+
 func TestResolvePvcTargetFromStructuralErrors(t *testing.T) {
 	now := time.Now()
 

--- a/src/services/storagehelper.go
+++ b/src/services/storagehelper.go
@@ -212,8 +212,10 @@ func findStorageHelperPod(pods []v1.Pod, pvcName string) *v1.Pod {
 // helperMounted flag and helperStatus field from the one scan the index holds.
 func helperPodFor(index namespacePodIndex, pvcName string) *v1.Pod {
 	for _, podIdx := range index.podsPerClaim[pvcName] {
-		if isStorageHelperPod(&index.pods[podIdx]) {
-			return &index.pods[podIdx]
+		pod := &index.pods[podIdx]
+		// a helper that is already terminating (unmount in progress) no longer counts as mounted
+		if isStorageHelperPod(pod) && pod.DeletionTimestamp == nil {
+			return pod
 		}
 	}
 	return nil

--- a/src/services/storagehelper_test.go
+++ b/src/services/storagehelper_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var dns1123Label = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
@@ -164,6 +165,16 @@ func TestHelperMountedFor(t *testing.T) {
 		idx := buildTestIndex(helperPod("test-ns", "helper", "other-pvc"))
 		if helperMountedFor(idx, "my-pvc") {
 			t.Fatal("expected helperMounted=false for a helper on a different pvc")
+		}
+	})
+
+	t.Run("terminating helper pod no longer counts as mounted", func(t *testing.T) {
+		pod := helperPod("test-ns", "helper", "my-pvc")
+		deleted := metav1.NewTime(now)
+		pod.DeletionTimestamp = &deleted
+		idx := buildTestIndex(pod)
+		if helperMountedFor(idx, "my-pvc") {
+			t.Fatal("expected helperMounted=false while the helper is terminating")
 		}
 	})
 }


### PR DESCRIPTION
Right after `storage/v2/unmount` the helper pod lingers in the store for its 5s grace period, so `storage/v2/info` kept reporting `helperMounted: true` / browsable and the UI showed a stale state until a hard refresh.

- `helperPodFor` skips pods with a `DeletionTimestamp` → `helperMounted` drops immediately
- `pvcMountCandidates` skips terminating pods → NOT_MOUNTED instead of exec'ing into a pod the kubelet is tearing down (applies to any pod, not just helpers)
- 2 new tests; `go vet`/`go test ./src/services/` green

Pairs with frontend #816 (polls until the helper is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)