### PR TITLE
fix: perf audit must-haves (watch scope, stream IDs, cache mutation, helm history, leaks)

### DIFF
--- a/src/core/xtermservice.go
+++ b/src/core/xtermservice.go
@@ -85,11 +85,15 @@ func (self *xtermService) LiveStreamConnection(conReq xterm.WsConnectionRequest,
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3600)
 	defer cancel()
 	// websocket connection
-	_, conn, connWriteLock, _, err := xterm.GenerateWsConnection(datagram.Pattern, "", "", "", "", websocketUrl, conReq, ctx, cancel)
+	readMessages, conn, connWriteLock, _, err := xterm.GenerateWsConnection(datagram.Pattern, "", "", "", "", websocketUrl, conReq, ctx, cancel)
 	if err != nil {
 		logger.Error("Unable to connect to websocket", "error", err)
 		return
 	}
+	// GenerateWsConnection already runs the single reader for this conn
+	// (gorilla allows one concurrent reader); consume its channel instead
+	// of reading the conn a second time from here.
+	go xterm.DiscardReadMessages(readMessages)
 
 	listener := NewMessageCallback(datagram, func(message any) {
 		if conn != nil {
@@ -105,16 +109,6 @@ func (self *xtermService) LiveStreamConnection(conReq xterm.WsConnectionRequest,
 
 	httpApi.Broadcaster().AddListener(listener)
 	defer httpApi.Broadcaster().RemoveListener(listener)
-
-	go func() {
-		for {
-			_, _, err := conn.ReadMessage()
-			if err != nil {
-				logger.Error("failed to read from connection", "error", err)
-				break
-			}
-		}
-	}()
 
 	// Pre-build set for O(1) pod name lookups instead of linear search per entry
 	podNameSet := make(map[string]bool, len(podNames))

--- a/src/helm/helm.go
+++ b/src/helm/helm.go
@@ -1293,6 +1293,9 @@ func HelmReleaseUpgrade(data HelmChartInstallUpgradeRequest) (result string, err
 	if data.DryRun {
 		upgrade.DryRunStrategy = action.DryRunServer
 	}
+	// Unset MaxHistory means unlimited: one release Secret per revision,
+	// forever. Use the CLI default (HELM_MAX_HISTORY, 10) like `helm upgrade`.
+	upgrade.MaxHistory = settings.MaxHistory
 	// Helm v4 requires a wait strategy whenever any wait happens — and hooks are
 	// always awaited. HookOnly waits only for hooks, not for full release readiness.
 	upgrade.WaitStrategy = kube.HookOnlyStrategy
@@ -2055,6 +2058,7 @@ func HelmReleaseRollback(data HelmReleaseRollbackRequest) (string, error) {
 	}
 
 	rollback := action.NewRollback(actionConfig)
+	rollback.MaxHistory = settings.MaxHistory
 	rollback.ServerSideApply = "auto"
 	rollback.WaitStrategy = kube.StatusWatcherStrategy
 	rollback.Version = data.Revision

--- a/src/kubernetes/persistentstorage.go
+++ b/src/kubernetes/persistentstorage.go
@@ -3,11 +3,13 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"mogenius-operator/src/shutdown"
 	"mogenius-operator/src/structs"
 	"mogenius-operator/src/utils"
 	"mogenius-operator/src/websocket"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -27,9 +29,37 @@ const (
 	PersitentVolumeKillingEventReason string = "Killing"
 )
 
-func handlePVDeletion(pv *v1.PersistentVolume) {
-	clientset := clientProvider.K8sClientSet()
+// pvEventRecorder is shared by all PV deletions. Previously every deletion
+// built its own record.NewBroadcaster() and never called Shutdown() on it,
+// leaking the broadcaster's goroutines and watch fan-out per deleted PV for
+// the lifetime of the process. A sink on Events("") creates each event in
+// the namespace of the object it is recorded against, so one recorder
+// serves every namespace.
+var (
+	pvEventRecorderOnce sync.Once
+	pvEventRecorder     record.EventRecorder
+)
 
+// pvDeletionEventDelay orders the Killing event after the PV deletion that
+// triggers it.
+const pvDeletionEventDelay = 2 * time.Second
+
+func getPvEventRecorder() record.EventRecorder {
+	pvEventRecorderOnce.Do(func() {
+		broadcaster := record.NewBroadcaster()
+		broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{
+			Interface: clientProvider.K8sClientSet().CoreV1().Events(""),
+		})
+		shutdown.Add(broadcaster.Shutdown)
+		pvEventRecorder = broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "mogenius.io/WatchPersistentVolumes"})
+	})
+	return pvEventRecorder
+}
+
+// handlePVDeletion records a Killing event in the namespace a mogenius NFS
+// volume belonged to. It runs on the informer delete handler and must return
+// promptly: the store deletion of the PV waits behind it.
+func handlePVDeletion(pv *v1.PersistentVolume) {
 	if !ContainsLabelKey(pv.Labels, LabelKeyVolumeName) {
 		return
 	}
@@ -37,7 +67,7 @@ func handlePVDeletion(pv *v1.PersistentVolume) {
 	// Extract label value from the PV
 	volumeName, err := GetLabelValue(pv.Labels, LabelKeyVolumeName)
 	if err != nil {
-		k8sLogger.Warn("Label value for identifier:'%s' not found on PV %s", LabelKeyVolumeName, pv.Name)
+		k8sLogger.Warn("Label value not found on PV", "label", LabelKeyVolumeName, "pv", pv.Name)
 		return
 	}
 
@@ -45,22 +75,19 @@ func handlePVDeletion(pv *v1.PersistentVolume) {
 	objectMetaName := pv.Name
 	namespaceName := strings.TrimSuffix(objectMetaName, "-"+volumeName)
 
-	// Set up a dynamic event broadcaster for the specific namespace
-	broadcaster := record.NewBroadcaster()
-	eventInterface := clientset.CoreV1().Events(namespaceName)
-	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: eventInterface})
-	namespaceRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "mogenius.io/WatchPersistentVolumes"})
-
-	// Manipulate PV to match the namespace constraint for the event
+	// Manipulate PV to match the namespace constraint for the event. pv is a
+	// typed copy converted by the caller, not the informer's cached object.
 	pv.Namespace = namespaceName
 	pv.Name = volumeName
 
-	delayDuration := 2 * time.Second
-	time.Sleep(delayDuration)
+	recorder := getPvEventRecorder()
 
-	// Trigger custom event
-	k8sLogger.Info("PV %s is being deleted in namespace %s, triggering event", objectMetaName, namespaceName)
-	namespaceRecorder.Eventf(pv, v1.EventTypeNormal, PersitentVolumeKillingEventReason, "PersistentVolume %s is being deleted", objectMetaName)
+	// Delay off the handler goroutine instead of sleeping on it: a bulk PV
+	// cleanup used to stall the store's delete path for 2s per PV.
+	time.AfterFunc(pvDeletionEventDelay, func() {
+		k8sLogger.Info("PV is being deleted, triggering event", "pv", objectMetaName, "namespace", namespaceName)
+		recorder.Eventf(pv, v1.EventTypeNormal, PersitentVolumeKillingEventReason, "PersistentVolume %s is being deleted", objectMetaName)
+	})
 }
 
 func GetVolumeMountsForK8sManager() ([]structs.Volume, error) {

--- a/src/kubernetes/watcheractions.go
+++ b/src/kubernetes/watcheractions.go
@@ -30,19 +30,29 @@ const (
 	VALKEY_RESOURCE_PREFIX = "resources"
 )
 
-// deprecatedResources are skipped during resource discovery because the API
-// version is deprecated and a non-deprecated replacement is already watched.
-// Watching them produces noisy client-go deprecation warnings and stores
-// duplicate data in Valkey. Keyed by "groupVersion/kind".
+// excludedResources are skipped during resource discovery. Every watched kind
+// costs a LIST + long-lived WATCH, a full in-memory informer cache, and per
+// event a JSON marshal, a Valkey write pipeline and a datagram to the event
+// server - so kinds that nothing reads back are pure overhead. Keyed by
+// "groupVersion/kind".
 //
-//   - v1/Endpoints: replaced by discovery.k8s.io/v1 EndpointSlice; scheduled
-//     for removal in Kubernetes 1.33+.
-var deprecatedResources = map[string]struct{}{
-	"v1/Endpoints": {},
+//   - v1/Endpoints: deprecated, replaced by discovery.k8s.io/v1 EndpointSlice
+//     (which is watched); scheduled for removal in Kubernetes 1.33+.
+//   - coordination.k8s.io/v1/Lease: every kubelet renews its node lease every
+//     10s and every leader-elected controller renews every 2-5s. On a
+//     100-node cluster that alone is ~10 events/s around the clock, and no
+//     code path reads Leases from the store.
+//   - events.k8s.io/v1/Event: the same Event objects as v1/Event, served
+//     under a second API group. Watching both stored every event twice under
+//     two key prefixes; only the v1/Event prefix is ever read.
+var excludedResources = map[string]struct{}{
+	"v1/Endpoints":                 {},
+	"coordination.k8s.io/v1/Lease": {},
+	"events.k8s.io/v1/Event":       {},
 }
 
-func isDeprecatedResource(groupVersion, kind string) bool {
-	_, ok := deprecatedResources[groupVersion+"/"+kind]
+func isExcludedResource(groupVersion, kind string) bool {
+	_, ok := excludedResources[groupVersion+"/"+kind]
 	return ok
 }
 
@@ -662,7 +672,7 @@ func GetAvailableResources() ([]utils.ResourceDescriptor, error) {
 			if !slices.Contains(resource.Verbs, "list") || !slices.Contains(resource.Verbs, "watch") {
 				continue
 			}
-			if isDeprecatedResource(resourceList.GroupVersion, resource.Kind) {
+			if isExcludedResource(resourceList.GroupVersion, resource.Kind) {
 				continue
 			}
 			availableResources = append(availableResources, utils.ResourceDescriptor{

--- a/src/kubernetes/watcheractions.go
+++ b/src/kubernetes/watcheractions.go
@@ -263,7 +263,10 @@ func handleCRDDeletion(wm watcher.WatcherModule, resource utils.ResourceDescript
 }
 
 func setStoreIfNeeded(apiVersion string, resourceName string, kind string, namespace string, obj *unstructured.Unstructured) {
-	obj = removeUnusedFieds(obj)
+	// obj is the informer's cached object and must not be modified here:
+	// it is shared with every other handler, with the resync path and with
+	// the goroutine that marshals it for the event server. managedFields
+	// and TypeMeta are already handled by the informer transform.
 
 	// store primary key + ZSET indexes (by-creation, by-name). The indexes are
 	// what every list read enumerates, so this pair has to stay in step; the
@@ -728,10 +731,5 @@ func removeManagedFields(obj *unstructured.Unstructured) *unstructured.Unstructu
 	if meta, ok := unstructuredContent["metadata"].(map[string]any); ok {
 		delete(meta, "managedFields")
 	}
-	return obj
-}
-
-func removeUnusedFieds(obj *unstructured.Unstructured) *unstructured.Unstructured {
-	obj = removeManagedFields(obj)
 	return obj
 }

--- a/src/store/store.go
+++ b/src/store/store.go
@@ -559,6 +559,9 @@ func SetResourceWithIndex(
 	// Persist the authoritative TypeMeta with the object: readers that
 	// aggregate across kinds (workspace search filters, helm workload
 	// matching) rely on GetKind()/GetAPIVersion() of the stored payload.
+	// For watcher-sourced objects this is a no-op - the informer transform
+	// already stamped TypeMeta, and the cached object must not be written
+	// to here. ensureTypeMeta only writes when a field is empty.
 	ensureTypeMeta(obj, apiVersion, kind)
 
 	payload, err := json.Marshal(obj)

--- a/src/valkeyclient/valkeyclient.go
+++ b/src/valkeyclient/valkeyclient.go
@@ -58,6 +58,9 @@ const (
 	// Defaults for time-series stream retention. Tuned for 1-minute write
 	// cadence: 1440 entries = 24h, which keeps each stream around ~400 KiB
 	// instead of the multi-MB streams produced by 10800 entries / 7d.
+	// Streams keyed per controller receive one entry per pod per minute, so
+	// the MAXLEN cap covers 24h/N for an N-replica controller; the MINID trim
+	// on MAX_RETENTION_TIME is what bounds the time window.
 	// Override with MO_STATS_RETENTION_MAX_ENTRIES and MO_STATS_RETENTION_HOURS.
 	defaultRetentionSize  int64         = 1440
 	defaultRetentionHours time.Duration = 24 * time.Hour
@@ -1031,7 +1034,14 @@ func (self *valkeyClient) StoreSortedListEntry(data any, timestamp int64, keys .
 		timestamp = timestamp * 1000
 	}
 
-	id := fmt.Sprintf("%d-0", timestamp)
+	// Let the server assign the sequence part of the stream ID. Pod and
+	// traffic stats key their streams per controller but write one entry per
+	// pod, all with the same minute-truncated timestamp. With a fixed "-0"
+	// sequence every replica after the first collided with the stream's top
+	// ID and was rejected (and swallowed below as a "duplicate"), so a
+	// 3-replica Deployment persisted one pod's stats and the per-minute
+	// aggregations under-reported by the replica count.
+	id := fmt.Sprintf("%d-*", timestamp)
 
 	// This path runs per log line and per pod-stats write. Pipeline XADD,
 	// retention trims and TTL refresh into a single roundtrip instead of
@@ -1059,9 +1069,10 @@ func (self *valkeyClient) StoreSortedListEntry(data any, timestamp int64, keys .
 		errString := err.Error()
 
 		if strings.Contains(errString, "The ID specified in XADD is equal or smaller than the target stream top item") {
-			// This means we're trying to insert a duplicate entry
-			// we dont care about duplicates (and skip the publish so
-			// subscribers don't see the same entry twice)
+			// Only reachable when a writer's clock is behind the stream's
+			// top entry (e.g. two nodes writing the same controller stream
+			// with skewed clocks). Nothing to store; skip the publish so
+			// subscribers don't see an entry that was not persisted.
 			return nil
 		}
 		// Previously: on WRONGTYPE the wrapper silently DEL'd the

--- a/src/watcher/watcher.go
+++ b/src/watcher/watcher.go
@@ -294,16 +294,33 @@ func (self *watcher) registerAndStartInformer(gvr schema.GroupVersionResource, r
 	resourceInformer := factory.ForResource(gvr).Informer()
 
 	if !self.informersConfigured[gvr] {
-		// Strip large metadata fields before caching to reduce in-process
-		// memory usage. managedFields (server-side apply tracking) and
+		// The transform is the only place that may mutate an object: it runs
+		// once, before the object enters the informer cache. Event handlers
+		// receive the cached pointer and share it with every other handler,
+		// with the resync path and with the goroutines that marshal it, so
+		// any write there is a concurrent map write.
+		//
+		// Strip large metadata fields to reduce in-process memory usage.
+		// managedFields (server-side apply tracking) and
 		// last-applied-configuration are never used by event handlers and
 		// can be several KB per object.
+		//
+		// Stamp apiVersion/kind while we are here: Unstructured objects from
+		// the dynamic client frequently arrive with empty TypeMeta, and the
+		// store persists it so cross-kind readers can call GetKind().
+		apiVersion, kind := resource.ApiVersion, resource.Kind
 		if err := resourceInformer.SetTransform(func(obj any) (any, error) {
 			if u, ok := obj.(*unstructured.Unstructured); ok {
 				u.SetManagedFields(nil)
 				annotations := u.GetAnnotations()
 				delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
 				u.SetAnnotations(annotations)
+				if u.GetAPIVersion() == "" {
+					u.SetAPIVersion(apiVersion)
+				}
+				if u.GetKind() == "" {
+					u.SetKind(kind)
+				}
 			}
 			return obj, nil
 		}); err != nil {

--- a/src/xterm/componentlogstreamconnection.go
+++ b/src/xterm/componentlogstreamconnection.go
@@ -41,11 +41,15 @@ func ComponentStreamConnection(
 	// context
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(30*time.Minute))
 	// websocket connection
-	_, conn, connWriteLock, _, err := GenerateWsConnection("log", "", "", "", "", websocketUrl, wsConnectionRequest, ctx, cancel)
+	readMessages, conn, connWriteLock, _, err := GenerateWsConnection("log", "", "", "", "", websocketUrl, wsConnectionRequest, ctx, cancel)
 	if err != nil {
 		xtermLogger.Error("Unable to connect to websocket", "error", err)
 		return
 	}
+	// Component logs are write-only from our side; inbound frames (peer
+	// ready, pings, close) still have to be consumed so the reader can
+	// observe the close and release the connection.
+	go DiscardReadMessages(readMessages)
 
 	defer func() {
 		cancel()

--- a/src/xterm/xterm.go
+++ b/src/xterm/xterm.go
@@ -195,7 +195,9 @@ func GenerateWsConnection(
 ) (readMessages *chan XtermReadMessages, conn *websocket.Conn, connWriteLock *sync.Mutex, connReadLock *sync.Mutex, err error) {
 	maxRetries := 6
 	currentRetries := 0
-	xtermMessages := make(chan XtermReadMessages)
+	// Small buffer so a burst of control frames (PEER_IS_READY, resize) does
+	// not park the reader goroutine while the consumer is between receives.
+	xtermMessages := make(chan XtermReadMessages, 16)
 
 	for {
 		// add header
@@ -276,7 +278,17 @@ func oncloseWs(conn *websocket.Conn, connReadLock *sync.Mutex, ctx context.Conte
 			messageType, p, err := conn.ReadMessage()
 			connReadLock.Unlock()
 			if readMessages != nil {
-				readMessages <- XtermReadMessages{MessageType: messageType, Data: p, Err: err}
+				// Never block on a consumer that has gone away. An
+				// unconditional send here parked this goroutine forever
+				// once the consumer returned (or never existed), and with
+				// it the connection, its buffers and connReadLock - one
+				// permanent leak per stream. The deferred cancel/close only
+				// runs if we can get out of this select.
+				select {
+				case readMessages <- XtermReadMessages{MessageType: messageType, Data: p, Err: err}:
+				case <-ctx.Done():
+					return
+				}
 			}
 			if err != nil {
 				if closeErr, ok := err.(*websocket.CloseError); ok {
@@ -372,6 +384,19 @@ func cmdOutputToWebsocket(ctx context.Context, cancel context.CancelFunc, conn *
 			}
 			return
 		}
+	}
+}
+
+// DiscardReadMessages drains a GenerateWsConnection read channel for
+// callers that never act on inbound frames. Without a consumer the reader
+// goroutine would block on its first delivery and the connection would only
+// be released when the context expires. Returns when oncloseWs closes the
+// channel, so its lifetime is bound to the connection.
+func DiscardReadMessages(readMessages *chan XtermReadMessages) {
+	if readMessages == nil {
+		return
+	}
+	for range *readMessages {
 	}
 }
 


### PR DESCRIPTION
## Summary

Six independent fixes from the performance/resource audit, one commit each. All are either correctness bugs, unbounded resource growth, or work the operator did for nothing. No behaviour is added.

| Commit | What | Why it matters |
|---|---|---|
| `perf(watcher)` | Exclude `coordination.k8s.io/v1 Lease` and `events.k8s.io/v1 Event` from watching | Leases renew every 2-10s per kubelet/controller and nothing reads them; the events.k8s.io kind duplicated every `v1/Event` under a second key prefix. Removes a large share of all watch events, Valkey writes and event-server datagrams. |
| `fix(valkey)` | Stream IDs `<ms>-*` instead of `<ms>-0` | Per-controller stats streams got one entry per pod with the same minute ID, so all replicas after the first were rejected and silently dropped. Dashboards under-reported by the replica count, and the marshal + write pipeline was wasted. |
| `fix(watcher)` | Stop mutating informer-cached objects; stamp TypeMeta in the transform | `removeManagedFields`/`ensureTypeMeta` wrote into the shared cached object while another goroutine read it via `NestedFieldNoCopy`. Latent `concurrent map read and map write` fatal. |
| `fix(helm)` | Set `MaxHistory` on upgrade and rollback | Unset means unlimited: one release Secret per revision forever, in etcd, in the informer and in Valkey. Now the Helm default (10, `HELM_MAX_HISTORY`). |
| `fix(storage)` | One shared event broadcaster; no `time.Sleep` in the PV delete handler | A `record.NewBroadcaster()` was created per deleted PV and never shut down. The 2s sleep ran synchronously in the informer delete path and stalled store deletions during bulk cleanups. |
| `fix(xterm)` | ctx-aware send in `oncloseWs`, drain channel for write-only callers | Component-log and live-stream views never consumed the read channel, so the reader goroutine, websocket and buffers leaked permanently per opened view. Also removes a second concurrent reader on a gorilla conn in xtermservice. |

## Behaviour changes to be aware of

- **Leases and `events.k8s.io` Events are no longer stored in Valkey or forwarded to the event server.** Nothing in the operator read them; if the platform UI lists Leases anywhere, that view would go empty.
- **Stats streams for multi-replica controllers now hold N entries per minute.** `MAX_RETENTION_SIZE` (1440) therefore covers 24h/N for an N-replica controller; the MINID trim on `MAX_RETENTION_TIME` still bounds the window at 24h. Raise `MO_STATS_RETENTION_MAX_ENTRIES` if full 24h at the 1-minute resolution is required for large controllers.
- **Existing releases with more than 10 revisions get pruned on their next upgrade.**

## Deliberately not included

Valkey call timeouts were on the list but are already covered: valkey-go applies `ConnWriteTimeout` (set to 10s) as the connection deadline for every command without its own context deadline, including waiting for the response.

## Verification

- `go build ./src/...`, `go vet` on touched packages
- Unit tests of `kubernetes`, `watcher`, `store`, `valkeyclient`, `helm`, `xterm`, `core` pass
- golangci-lint reports 3 pre-existing issues in untouched files (`dtos/persistentfiledto_linux.go`, `services/storagehelper_test.go`), none in this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)