### PR TITLE
fix(storage): ignore terminating pods in mountedBy and browsable

### DIFF
--- a/src/services/pvcmounts_test.go
+++ b/src/services/pvcmounts_test.go
@@ -258,6 +258,17 @@ func TestComputeMountsStructural(t *testing.T) {
 		}
 	})
 
+	t.Run("terminating pod is neither listed nor browsable", func(t *testing.T) {
+		terminating := makePvcPod("helper", now, v1.PodRunning, "my-pvc", []testMount{{container: "helper", ready: true}})
+		deleted := metav1.NewTime(now)
+		terminating.DeletionTimestamp = &deleted
+		idx := index(terminating)
+		mounts, browsable, reason := computeMounts(idx, "my-pvc")
+		if browsable || reason != BrowsableReasonNotMounted || len(mounts) != 0 {
+			t.Fatalf("expected NOT_MOUNTED without mounts, got browsable=%v reason=%q mounts=%d", browsable, reason, len(mounts))
+		}
+	})
+
 	t.Run("direct owner is attributed without replicaset walk", func(t *testing.T) {
 		pod := makePvcPod("db-0", now, v1.PodRunning, "my-pvc", []testMount{{container: "db", ready: true}})
 		controller := true

--- a/src/services/storageinfo.go
+++ b/src/services/storageinfo.go
@@ -247,6 +247,12 @@ func computeMounts(index namespacePodIndex, pvcName string) ([]StorageV2MountedB
 
 	for _, podIdx := range index.podsPerClaim[pvcName] {
 		pod := &index.pods[podIdx]
+		// a terminating pod (e.g. the helper right after an unmount) is no mount
+		// target anymore; keeping it here would report browsable=true for a
+		// volume nobody can exec into and the UI would keep the file view open
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
 
 		volumeNames := map[string]bool{}
 		for _, volume := range pod.Spec.Volumes {


### PR DESCRIPTION
`storage/v2/info` kept listing a terminating pod (the helper right after an unmount) in `mountedBy` and reported `browsable=true` for a volume nobody can exec into - the UI kept the file view open until the pod was fully gone.

- `computeMounts` skips pods with a deletionTimestamp, consistent with the exec-target resolver (#1215).
- Test: terminating pod is neither listed nor browsable → NOT_MOUNTED.

Frontend companion: mogenius/mo-frontend PR "close the file view after unmount".

🤖 Generated with [Claude Code](https://claude.com/claude-code)