### PR TITLE
fix(deps): pin snoopy back to v0.4.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG BPFTOOL_IMAGE=ghcr.io/mogenius/bpftool:latest
 # Pinned snoopy release (github.com/mogenius/snoopy). The release assets are
 # built from the tagged source; the ghcr.io/mogenius/snoopy image only has
 # non-human-readable date/sha tags, so we pin the release version instead.
-ARG SNOOPY_VERSION=v0.4.15
+ARG SNOOPY_VERSION=v0.4.13
 
 # Get bpftool binary (target platform - armv7 binary for armv7 build)
 FROM ${BPFTOOL_IMAGE} AS bpftool-source


### PR DESCRIPTION
## Why

Every \`Build, Package, Release (Develop)\` run on main fails since the Renovate bump to snoopy v0.4.15 (8bc1702b), e.g. https://github.com/mogenius/mogenius-operator/actions/runs/34102704962:

\`\`\`
wget: server returned error: HTTP/1.1 404 Not Found
https://github.com/mogenius/snoopy/releases/download/v0.4.15/snoopy_x86_64
\`\`\`

The snoopy releases v0.4.14 and v0.4.15 exist but have **no binary assets**. The snoopy release pipeline is broken since bpf-linker v0.11.0 dropped its bundled-LLVM features, so \`cargo install bpf-linker\` fails; semantic-release had already created the tag and GitHub release before the build ran.

v0.4.13 is the latest snoopy release that ships binaries.

## Follow-up

The snoopy side is fixed in a separate PR (prebuilt bpf-linker binary, build before tagging), after which Renovate will bump this pin again to a release that actually has assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)