### PR TITLE
fix(storage): reap helper pods of terminating PVCs

### DIFF
--- a/src/services/storagehelper.go
+++ b/src/services/storagehelper.go
@@ -424,6 +424,7 @@ func StartStorageHelperReaper() {
 				return
 			case <-ticker.C:
 				reapIdleStorageHelpers()
+				reapStorageHelpersOfTerminatingPvcs()
 			}
 		}
 	}()
@@ -452,6 +453,53 @@ func listStorageHelperPods() []v1.Pod {
 		return nil
 	}
 	return list.Items
+}
+
+// helperPodClaim returns the PVC a helper pod mounts (its single "data" volume).
+func helperPodClaim(pod *v1.Pod) string {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			return volume.PersistentVolumeClaim.ClaimName
+		}
+	}
+	return ""
+}
+
+// selectHelpersOfTerminatingPvcs returns the live helper pods whose PVC carries
+// a deletionTimestamp. Such a pod pins kubernetes.io/pvc-protection and the PVC
+// would hang in Terminating forever - e.g. after a kubectl delete that bypassed
+// the API's unmount-before-delete.
+func selectHelpersOfTerminatingPvcs(pods []v1.Pod, lookup func(namespace, name string) *v1.PersistentVolumeClaim) []v1.Pod {
+	var blocking []v1.Pod
+	for i := range pods {
+		pod := &pods[i]
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		claim := helperPodClaim(pod)
+		if claim == "" {
+			continue
+		}
+		if pvc := lookup(pod.Namespace, claim); pvc != nil && pvc.DeletionTimestamp != nil {
+			blocking = append(blocking, *pod)
+		}
+	}
+	return blocking
+}
+
+func reapStorageHelpersOfTerminatingPvcs() {
+	blocking := selectHelpersOfTerminatingPvcs(listStorageHelperPods(), getPvc)
+	for _, pod := range blocking {
+		err := clientProvider.K8sClientSet().CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			serviceLogger.Warn("storage helper reaper: failed to delete helper pod of terminating pvc",
+				"namespace", pod.Namespace, "pod", pod.Name, "error", err)
+			continue
+		}
+		serviceLogger.Info("storage helper reaper: deleted helper pod of terminating pvc",
+			"namespace", pod.Namespace, "pod", pod.Name, "pvc", helperPodClaim(&pod))
+		helperTracker.forget(pod.Namespace, pod.Name)
+	}
 }
 
 func reapIdleStorageHelpers() {

--- a/src/services/storagehelper_test.go
+++ b/src/services/storagehelper_test.go
@@ -342,3 +342,33 @@ func TestStorageHelperPodSpec(t *testing.T) {
 		t.Fatal("capabilities must not be restricted (default set required for chown/chmod as root)")
 	}
 }
+
+func TestSelectHelpersOfTerminatingPvcs(t *testing.T) {
+	now := metav1.Now()
+	helper := func(name, claim string) v1.Pod {
+		pod := *buildStorageHelperPod("ns", claim)
+		pod.Name = name
+		return pod
+	}
+	pvcs := map[string]*v1.PersistentVolumeClaim{
+		"ns/gone":  {ObjectMeta: metav1.ObjectMeta{Name: "gone", Namespace: "ns", DeletionTimestamp: &now}},
+		"ns/alive": {ObjectMeta: metav1.ObjectMeta{Name: "alive", Namespace: "ns"}},
+	}
+	lookup := func(namespace, name string) *v1.PersistentVolumeClaim { return pvcs[namespace+"/"+name] }
+
+	t.Run("helper of a terminating pvc is selected", func(t *testing.T) {
+		got := selectHelpersOfTerminatingPvcs([]v1.Pod{helper("h-gone", "gone"), helper("h-alive", "alive")}, lookup)
+		if len(got) != 1 || got[0].Name != "h-gone" {
+			t.Fatalf("expected only h-gone, got %+v", got)
+		}
+	})
+
+	t.Run("already terminating helper and unknown pvc are left alone", func(t *testing.T) {
+		terminating := helper("h-term", "gone")
+		terminating.DeletionTimestamp = &now
+		got := selectHelpersOfTerminatingPvcs([]v1.Pod{terminating, helper("h-unknown", "missing")}, lookup)
+		if len(got) != 0 {
+			t.Fatalf("expected no selection, got %+v", got)
+		}
+	})
+}


### PR DESCRIPTION
A helper pod pins `kubernetes.io/pvc-protection`; if the PVC gets deleted while the helper is up (e.g. `kubectl delete pvc`), the PVC hangs in Terminating.

- Reaper sweep (60s) now also deletes live helper pods whose PVC carries a deletionTimestamp.
- Unit test for the selection (terminating PVC selected; already-terminating helper and unknown PVC left alone).

The API side (mo-platform-api-service) unmounts the helper before its own delete; this is the safety net for deletes that bypass the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)