### PR TITLE
feat(platform): deliver components through a user-managed GitOps engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ bin
 /patternlogs_*
 /patternlogs.jsonl
 Dockerfile.bak
+# Helm subchart archives; Chart.lock pins the versions and is committed.
+helm/charts/*/charts/*.tgz

--- a/helm/charts/mogenius-operator/templates/deployment.yaml
+++ b/helm/charts/mogenius-operator/templates/deployment.yaml
@@ -82,6 +82,18 @@ spec:
             {{- end }}
             - name: MO_ENABLE_AUTO_UPGRADE
               value: {{ .Values.features.autoUpgrade.enabled | quote }}
+            {{- with .Values.platformBootstrap }}
+            {{- if .repository.url }}
+            - name: PLATFORM_BOOTSTRAP_REPOSITORY_URL
+              value: {{ .repository.url | quote }}
+            - name: PLATFORM_BOOTSTRAP_REPOSITORY_BRANCH
+              value: {{ .repository.branch | quote }}
+            - name: PLATFORM_BOOTSTRAP_REPOSITORY_PATH
+              value: {{ .repository.path | quote }}
+            - name: PLATFORM_BOOTSTRAP_GITOPS_ENGINE
+              value: {{ .gitOps.engine | quote }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - mountPath: /app/helm-data
               name: helm-data

--- a/helm/charts/mogenius-operator/templates/deployment.yaml
+++ b/helm/charts/mogenius-operator/templates/deployment.yaml
@@ -82,6 +82,8 @@ spec:
             {{- end }}
             - name: MO_ENABLE_AUTO_UPGRADE
               value: {{ .Values.features.autoUpgrade.enabled | quote }}
+            - name: PLATFORM_CONFIG_ENABLED
+              value: {{ .Values.features.platformConfig.enabled | quote }}
           volumeMounts:
             - mountPath: /app/helm-data
               name: helm-data

--- a/helm/charts/mogenius-operator/templates/deployment.yaml
+++ b/helm/charts/mogenius-operator/templates/deployment.yaml
@@ -82,8 +82,6 @@ spec:
             {{- end }}
             - name: MO_ENABLE_AUTO_UPGRADE
               value: {{ .Values.features.autoUpgrade.enabled | quote }}
-            - name: PLATFORM_CONFIG_ENABLED
-              value: {{ .Values.features.platformConfig.enabled | quote }}
           volumeMounts:
             - mountPath: /app/helm-data
               name: helm-data

--- a/helm/charts/mogenius-operator/values.yaml
+++ b/helm/charts/mogenius-operator/values.yaml
@@ -133,11 +133,11 @@ platformBootstrap:
     # -- so pointing at the repository root would sync every manifest next to it.
     path: platform
   gitOps:
-    # -- engine this cluster runs, "argo-cd" or "flux". Declared in the seeded
+    # -- engine this cluster runs, "flux" or "argo-cd". Declared in the seeded
     # -- PlatformConfig without being enabled: the mogenius-platform-bootstrap
     # -- chart installs it, and enabling it here would have the operator install
     # -- a second one alongside.
-    engine: argo-cd
+    engine: flux
 
 # -- environment variables to be set in the mogenius-operator deployment
 envVars:

--- a/helm/charts/mogenius-operator/values.yaml
+++ b/helm/charts/mogenius-operator/values.yaml
@@ -26,6 +26,13 @@ cluster:
 features:
   autoUpgrade:
     enabled: true
+  # -- manage the cluster's platform from a PlatformConfig resource
+  platformConfig:
+    # -- install the PlatformConfig CRDs, watch them, and create the components they
+    # -- declare (ingress, cert-manager, metrics, ...). Off by default: switching it
+    # -- on hands the platform stack of this cluster over to the operator. The
+    # -- mogenius-platform-bootstrap chart sets this for you.
+    enabled: false
   debugTools:
     # -- enable the debug tools container in the mogenius-operator pod
     enabled: false

--- a/helm/charts/mogenius-operator/values.yaml
+++ b/helm/charts/mogenius-operator/values.yaml
@@ -26,13 +26,6 @@ cluster:
 features:
   autoUpgrade:
     enabled: true
-  # -- manage the cluster's platform from a PlatformConfig resource
-  platformConfig:
-    # -- install the PlatformConfig CRDs, watch them, and create the components they
-    # -- declare (ingress, cert-manager, metrics, ...). Off by default: switching it
-    # -- on hands the platform stack of this cluster over to the operator. The
-    # -- mogenius-platform-bootstrap chart sets this for you.
-    enabled: false
   debugTools:
     # -- enable the debug tools container in the mogenius-operator pod
     enabled: false

--- a/helm/charts/mogenius-operator/values.yaml
+++ b/helm/charts/mogenius-operator/values.yaml
@@ -113,6 +113,32 @@ global:
     secretName: mogenius-operator-api-secret
     secretKey: API_KEY
 
+# -- the repository holding this cluster's platformconfig.yaml.
+# --
+# -- Seeded into the PlatformConfig the operator creates, which is what lets it
+# -- point the GitOps engine at the repository before the config itself has ever
+# -- been read from there. Once the engine syncs the file, that file is the
+# -- authority and this is not read again.
+# --
+# -- Set by the install command the mogenius UI generates. Leave empty on a
+# -- cluster that does not manage its platform from git.
+platformBootstrap:
+  repository:
+    # -- clone URL, e.g. https://github.com/acme/platform.git
+    url: ""
+    # -- branch the repository is tracked on
+    branch: main
+    # -- directory holding platformconfig.yaml. A directory, not a file: Argo CD's
+    # -- source.path and Flux's Kustomization.spec.path both address directories,
+    # -- so pointing at the repository root would sync every manifest next to it.
+    path: platform
+  gitOps:
+    # -- engine this cluster runs, "argo-cd" or "flux". Declared in the seeded
+    # -- PlatformConfig without being enabled: the mogenius-platform-bootstrap
+    # -- chart installs it, and enabling it here would have the operator install
+    # -- a second one alongside.
+    engine: argo-cd
+
 # -- environment variables to be set in the mogenius-operator deployment
 envVars:
   MO_API_SERVER: "wss://k8s-ws.mogenius.com/ws"

--- a/helm/charts/mogenius-platform-bootstrap/Chart.lock
+++ b/helm/charts/mogenius-platform-bootstrap/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: argo-cd
+  repository: https://argoproj.github.io/argo-helm
+  version: 10.8.2
+- name: flux-operator
+  repository: oci://ghcr.io/controlplaneio-fluxcd/charts
+  version: 0.48.0
+digest: sha256:0dd12cb09177d0a9c71a035f276f486c2a0f3765d04040734fe8b943d84b7372
+generated: "2026-09-08T13:11:25.503404055+02:00"

--- a/helm/charts/mogenius-platform-bootstrap/Chart.yaml
+++ b/helm/charts/mogenius-platform-bootstrap/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+appVersion: "1.0"
+name: mogenius-platform-bootstrap
+version: 0.1.0
+description: "Installs the GitOps engine for a mogenius platform and points it at the repository holding the PlatformConfig"
+home: https://mogenius.com
+icon: https://avatars.githubusercontent.com/u/92862356
+sources:
+  - https://github.com/mogenius/mogenius-operator
+  - https://helm.mogenius.com/public
+maintainers:
+  - email: info@mogenius.com
+    name: the mogenius tech team
+
+# The engine is a dependency rather than something the operator installs. Flux
+# leaves no choice -- the flux-operator chart ships no controllers, those come
+# from the FluxInstance below, and the operator's own component delivery needs a
+# running helm-controller before it can do anything. Argo CD follows the same
+# shape so both engines are onboarded the same way.
+# Versions track platform-defaults (argocd.yaml, flux-operator.yaml), so a
+# cluster onboarded through this chart runs the same engine version the operator
+# would install itself.
+dependencies:
+  # renovate: datasource=helm registryUrl=https://argoproj.github.io/argo-helm chart=argo-cd
+  - name: argo-cd
+    alias: argoCd
+    version: "10.8.2"
+    repository: https://argoproj.github.io/argo-helm
+    condition: argoCd.enabled
+  # renovate: datasource=docker packageName=ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+  - name: flux-operator
+    alias: flux
+    version: "0.48.0"
+    repository: oci://ghcr.io/controlplaneio-fluxcd/charts
+    condition: flux.enabled

--- a/helm/charts/mogenius-platform-bootstrap/README.md
+++ b/helm/charts/mogenius-platform-bootstrap/README.md
@@ -45,14 +45,14 @@ all.
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `argoCd.enabled` | `true` | Install Argo CD. Mutually exclusive with `flux.enabled`. Upstream `argo-cd` chart values pass through under this key. |
-| `flux.enabled` | `false` | Install Flux via `flux-operator`. Mutually exclusive with `argoCd.enabled`. Upstream chart values pass through under this key. |
+| `flux.enabled` | `true` | Install Flux via `flux-operator`. The default engine. Mutually exclusive with `argoCd.enabled`. Upstream chart values pass through under this key. |
+| `argoCd.enabled` | `false` | Install Argo CD instead. Mutually exclusive with `flux.enabled`. Upstream `argo-cd` chart values pass through under this key. |
 | `repository.name` | `platform` | Name given to the credential Secret and, later, to the sync objects. |
 | `repository.url` | *required* | Clone URL of the repository holding `platformconfig.yaml`. |
 | `repository.token` | `""` | Token for a private repository. Written into a Secret in the engine's own format. Leave empty for a public repository. |
 | `repository.existingSecret.name` | `""` | Use a credential Secret you created yourself instead of passing a token. It must already be in the engine's format: labelled `argocd.argoproj.io/secret-type=repository` for Argo CD, a basic-auth Secret for Flux. Wins over `token`. |
 
-Install into the namespace the engine should run in — `argocd` or `flux-system`
+Install into the namespace the engine should run in — `flux-system` or `argocd`
 by convention. Every object this chart creates lands in the release namespace.
 
 Because the engine charts are aliased (`argoCd`, `flux`) so that one value both

--- a/helm/charts/mogenius-platform-bootstrap/README.md
+++ b/helm/charts/mogenius-platform-bootstrap/README.md
@@ -1,0 +1,68 @@
+# mogenius-platform-bootstrap
+
+Installs the GitOps engine for a mogenius platform and the credential it needs
+to read the repository holding your `PlatformConfig`.
+
+Installed alongside `mogenius-operator` during cluster onboarding. The mogenius
+UI generates the exact command; this README explains what it does.
+
+## Why the engine is not installed by the operator
+
+`spec.gitOps.argocd.enabled` / `spec.gitOps.fluxcd.enabled` let the operator
+install and own the engine, and that is a valid setup — but not for bootstrap.
+The engine is what delivers the `PlatformConfig` into the cluster, so it has to
+exist before there is a `PlatformConfig` to declare it in. For Flux there is no
+choice at all: the `flux-operator` chart ships no controllers, those come from a
+`FluxInstance`, and the operator's own component delivery needs a running
+`helm-controller` before it can create anything.
+
+So this chart owns the engine, and the `PlatformConfig` declares it as
+`enabled: false`. The operator then reports it as `isUserManaged` and delivers
+the platform components through it without trying to take it over.
+
+**Do not also enable the engine in your `PlatformConfig`** — the operator would
+install a second one next to this release.
+
+## Why the sync objects are not in this chart
+
+The Argo CD `Application`, and Flux's `FluxInstance` / `GitRepository` /
+`Kustomization`, are created by the mogenius platform once the operator connects
+and reports the engine as running — not by this chart.
+
+Helm resolves every manifest in a release through the API server's RESTMapper
+*before* it creates anything. A custom resource shipped in the same release as
+the CRD that defines it therefore fails the install outright ("resource mapping
+not found for kind ...") on any cluster that does not already have that CRD —
+which is every cluster being onboarded. Helm hooks do not fix it either: a
+persistent object cannot be a hook, because hooks are re-applied on every
+upgrade and would have to delete and recreate it.
+
+Letting the platform create them also means the same code path handles a cluster
+that already runs its own Argo CD or Flux, where this chart is not installed at
+all.
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `argoCd.enabled` | `true` | Install Argo CD. Mutually exclusive with `flux.enabled`. Upstream `argo-cd` chart values pass through under this key. |
+| `flux.enabled` | `false` | Install Flux via `flux-operator`. Mutually exclusive with `argoCd.enabled`. Upstream chart values pass through under this key. |
+| `repository.name` | `platform` | Name given to the credential Secret and, later, to the sync objects. |
+| `repository.url` | *required* | Clone URL of the repository holding `platformconfig.yaml`. |
+| `repository.token` | `""` | Token for a private repository. Written into a Secret in the engine's own format. Leave empty for a public repository. |
+| `repository.existingSecret.name` | `""` | Use a credential Secret you created yourself instead of passing a token. It must already be in the engine's format: labelled `argocd.argoproj.io/secret-type=repository` for Argo CD, a basic-auth Secret for Flux. Wins over `token`. |
+
+Install into the namespace the engine should run in — `argocd` or `flux-system`
+by convention. Every object this chart creates lands in the release namespace.
+
+Because the engine charts are aliased (`argoCd`, `flux`) so that one value both
+selects the engine and carries its settings, subchart resources render with a
+`helm.sh/chart: argoCd-<version>` label rather than `argo-cd-<version>`. Only
+that label is affected; the engine's own `app.kubernetes.io/*` labels, which is
+what the operator detects it by, are unchanged.
+
+## Engines
+
+Chart versions track [`platform-defaults`](https://github.com/mogenius/platform-defaults)
+(`argocd.yaml`, `flux-operator.yaml`), so a cluster onboarded through this chart
+runs the same engine version the operator would install itself.

--- a/helm/charts/mogenius-platform-bootstrap/templates/NOTES.txt
+++ b/helm/charts/mogenius-platform-bootstrap/templates/NOTES.txt
@@ -1,0 +1,17 @@
+{{ .Chart.Name }} {{ .Chart.Version }} installed into namespace {{ .Release.Namespace }}.
+
+GitOps engine: {{ if .Values.argoCd.enabled }}Argo CD{{ else }}Flux{{ end }}
+Repository:    {{ .Values.repository.url }}
+
+What happens next is driven by the mogenius platform, not by this chart:
+
+  1. the mogenius operator connects and reports the engine it found here
+  2. the platform creates the objects that sync your PlatformConfig
+     ({{ if .Values.argoCd.enabled }}an Argo CD Application{{ else }}a FluxInstance, GitRepository and Kustomization{{ end }})
+  3. the engine syncs platformconfig.yaml and the operator builds the components
+
+Follow it in the mogenius UI under the cluster you are onboarding.
+
+Do not also enable the engine in your PlatformConfig
+(spec.gitOps.{{ if .Values.argoCd.enabled }}argocd{{ else }}fluxcd{{ end }}.enabled must stay false): this release owns it, and the
+operator would otherwise install a second one alongside it.

--- a/helm/charts/mogenius-platform-bootstrap/templates/_helpers.tpl
+++ b/helm/charts/mogenius-platform-bootstrap/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+Fails unless exactly one engine is selected. Both would race for ownership of
+the same PlatformConfig, neither leaves anything to sync the config with -- in
+both cases the install is better refused than half-applied.
+*/}}
+{{- define "bootstrap.validateEngine" -}}
+{{- if and .Values.argoCd.enabled .Values.flux.enabled -}}
+{{- fail "argoCd.enabled and flux.enabled are mutually exclusive: pick one GitOps engine" -}}
+{{- end -}}
+{{- if and (not .Values.argoCd.enabled) (not .Values.flux.enabled) -}}
+{{- fail "no GitOps engine selected: set either argoCd.enabled or flux.enabled" -}}
+{{- end -}}
+{{- if not .Values.repository.url -}}
+{{- fail "repository.url is required: without it the engine has nothing to sync the PlatformConfig from" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the repository credential Secret, or empty when the repository needs no
+credentials. An existing Secret wins over a token: it is the more explicit of
+the two, and it is what a user who manages their own credentials would set.
+*/}}
+{{- define "bootstrap.repositorySecretName" -}}
+{{- if .Values.repository.existingSecret.name -}}
+{{- .Values.repository.existingSecret.name -}}
+{{- else if .Values.repository.token -}}
+{{- printf "%s-repository" .Values.repository.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "bootstrap.labels" -}}
+app.kubernetes.io/managed-by: mogenius-platform-bootstrap
+app.kubernetes.io/component: platform-config
+app.kubernetes.io/part-of: mogenius
+{{- end -}}

--- a/helm/charts/mogenius-platform-bootstrap/templates/repository-secret.yaml
+++ b/helm/charts/mogenius-platform-bootstrap/templates/repository-secret.yaml
@@ -1,0 +1,30 @@
+{{- include "bootstrap.validateEngine" . -}}
+{{/*
+Only written when a token was passed. The Secret's shape is the engine's, not
+ours: Argo CD discovers repository credentials by label and expects the
+repository URL inside the Secret, Flux expects plain basic-auth keys and is
+pointed at the Secret by name from the GitRepository.
+*/}}
+{{- if and .Values.repository.token (not .Values.repository.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "bootstrap.repositorySecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bootstrap.labels" . | nindent 4 }}
+    {{- if .Values.argoCd.enabled }}
+    argocd.argoproj.io/secret-type: repository
+    {{- end }}
+type: Opaque
+stringData:
+  {{- if .Values.argoCd.enabled }}
+  type: git
+  url: {{ .Values.repository.url | quote }}
+  {{- /* x-token-auth: accepted as the username by GitHub, GitLab and Gitea alike. */}}
+  username: x-token-auth
+  {{- else }}
+  username: git
+  {{- end }}
+  password: {{ .Values.repository.token | quote }}
+{{- end }}

--- a/helm/charts/mogenius-platform-bootstrap/values.yaml
+++ b/helm/charts/mogenius-platform-bootstrap/values.yaml
@@ -1,0 +1,35 @@
+# -- the repository holding platformconfig.yaml. Only the credential for it is
+# -- created here: the objects that sync it (Argo CD Application, Flux
+# -- GitRepository/Kustomization, FluxInstance) are created by the mogenius
+# -- platform once the operator reports the engine as running.
+# --
+# -- They cannot live in this chart. Helm resolves every manifest through the
+# -- RESTMapper before it creates anything, so a custom resource shipped in the
+# -- same release as the CRD defining it fails the install outright on a cluster
+# -- that does not have that CRD yet -- which is every cluster being onboarded.
+repository:
+  # -- name for the sync objects created in the cluster (Application, GitRepository, ...)
+  name: platform
+  # -- clone URL, e.g. https://github.com/acme/platform.git
+  url: ""
+  # -- token for a private repository. Written into a Secret in the engine's
+  # -- format. Leave empty for a public repository, or use existingSecret.
+  token: ""
+  # -- reference a repository credential Secret you created yourself, instead of
+  # -- passing a token. It must already be in the engine's expected format:
+  # -- for Argo CD labelled argocd.argoproj.io/secret-type=repository, for Flux
+  # -- a basic-auth Secret with username/password keys.
+  existingSecret:
+    # -- name of the existing Secret, in this release's namespace
+    name: ""
+
+# -- Argo CD as the GitOps engine. Values of the upstream argo-cd chart pass
+# -- through under this key. Mutually exclusive with flux.enabled.
+argoCd:
+  enabled: true
+
+# -- Flux as the GitOps engine, via the flux-operator chart. Values of that
+# -- chart pass through under this key. Mutually exclusive with argoCd.enabled.
+flux:
+  enabled: false
+

--- a/helm/charts/mogenius-platform-bootstrap/values.yaml
+++ b/helm/charts/mogenius-platform-bootstrap/values.yaml
@@ -23,13 +23,14 @@ repository:
     # -- name of the existing Secret, in this release's namespace
     name: ""
 
+# -- Flux as the GitOps engine, via the flux-operator chart. The default engine.
+# -- Values of that chart pass through under this key. Mutually exclusive with
+# -- argoCd.enabled.
+flux:
+  enabled: true
+
 # -- Argo CD as the GitOps engine. Values of the upstream argo-cd chart pass
 # -- through under this key. Mutually exclusive with flux.enabled.
 argoCd:
-  enabled: true
-
-# -- Flux as the GitOps engine, via the flux-operator chart. Values of that
-# -- chart pass through under this key. Mutually exclusive with argoCd.enabled.
-flux:
   enabled: false
 

--- a/src/cmd/cluster.go
+++ b/src/cmd/cluster.go
@@ -293,6 +293,17 @@ func startClusterSystems(logManagerModule logging.SlogManager, configModule *con
 		core.SeedDefaultAgents(logManagerModule.CreateLogger("agent-seeder"), configModule, systems.clientProvider, systems.workspaceManager)
 
 		core.EnsureDefaultWorkspaceDashboard(logManagerModule.CreateLogger("dashboard-seeder"), configModule)
+
+		core.EnsureDefaultPlatformConfig(
+			logManagerModule.CreateLogger("platform-config-seeder"),
+			systems.clientProvider,
+			core.PlatformBootstrap{
+				RepositoryURL: configModule.Get("MO_PLATFORM_BOOTSTRAP_REPOSITORY_URL"),
+				Branch:        configModule.Get("MO_PLATFORM_BOOTSTRAP_REPOSITORY_BRANCH"),
+				Path:          configModule.Get("MO_PLATFORM_BOOTSTRAP_REPOSITORY_PATH"),
+				Engine:        configModule.Get("MO_PLATFORM_BOOTSTRAP_GITOPS_ENGINE"),
+			},
+		)
 	})
 
 	systems.leaderElector.OnLeadingEnded(func() {

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -261,6 +261,13 @@ func LoadConfigDeclarations(configModule *config.Config) {
 		Type:         new(config.ConfigVariableTypeBool),
 	})
 	configModule.Declare(config.ConfigDeclaration{
+		Key:          "MO_PLATFORM_CONFIG_ENABLED",
+		DefaultValue: new("false"),
+		Description:  new("Manage the cluster's platform from a PlatformConfig: install the platformconfigs/platformpatches CRDs, watch them, and create the declared components (ingress, cert-manager, metrics, ...). Off by default because switching it on hands the platform stack of an existing cluster over to the operator."),
+		Envs:         []string{"PLATFORM_CONFIG_ENABLED"},
+		Type:         new(config.ConfigVariableTypeBool),
+	})
+	configModule.Declare(config.ConfigDeclaration{
 		Key:          "MO_SSH_GATEWAY_ENABLED",
 		DefaultValue: new("true"),
 		Description:  new("Serve SSH sessions (kind=ssh port-forwards) from the embedded SSH gateway: interactive shell, sftp file access and port forwarding inside the pod. Set to false to switch the feature off for this cluster."),

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -261,13 +261,6 @@ func LoadConfigDeclarations(configModule *config.Config) {
 		Type:         new(config.ConfigVariableTypeBool),
 	})
 	configModule.Declare(config.ConfigDeclaration{
-		Key:          "MO_PLATFORM_CONFIG_ENABLED",
-		DefaultValue: new("false"),
-		Description:  new("Manage the cluster's platform from a PlatformConfig: install the platformconfigs/platformpatches CRDs, watch them, and create the declared components (ingress, cert-manager, metrics, ...). Off by default because switching it on hands the platform stack of an existing cluster over to the operator."),
-		Envs:         []string{"PLATFORM_CONFIG_ENABLED"},
-		Type:         new(config.ConfigVariableTypeBool),
-	})
-	configModule.Declare(config.ConfigDeclaration{
 		Key:          "MO_SSH_GATEWAY_ENABLED",
 		DefaultValue: new("true"),
 		Description:  new("Serve SSH sessions (kind=ssh port-forwards) from the embedded SSH gateway: interactive shell, sftp file access and port forwarding inside the pod. Set to false to switch the feature off for this cluster."),

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -280,8 +280,8 @@ func LoadConfigDeclarations(configModule *config.Config) {
 	})
 	configModule.Declare(config.ConfigDeclaration{
 		Key:          "MO_PLATFORM_BOOTSTRAP_GITOPS_ENGINE",
-		DefaultValue: new("argo-cd"),
-		Description:  new("GitOps engine this cluster runs, \"argo-cd\" or \"flux\". Declared in the seeded PlatformConfig without being enabled: Helm installs the engine during onboarding, and enabling it would have the operator install a second one alongside."),
+		DefaultValue: new("flux"),
+		Description:  new("GitOps engine this cluster runs, \"flux\" or \"argo-cd\". Declared in the seeded PlatformConfig without being enabled: Helm installs the engine during onboarding, and enabling it would have the operator install a second one alongside."),
 		Envs:         []string{"PLATFORM_BOOTSTRAP_GITOPS_ENGINE"},
 	})
 	configModule.Declare(config.ConfigDeclaration{

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -261,6 +261,30 @@ func LoadConfigDeclarations(configModule *config.Config) {
 		Type:         new(config.ConfigVariableTypeBool),
 	})
 	configModule.Declare(config.ConfigDeclaration{
+		Key:          "MO_PLATFORM_BOOTSTRAP_REPOSITORY_URL",
+		DefaultValue: new(""),
+		Description:  new("Clone URL of the repository holding platformconfig.yaml. Seeded into the PlatformConfig the operator creates, so the GitOps engine can be pointed at it before the config itself has been read from there. Empty means this cluster was not onboarded with a platform repository."),
+		Envs:         []string{"PLATFORM_BOOTSTRAP_REPOSITORY_URL"},
+	})
+	configModule.Declare(config.ConfigDeclaration{
+		Key:          "MO_PLATFORM_BOOTSTRAP_REPOSITORY_BRANCH",
+		DefaultValue: new("main"),
+		Description:  new("Branch the platform repository is tracked on."),
+		Envs:         []string{"PLATFORM_BOOTSTRAP_REPOSITORY_BRANCH"},
+	})
+	configModule.Declare(config.ConfigDeclaration{
+		Key:          "MO_PLATFORM_BOOTSTRAP_REPOSITORY_PATH",
+		DefaultValue: new("platform"),
+		Description:  new("Directory in the platform repository holding platformconfig.yaml. A directory, not a file: Argo CD's source.path and Flux's Kustomization.spec.path both address directories, so pointing at the repository root would sync every manifest next to it."),
+		Envs:         []string{"PLATFORM_BOOTSTRAP_REPOSITORY_PATH"},
+	})
+	configModule.Declare(config.ConfigDeclaration{
+		Key:          "MO_PLATFORM_BOOTSTRAP_GITOPS_ENGINE",
+		DefaultValue: new("argo-cd"),
+		Description:  new("GitOps engine this cluster runs, \"argo-cd\" or \"flux\". Declared in the seeded PlatformConfig without being enabled: Helm installs the engine during onboarding, and enabling it would have the operator install a second one alongside."),
+		Envs:         []string{"PLATFORM_BOOTSTRAP_GITOPS_ENGINE"},
+	})
+	configModule.Declare(config.ConfigDeclaration{
 		Key:          "MO_SSH_GATEWAY_ENABLED",
 		DefaultValue: new("true"),
 		Description:  new("Serve SSH sessions (kind=ssh port-forwards) from the embedded SSH gateway: interactive shell, sftp file access and port forwarding inside the pod. Set to false to switch the feature off for this cluster."),

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -258,7 +258,8 @@ func (self *core) Initialize() error {
 		return fmt.Errorf("failed to create resource template configmap: %s", err)
 	}
 
-	mokubernetes.InitOrUpdateCrds()
+	platformConfigEnabled, _ := self.config.TryGetBool("MO_PLATFORM_CONFIG_ENABLED")
+	mokubernetes.InitOrUpdateCrds(platformConfigEnabled)
 
 	// Init Helm Config
 	go func() {

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -258,8 +258,7 @@ func (self *core) Initialize() error {
 		return fmt.Errorf("failed to create resource template configmap: %s", err)
 	}
 
-	platformConfigEnabled, _ := self.config.TryGetBool("MO_PLATFORM_CONFIG_ENABLED")
-	mokubernetes.InitOrUpdateCrds(platformConfigEnabled)
+	mokubernetes.InitOrUpdateCrds()
 
 	// Init Helm Config
 	go func() {

--- a/src/core/platformconfigseeder.go
+++ b/src/core/platformconfigseeder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 
+	"mogenius-operator/src/gitops"
 	"mogenius-operator/src/k8sclient"
 	"mogenius-operator/src/kubernetes"
 	"mogenius-operator/src/utils"
@@ -17,12 +18,67 @@ import (
 // reads the GitOps status from. The name is a convention shared with the API.
 const DEFAULT_PLATFORM_CONFIG_NAME = "platform"
 
-// EnsureDefaultPlatformConfig creates an empty default PlatformConfig if none
-// exists, so the operator always has an object to publish the detected GitOps
-// status on. Meant to run on the leader — concurrent replicas would only race
-// into AlreadyExists errors, which are tolerated anyway. Non-fatal: without the
+// PlatformBootstrap is the repository the operator was installed with, from
+// MO_PLATFORM_BOOTSTRAP_*.
+//
+// It exists to break one circle: the GitOps engine has to be pointed at the
+// repository before the PlatformConfig can arrive from it, and the config
+// cannot declare its own location before anything has read it. Passing the
+// location at install time seeds it into the resource the operator creates
+// anyway, and reconciling that entry is what pulls the real config in — which
+// then declares the same repository and takes over.
+type PlatformBootstrap struct {
+	RepositoryURL string
+	Branch        string
+	Path          string
+	Engine        string
+}
+
+func (b PlatformBootstrap) configured() bool {
+	return b.RepositoryURL != "" && b.Path != ""
+}
+
+// gitOpsSpec is the seed's spec.gitOps: the engine declared but not enabled,
+// and the repository it should sync.
+//
+// Not enabled, because Helm installed the engine — enabling it would have the
+// operator install a second one next to that release. Declaring it is still
+// what tells the platform which engine this cluster runs.
+func (b PlatformBootstrap) gitOpsSpec() map[string]any {
+	engineBlock := map[string]any{"enabled": false}
+
+	gitOps := map[string]any{}
+	if b.Engine == gitops.EngineFlux {
+		gitOps["fluxcd"] = engineBlock
+	} else {
+		gitOps["argocd"] = engineBlock
+	}
+
+	gitOps["repositories"] = []any{
+		map[string]any{
+			"name": DEFAULT_PLATFORM_CONFIG_NAME,
+			"url":  b.RepositoryURL,
+			// The CRD calls it revision; it is the branch the source tracks.
+			"revision": b.Branch,
+			"path":     b.Path,
+		},
+	}
+
+	return gitOps
+}
+
+// EnsureDefaultPlatformConfig creates a default PlatformConfig if none exists,
+// so the operator always has an object to publish the detected GitOps status
+// on, and — when the operator was installed with a bootstrap repository — to
+// carry that repository until the synced config replaces it.
+//
+// Only on create. Once the GitOps engine syncs the real config, that is the
+// authority, and re-seeding would fight it on every restart.
+//
+// Meant to run on the leader — concurrent replicas would only race into
+// AlreadyExists errors, which are tolerated anyway. Non-fatal: without the
 // object the operator simply reports no status.
-func EnsureDefaultPlatformConfig(logger *slog.Logger, clientProvider k8sclient.K8sClientProvider) {
+func EnsureDefaultPlatformConfig(logger *slog.Logger, clientProvider k8sclient.K8sClientProvider, bootstrap PlatformBootstrap) {
 	client := clientProvider.DynamicClient().Resource(
 		kubernetes.CreateGroupVersionResource(utils.PlatformConfigResource.ApiVersion, utils.PlatformConfigResource.Plural),
 	)
@@ -36,11 +92,16 @@ func EnsureDefaultPlatformConfig(logger *slog.Logger, clientProvider k8sclient.K
 		return
 	}
 
+	spec := map[string]any{}
+	if bootstrap.configured() {
+		spec["gitOps"] = bootstrap.gitOpsSpec()
+	}
+
 	platformConfig := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": utils.PlatformConfigResource.ApiVersion,
 		"kind":       utils.PlatformConfigResource.Kind,
 		"metadata":   map[string]any{"name": DEFAULT_PLATFORM_CONFIG_NAME},
-		"spec":       map[string]any{},
+		"spec":       spec,
 	}}
 
 	if _, err := client.Create(context.Background(), platformConfig, metav1.CreateOptions{}); err != nil {
@@ -51,5 +112,6 @@ func EnsureDefaultPlatformConfig(logger *slog.Logger, clientProvider k8sclient.K
 		return
 	}
 
-	logger.Info("created default platform config", "name", DEFAULT_PLATFORM_CONFIG_NAME)
+	logger.Info("created default platform config", "name", DEFAULT_PLATFORM_CONFIG_NAME,
+		"bootstrapRepository", bootstrap.RepositoryURL, "bootstrapPath", bootstrap.Path)
 }

--- a/src/core/platformconfigseeder.go
+++ b/src/core/platformconfigseeder.go
@@ -48,10 +48,12 @@ func (b PlatformBootstrap) gitOpsSpec() map[string]any {
 	engineBlock := map[string]any{"enabled": false}
 
 	gitOps := map[string]any{}
-	if b.Engine == gitops.EngineFlux {
-		gitOps["fluxcd"] = engineBlock
-	} else {
+	// Flux unless Argo CD was asked for by name, so an empty or unrecognised
+	// value lands on the same engine the charts default to.
+	if b.Engine == gitops.EngineArgoCD {
 		gitOps["argocd"] = engineBlock
+	} else {
+		gitOps["fluxcd"] = engineBlock
 	}
 
 	gitOps["repositories"] = []any{

--- a/src/core/platformconfigseeder_test.go
+++ b/src/core/platformconfigseeder_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"testing"
+
+	"mogenius-operator/src/gitops"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlatformBootstrapConfigured(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, PlatformBootstrap{RepositoryURL: "https://github.com/acme/platform.git", Path: "platform"}.configured())
+
+	// Both are needed: a url without a directory gives the engine nothing to
+	// sync, and a directory without a url points nowhere.
+	assert.False(t, PlatformBootstrap{Path: "platform"}.configured())
+	assert.False(t, PlatformBootstrap{RepositoryURL: "https://github.com/acme/platform.git"}.configured())
+	assert.False(t, PlatformBootstrap{}.configured())
+}
+
+func TestPlatformBootstrapGitOpsSpec(t *testing.T) {
+	t.Parallel()
+
+	bootstrap := PlatformBootstrap{
+		RepositoryURL: "https://github.com/acme/platform.git",
+		Branch:        "main",
+		Path:          "platform",
+		Engine:        gitops.EngineArgoCD,
+	}
+
+	spec := bootstrap.gitOpsSpec()
+
+	/**
+	 * Declared but not enabled. Helm installed the engine, so enabling it would
+	 * have the operator install a second one next to that release -- while
+	 * declaring it is still what tells the platform which engine runs here.
+	 */
+	argocd, ok := spec["argocd"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, false, argocd["enabled"])
+	assert.NotContains(t, spec, "fluxcd")
+
+	repositories, ok := spec["repositories"].([]any)
+	assert.True(t, ok)
+	assert.Len(t, repositories, 1)
+
+	repository := repositories[0].(map[string]any)
+	assert.Equal(t, "https://github.com/acme/platform.git", repository["url"])
+	// The CRD calls the branch "revision".
+	assert.Equal(t, "main", repository["revision"])
+	assert.Equal(t, "platform", repository["path"])
+	assert.Equal(t, DEFAULT_PLATFORM_CONFIG_NAME, repository["name"])
+}
+
+func TestPlatformBootstrapGitOpsSpecFlux(t *testing.T) {
+	t.Parallel()
+
+	spec := PlatformBootstrap{
+		RepositoryURL: "https://github.com/acme/platform.git",
+		Branch:        "main",
+		Path:          "platform",
+		Engine:        gitops.EngineFlux,
+	}.gitOpsSpec()
+
+	fluxcd, ok := spec["fluxcd"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, false, fluxcd["enabled"])
+	assert.NotContains(t, spec, "argocd")
+}
+
+// An unrecognised engine falls back to Argo CD rather than declaring nothing:
+// a spec with no engine block leaves the platform unable to tell what runs.
+func TestPlatformBootstrapGitOpsSpecUnknownEngineFallsBackToArgo(t *testing.T) {
+	t.Parallel()
+
+	spec := PlatformBootstrap{
+		RepositoryURL: "https://github.com/acme/platform.git",
+		Path:          "platform",
+		Engine:        "something-else",
+	}.gitOpsSpec()
+
+	assert.Contains(t, spec, "argocd")
+	assert.NotContains(t, spec, "fluxcd")
+}

--- a/src/core/platformconfigseeder_test.go
+++ b/src/core/platformconfigseeder_test.go
@@ -70,17 +70,20 @@ func TestPlatformBootstrapGitOpsSpecFlux(t *testing.T) {
 	assert.NotContains(t, spec, "argocd")
 }
 
-// An unrecognised engine falls back to Argo CD rather than declaring nothing:
-// a spec with no engine block leaves the platform unable to tell what runs.
-func TestPlatformBootstrapGitOpsSpecUnknownEngineFallsBackToArgo(t *testing.T) {
+// An unrecognised engine falls back to Flux rather than declaring nothing: a
+// spec with no engine block leaves the platform unable to tell what runs, and
+// Flux is what the charts install when nobody chose.
+func TestPlatformBootstrapGitOpsSpecUnknownEngineFallsBackToFlux(t *testing.T) {
 	t.Parallel()
 
-	spec := PlatformBootstrap{
-		RepositoryURL: "https://github.com/acme/platform.git",
-		Path:          "platform",
-		Engine:        "something-else",
-	}.gitOpsSpec()
+	for _, engine := range []string{"", "something-else"} {
+		spec := PlatformBootstrap{
+			RepositoryURL: "https://github.com/acme/platform.git",
+			Path:          "platform",
+			Engine:        engine,
+		}.gitOpsSpec()
 
-	assert.Contains(t, spec, "argocd")
-	assert.NotContains(t, spec, "fluxcd")
+		assert.Contains(t, spec, "fluxcd", "engine %q", engine)
+		assert.NotContains(t, spec, "argocd", "engine %q", engine)
+	}
 }

--- a/src/gitops/argocd.go
+++ b/src/gitops/argocd.go
@@ -26,14 +26,14 @@ type argocdInstaller struct {
 func (a *argocdInstaller) Install(component string, artifact GitOpsArtifact) error {
 	app := buildArgoApplication(component, artifact, a.namespace)
 	app.SetOwnerReferences(a.ownerRefs)
-	if err := applyUnstructured(a.clientProvider, argoApplicationGVR, a.namespace, app); err != nil {
+	if err := Apply(a.clientProvider, argoApplicationGVR, a.namespace, app); err != nil {
 		return fmt.Errorf("apply argocd application %s: %w", component, err)
 	}
 
 	if len(artifact.ExtraObjects) > 0 {
 		moacApp := buildArgoMoacApplication(component, artifact, a.namespace)
 		moacApp.SetOwnerReferences(a.ownerRefs)
-		if err := applyUnstructured(a.clientProvider, argoApplicationGVR, a.namespace, moacApp); err != nil {
+		if err := Apply(a.clientProvider, argoApplicationGVR, a.namespace, moacApp); err != nil {
 			return fmt.Errorf("apply argocd moac application %s-resources: %w", component, err)
 		}
 	}

--- a/src/gitops/flux.go
+++ b/src/gitops/flux.go
@@ -44,25 +44,25 @@ func (f *fluxInstaller) Install(component string, artifact GitOpsArtifact) error
 	if isOCIRepository(artifact.HelmChart.Repository) {
 		ociRepo := buildFluxOCIRepository(component, artifact.HelmChart.Repository, artifact.HelmChart.Version, f.namespace)
 		ociRepo.SetOwnerReferences(f.ownerRefs)
-		if err := applyUnstructured(f.clientProvider, fluxOCIRepositoryGVR, f.namespace, ociRepo); err != nil {
+		if err := Apply(f.clientProvider, fluxOCIRepositoryGVR, f.namespace, ociRepo); err != nil {
 			return fmt.Errorf("apply flux ocirepository %s: %w", component, err)
 		}
 
 		release := buildFluxOCIHelmRelease(component, artifact, f.namespace)
 		release.SetOwnerReferences(f.ownerRefs)
-		if err := applyUnstructured(f.clientProvider, fluxHelmReleaseGVR, f.namespace, release); err != nil {
+		if err := Apply(f.clientProvider, fluxHelmReleaseGVR, f.namespace, release); err != nil {
 			return fmt.Errorf("apply flux helmrelease %s: %w", component, err)
 		}
 	} else {
 		repo := buildFluxHelmRepository(component, artifact.HelmChart.Repository, f.namespace)
 		repo.SetOwnerReferences(f.ownerRefs)
-		if err := applyUnstructured(f.clientProvider, fluxHelmRepositoryGVR, f.namespace, repo); err != nil {
+		if err := Apply(f.clientProvider, fluxHelmRepositoryGVR, f.namespace, repo); err != nil {
 			return fmt.Errorf("apply flux helmrepository %s: %w", component, err)
 		}
 
 		release := buildFluxHelmRelease(component, artifact, artifact.Values, f.namespace)
 		release.SetOwnerReferences(f.ownerRefs)
-		if err := applyUnstructured(f.clientProvider, fluxHelmReleaseGVR, f.namespace, release); err != nil {
+		if err := Apply(f.clientProvider, fluxHelmReleaseGVR, f.namespace, release); err != nil {
 			return fmt.Errorf("apply flux helmrelease %s: %w", component, err)
 		}
 	}
@@ -70,13 +70,13 @@ func (f *fluxInstaller) Install(component string, artifact GitOpsArtifact) error
 	if len(artifact.ExtraObjects) > 0 {
 		moacRepo := buildFluxHelmRepository(component+"-resources", moacRepository, f.namespace)
 		moacRepo.SetOwnerReferences(f.ownerRefs)
-		if err := applyUnstructured(f.clientProvider, fluxHelmRepositoryGVR, f.namespace, moacRepo); err != nil {
+		if err := Apply(f.clientProvider, fluxHelmRepositoryGVR, f.namespace, moacRepo); err != nil {
 			return fmt.Errorf("apply flux moac helmrepository %s-resources: %w", component, err)
 		}
 
 		moacRelease := buildFluxMoacHelmRelease(component, artifact, f.namespace)
 		moacRelease.SetOwnerReferences(f.ownerRefs)
-		if err := applyUnstructured(f.clientProvider, fluxHelmReleaseGVR, f.namespace, moacRelease); err != nil {
+		if err := Apply(f.clientProvider, fluxHelmReleaseGVR, f.namespace, moacRelease); err != nil {
 			return fmt.Errorf("apply flux moac helmrelease %s-resources: %w", component, err)
 		}
 	}

--- a/src/gitops/installer.go
+++ b/src/gitops/installer.go
@@ -84,7 +84,12 @@ func defaultLabels(component string) map[string]string {
 }
 
 // applyUnstructured creates or updates a namespaced resource via the dynamic client.
-func applyUnstructured(cp k8sclient.K8sClientProvider, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
+// Apply creates the object, or updates it in place when it already exists.
+//
+// Exported for the reconciler: objects that belong to an engine mogenius does
+// not own cannot ship as extra objects of a release it installed, because
+// there is no such release -- they have to be applied directly.
+func Apply(cp k8sclient.K8sClientProvider, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
 	ctx := context.Background()
 	client := cp.DynamicClient().Resource(gvr).Namespace(namespace)
 

--- a/src/kubernetes/addresources.go
+++ b/src/kubernetes/addresources.go
@@ -33,18 +33,9 @@ func GetValkeyPwd() (*string, error) {
 	return &foundPwd, nil
 }
 
-// InitOrUpdateCrds installs the mogenius CRDs. platformConfigEnabled carries
-// MO_PLATFORM_CONFIG_ENABLED: the PlatformConfig CRDs only go on when the
-// cluster opted into having its platform managed, because their presence is
-// what makes the operator start creating platform components.
-func InitOrUpdateCrds(platformConfigEnabled bool) {
+func InitOrUpdateCrds() {
 	crds := crds.GetCRDs()
 	for _, crd := range crds {
-		if (crd.Filename == "mogenius.com_platformconfigs.yaml" ||
-			crd.Filename == "mogenius.com_platformpatches.yaml") &&
-			!platformConfigEnabled && !utils.IsDevBuild() {
-			continue
-		}
 		// TODO: Remove the dev build gaurd when the UI config feature is ready.
 		if crd.Filename == "mogenius.com_uiconfigs.yaml" && !utils.IsDevBuild() {
 			continue

--- a/src/kubernetes/addresources.go
+++ b/src/kubernetes/addresources.go
@@ -33,13 +33,20 @@ func GetValkeyPwd() (*string, error) {
 	return &foundPwd, nil
 }
 
-func InitOrUpdateCrds() {
+// InitOrUpdateCrds installs the mogenius CRDs. platformConfigEnabled carries
+// MO_PLATFORM_CONFIG_ENABLED: the PlatformConfig CRDs only go on when the
+// cluster opted into having its platform managed, because their presence is
+// what makes the operator start creating platform components.
+func InitOrUpdateCrds(platformConfigEnabled bool) {
 	crds := crds.GetCRDs()
 	for _, crd := range crds {
-		// TODO: Remove the dev build gaurd when platform config is ready, and add other platform components as needed.
 		if (crd.Filename == "mogenius.com_platformconfigs.yaml" ||
-			crd.Filename == "mogenius.com_platformpatches.yaml" ||
-			crd.Filename == "mogenius.com_uiconfigs.yaml") && !utils.IsDevBuild() {
+			crd.Filename == "mogenius.com_platformpatches.yaml") &&
+			!platformConfigEnabled && !utils.IsDevBuild() {
+			continue
+		}
+		// TODO: Remove the dev build gaurd when the UI config feature is ready.
+		if crd.Filename == "mogenius.com_uiconfigs.yaml" && !utils.IsDevBuild() {
 			continue
 		}
 		err := CreateOrUpdateYamlString(crd.Content)

--- a/src/kubernetes/addresources.go
+++ b/src/kubernetes/addresources.go
@@ -7,7 +7,6 @@ import (
 
 	"mogenius-operator/src/crds"
 	"mogenius-operator/src/shutdown"
-	"mogenius-operator/src/utils"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,10 +35,6 @@ func GetValkeyPwd() (*string, error) {
 func InitOrUpdateCrds() {
 	crds := crds.GetCRDs()
 	for _, crd := range crds {
-		// TODO: Remove the dev build gaurd when the UI config feature is ready.
-		if crd.Filename == "mogenius.com_uiconfigs.yaml" && !utils.IsDevBuild() {
-			continue
-		}
 		err := CreateOrUpdateYamlString(crd.Content)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
 			k8sLogger.Error("error updating/creating mogenius CRD", "filename", crd.Filename, "error", err)

--- a/src/reconciler/factory.go
+++ b/src/reconciler/factory.go
@@ -66,12 +66,12 @@ func NewReconcilerFactory(logger *slog.Logger, clientProvider k8sclient.K8sClien
 	factory.WithReconciler(utils.AiModelResource, factory.module.reconcileAiModels, NamespaceFilter(ownNamespace))
 	factory.WithReconciler(utils.McpServerResource, factory.module.reconcileMcpServers, NamespaceFilter(ownNamespace))
 
-	// TODO: Remove gaurd when platform config is ready, and add other platform components as needed.
-	// Gated together with the platformconfigs CRD (see kubernetes.InitOrUpdateCrds).
-	// Reporting the detected GitOps engine in the status is safe on any cluster, so
-	// this guard can go once the CRD ships everywhere; installing platform
-	// components from the spec keeps its own guard inside reconcilePlatformConfig.
-	if utils.IsDevBuild() {
+	// Gated together with the platformconfigs CRD (see kubernetes.InitOrUpdateCrds):
+	// without the CRD there is nothing to watch, and with it the operator is
+	// expected to act on what it finds. Dev builds keep the feature on so the
+	// onboarding flow can be exercised without setting the flag.
+	platformConfigEnabled, _ := configModule.TryGetBool("MO_PLATFORM_CONFIG_ENABLED")
+	if platformConfigEnabled || utils.IsDevBuild() {
 		factory.WithReconciler(utils.PlatformConfigResource, factory.module.reconcilePlatformConfig)
 	}
 

--- a/src/reconciler/factory.go
+++ b/src/reconciler/factory.go
@@ -66,14 +66,10 @@ func NewReconcilerFactory(logger *slog.Logger, clientProvider k8sclient.K8sClien
 	factory.WithReconciler(utils.AiModelResource, factory.module.reconcileAiModels, NamespaceFilter(ownNamespace))
 	factory.WithReconciler(utils.McpServerResource, factory.module.reconcileMcpServers, NamespaceFilter(ownNamespace))
 
-	// Gated together with the platformconfigs CRD (see kubernetes.InitOrUpdateCrds):
-	// without the CRD there is nothing to watch, and with it the operator is
-	// expected to act on what it finds. Dev builds keep the feature on so the
-	// onboarding flow can be exercised without setting the flag.
-	platformConfigEnabled, _ := configModule.TryGetBool("MO_PLATFORM_CONFIG_ENABLED")
-	if platformConfigEnabled || utils.IsDevBuild() {
-		factory.WithReconciler(utils.PlatformConfigResource, factory.module.reconcilePlatformConfig)
-	}
+	// Cluster-scoped, hence no namespace filter. An empty spec only publishes the
+	// detected GitOps status, so watching this costs a cluster nothing until it
+	// declares components.
+	factory.WithReconciler(utils.PlatformConfigResource, factory.module.reconcilePlatformConfig)
 
 	return factory
 }

--- a/src/reconciler/platformConfig.go
+++ b/src/reconciler/platformConfig.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"mogenius-operator/src/crds/v1alpha1"
 	"mogenius-operator/src/gitops"
-	"mogenius-operator/src/utils"
 	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +59,33 @@ const (
 	gitOpsSourceDetected = "detected"
 )
 
-const argoCDDefaultProject = "mogenius"
+// argoCDDefaultProject is the AppProject mogenius creates alongside its own
+// Argo CD install. argoCDFallbackProject is what the platform uses instead when
+// the engine belongs to the user: "default" ships with every Argo CD, while
+// "mogenius" would only exist where mogenius installed the engine itself.
+const (
+	argoCDDefaultProject  = "mogenius"
+	argoCDFallbackProject = "default"
+)
+
+// argoProjectName is the AppProject the platform's Applications are created in.
+//
+// An explicit spec.gitOps.argocd.project is always honoured — it is the user's
+// declaration, and keeping it existing is then their business. Without one the
+// answer depends on who owns the engine, because the platform can only rely on
+// a project it created itself.
+func argoProjectName(gitOps *v1alpha1.GitOpsConfig) string {
+	if gitOps == nil || gitOps.ArgoCD == nil {
+		return argoCDFallbackProject
+	}
+	if gitOps.ArgoCD.Project != "" {
+		return gitOps.ArgoCD.Project
+	}
+	if gitOps.ArgoCD.Enabled {
+		return argoCDDefaultProject
+	}
+	return argoCDFallbackProject
+}
 
 func (d *reconcilerModule) reconcilePlatformConfig(ctx context.Context, obj *unstructured.Unstructured, op operation) []ReconcileResult {
 	var platformConfig v1alpha1.PlatformConfig
@@ -70,18 +95,21 @@ func (d *reconcilerModule) reconcilePlatformConfig(ctx context.Context, obj *uns
 
 	gitOpsStatus := buildGitOpsStatus(platformConfig.Spec, d.detectGitOpsStatus(ctx))
 
-	engine, engineNs, err := inferGitOpsEngine(platformConfig.Spec.GitOps)
+	// specEngine is the engine mogenius is asked to install; it is empty unless
+	// spec.gitOps enables one.
+	specEngine, specEngineNs, err := inferGitOpsEngine(platformConfig.Spec.GitOps)
 	if err != nil {
 		d.patchGitOpsStatus(ctx, obj.GetName(), platformConfig.Status.GitOpsStatus, gitOpsStatus)
 		return []ReconcileResult{{Err: err}}
 	}
 
-	// Installing platform components is still gated behind dev builds, but the
-	// GitOps status is reported on every cluster — including clusters where the
-	// engine is user-managed and the spec configures nothing at all.
-	if engine == "" || !utils.IsDevBuild() {
-		d.logger.Info("skipping reconciliation of GitOps components, reporting GitOps status only",
-			"name", obj.GetName(), "specEngine", engine, "engine", gitOpsStatus.Engine, "installed", gitOpsStatus.Installed)
+	engine, engineNs := deliveryEngine(specEngine, specEngineNs, gitOpsStatus)
+
+	// No engine anywhere: components ship as Applications/HelmReleases, so there
+	// is nothing to deliver them with. The status still gets reported.
+	if engine == "" {
+		d.logger.Info("skipping reconciliation of platform components, reporting GitOps status only",
+			"name", obj.GetName(), "specEngine", specEngine, "engine", gitOpsStatus.Engine, "installed", gitOpsStatus.Installed)
 		d.patchGitOpsStatus(ctx, obj.GetName(), platformConfig.Status.GitOpsStatus, gitOpsStatus)
 		return nil
 	}
@@ -99,25 +127,28 @@ func (d *reconcilerModule) reconcilePlatformConfig(ctx context.Context, obj *uns
 		result *ReconcileResult
 	}
 
-	var gitopsResult componentResult
-	switch engine {
+	// Capacity: the eight non-engine components plus the engine, when mogenius
+	// owns it. The engine is only reconciled in that case — reconciling a
+	// user-managed engine would adopt a Helm release someone else installed and
+	// overwrite their values on the next sweep.
+	components := make([]componentResult, 0, 9)
+	switch specEngine {
 	case gitOpsEngineArgoCD:
-		gitopsResult = componentResult{name: componentArgoCD, result: d.reconcileArgoCD(ctx, platformConfig.Spec, installer, op)}
+		components = append(components, componentResult{name: componentArgoCD, result: d.reconcileArgoCD(ctx, platformConfig.Spec, installer, op)})
 	case gitOpsEngineFlux:
-		gitopsResult = componentResult{name: componentFluxCD, result: d.reconcileFluxCD(ctx, platformConfig.Spec, installer, op)}
+		components = append(components, componentResult{name: componentFluxCD, result: d.reconcileFluxCD(ctx, platformConfig.Spec, installer, op)})
 	}
 
-	components := []componentResult{
-		gitopsResult,
-		{componentExternalSecretsOperator, d.reconcileExternalSecretsOperator(ctx, platformConfig.Spec, installer, op)},
-		{componentCertManager, d.reconcileCertManager(ctx, platformConfig.Spec, installer, op)},
-		{componentTraefik, d.reconcileTraefik(ctx, platformConfig.Spec, installer, op)},
-		{componentExternalDNS, d.reconcileExternalDNS(ctx, platformConfig.Spec, installer, op)},
-		{componentKubePrometheusStack, d.reconcileKubePrometheusStack(ctx, platformConfig.Spec, installer, op)},
-		{componentLoki, d.reconcileLoki(ctx, platformConfig.Spec, installer, op)},
-		{componentAlloy, d.reconcileAlloy(ctx, platformConfig.Spec, installer, op)},
-		{componentRenovateOperator, d.reconcileRenovateOperator(ctx, platformConfig.Spec, installer, op)},
-	}
+	components = append(components,
+		componentResult{componentExternalSecretsOperator, d.reconcileExternalSecretsOperator(ctx, platformConfig.Spec, installer, op)},
+		componentResult{componentCertManager, d.reconcileCertManager(ctx, platformConfig.Spec, installer, op)},
+		componentResult{componentTraefik, d.reconcileTraefik(ctx, platformConfig.Spec, installer, op)},
+		componentResult{componentExternalDNS, d.reconcileExternalDNS(ctx, platformConfig.Spec, installer, op)},
+		componentResult{componentKubePrometheusStack, d.reconcileKubePrometheusStack(ctx, platformConfig.Spec, installer, op)},
+		componentResult{componentLoki, d.reconcileLoki(ctx, platformConfig.Spec, installer, op)},
+		componentResult{componentAlloy, d.reconcileAlloy(ctx, platformConfig.Spec, installer, op)},
+		componentResult{componentRenovateOperator, d.reconcileRenovateOperator(ctx, platformConfig.Spec, installer, op)},
+	)
 
 	// Index existing conditions so LastTransitionTime is preserved when status hasn't changed.
 	existingConditions := make(map[string]metav1.Condition, len(platformConfig.Status.Conditions))
@@ -245,7 +276,10 @@ func buildGitOpsStatus(spec v1alpha1.PlatformConfigSpec, detection gitOpsDetecti
 		ReleaseName:   helmReleaseName(chart, ""),
 	}
 	if engine == gitOpsEngineArgoCD {
-		status.DefaultProjectName = firstNonEmpty(project, argoCDDefaultProject)
+		// The same project getSpecificGitOpsConfig hands to the installer: the API
+		// places its own Applications by this value, so a name that only exists on
+		// a mogenius-installed engine would break them on a user-managed one.
+		status.DefaultProjectName = firstNonEmpty(project, argoProjectName(spec.GitOps))
 	}
 
 	if detected != nil {
@@ -341,6 +375,26 @@ func inferGitOpsEngine(gitOps *v1alpha1.GitOpsConfig) (engine, namespace string,
 		return gitOpsEngineFlux, helmNamespace(gitOps.FluxCD.Chart, fluxcdDefaultNamespace), nil
 	}
 	return "", "", nil
+}
+
+// deliveryEngine picks the engine the platform components are delivered
+// through. That is a different question from who installs the engine: during
+// onboarding Helm brings Argo CD or Flux and spec.gitOps leaves it disabled, so
+// without falling back to the detected engine those clusters would get no
+// components at all — the spec engine is empty and everything ships as an
+// Application or HelmRelease.
+//
+// An empty engine means there is nothing to deliver with.
+func deliveryEngine(specEngine, specEngineNamespace string, status *v1alpha1.GitOpsStatus) (engine, namespace string) {
+	if specEngine != "" {
+		return specEngine, specEngineNamespace
+	}
+	// Only a running engine counts. A declared-but-absent one has no namespace
+	// to create objects in, and they would be rejected outright.
+	if status != nil && status.Installed {
+		return status.Engine, status.Namespace
+	}
+	return "", ""
 }
 
 // extractPatchExtraObjects decodes the raw ExtraObjects from a PlatformPatch into

--- a/src/reconciler/platformConfig.go
+++ b/src/reconciler/platformConfig.go
@@ -38,6 +38,9 @@ const (
 	componentAlloy                   = "alloy"
 	componentRenovateOperator        = "renovate-operator"
 	componentExternalSecretsOperator = "external-secrets-operator"
+	// Not a Helm chart like the others: the condition reports whether the
+	// objects that make the engine sync spec.gitOps.repositories are in place.
+	componentPlatformRepositories = "platform-repositories"
 )
 
 // GitOps engine identities as reported in status.gitOpsStatus.engine. These are
@@ -137,6 +140,16 @@ func (d *reconcilerModule) reconcilePlatformConfig(ctx context.Context, obj *uns
 		components = append(components, componentResult{name: componentArgoCD, result: d.reconcileArgoCD(ctx, platformConfig.Spec, installer, op)})
 	case gitOpsEngineFlux:
 		components = append(components, componentResult{name: componentFluxCD, result: d.reconcileFluxCD(ctx, platformConfig.Spec, installer, op)})
+	}
+
+	// Repositories the platform syncs itself. Only when mogenius does not own
+	// the engine: when it does, reconcileArgoCD/reconcileFluxCD ship the same
+	// objects as extra objects of the release they install.
+	if specEngine == "" {
+		components = append(components, componentResult{
+			name:   componentPlatformRepositories,
+			result: d.reconcilePlatformRepositories(ctx, platformConfig.Spec, engine, engineNs),
+		})
 	}
 
 	components = append(components,

--- a/src/reconciler/platform_argocd.go
+++ b/src/reconciler/platform_argocd.go
@@ -29,10 +29,7 @@ func (d *reconcilerModule) reconcileArgoCD(ctx context.Context, spec v1alpha1.Pl
 		func(ctx context.Context) ([]any, error) {
 			extraObjects := []any{}
 
-			project := "mogenius"
-			if spec.GitOps.ArgoCD.Project != "" {
-				project = spec.GitOps.ArgoCD.Project
-			}
+			project := argoProjectName(spec.GitOps)
 
 			appProject := map[string]any{
 				"apiVersion": utils.AppProjectResource.ApiVersion,

--- a/src/reconciler/platform_component.go
+++ b/src/reconciler/platform_component.go
@@ -109,12 +109,8 @@ func getSpecificGitOpsConfig(settings *v1alpha1.GitOpsConfig) (*gitops.ArgoCDSet
 	}
 
 	if settings.ArgoCD != nil {
-		project := "mogenius"
-		if settings.ArgoCD.Project != "" {
-			project = settings.ArgoCD.Project
-		}
 		return &gitops.ArgoCDSettings{
-			Project: project,
+			Project: argoProjectName(settings),
 		}, nil
 	}
 

--- a/src/reconciler/platform_default.go
+++ b/src/reconciler/platform_default.go
@@ -42,6 +42,12 @@ func getDefaultConfig(source string, version string, component string) (componen
 	if source == "" {
 		source = "https://raw.githubusercontent.com/mogenius/platform-defaults/refs/heads"
 	}
+	// An empty version would build ".../refs/heads//traefik.yaml", so every
+	// component fetch would 404 and no component could be installed at all --
+	// a confusing failure for a field the UI does not even offer.
+	if version == "" {
+		version = "main"
+	}
 	url := fmt.Sprintf("%s/%s/%s.yaml", source, version, component)
 
 	body, err := fetchDefaultConfigCached(url)

--- a/src/reconciler/platform_gitops_status.go
+++ b/src/reconciler/platform_gitops_status.go
@@ -58,13 +58,19 @@ func (g gitOpsDetection) forEngine(engine string) *engineDetection {
 	return nil
 }
 
-// preferred picks the engine to report when the spec names none. ArgoCD wins a
-// tie because it is the engine mogenius installs by default.
+// preferred picks the engine to report when the spec names none. Only an engine
+// that actually runs qualifies: CRDs outlive the install they came with, so a
+// leftover argoproj.io group must not outrank the engine doing the work. ArgoCD
+// wins a tie because it is the engine mogenius installs by default. Nil means
+// nothing runs, which leaves whatever the spec declares in place.
 func (g gitOpsDetection) preferred() *engineDetection {
-	if g.argoCD != nil {
+	if g.argoCD != nil && g.argoCD.installed {
 		return g.argoCD
 	}
-	return g.flux
+	if g.flux != nil && g.flux.installed {
+		return g.flux
+	}
+	return nil
 }
 
 // detectGitOpsStatus probes the live cluster for installed GitOps engines.
@@ -77,17 +83,18 @@ func (d *reconcilerModule) detectGitOpsStatus(ctx context.Context) gitOpsDetecti
 	}
 }
 
-// detectEngine probes a single engine. crd is the resource whose presence proves
-// the engine is installed; partOf is the app.kubernetes.io/part-of label value
-// its controller deployments carry.
+// detectEngine probes a single engine. crd is the resource the engine registers
+// -- without it the engine was never installed here, with it the probe goes on
+// to look for what actually runs; partOf is the app.kubernetes.io/part-of label
+// value its controller deployments carry.
 func (d *reconcilerModule) detectEngine(ctx context.Context, engine string, crd utils.ResourceDescriptor, partOf string) *engineDetection {
 	if !d.crdChecker.IsAvailable(crd) {
 		return nil
 	}
 
-	detection := &engineDetection{engine: engine, installed: true}
+	detection := &engineDetection{engine: engine}
 
-	deployments := d.listEngineDeployments(ctx, partOf)
+	deployments, listErr := d.listEngineDeployments(ctx, partOf)
 	for _, deployment := range deployments {
 		annotations := deployment.GetAnnotations()
 		if detection.namespace == "" {
@@ -101,10 +108,12 @@ func (d *reconcilerModule) detectEngine(ctx context.Context, engine string, crd 
 
 	switch engine {
 	case gitOpsEngineFlux:
-		detection.version = firstNonEmpty(
-			d.fluxReportVersion(ctx, detection.namespace),
-			mostCommonControllerVersion(detection.controllers),
-		)
+		reportVersion, reportFound := d.fluxReport(ctx, detection.namespace)
+		detection.version = firstNonEmpty(reportVersion, mostCommonControllerVersion(detection.controllers))
+		// The Flux Operator reports the distribution it manages, which proves the
+		// install on its own -- its controllers are created by the operator and
+		// need not be there yet.
+		detection.installed = reportFound
 	case gitOpsEngineArgoCD:
 		detection.version = firstNonEmpty(
 			controllerVersionByName(detection.controllers, argoCDServerDeployment),
@@ -112,44 +121,53 @@ func (d *reconcilerModule) detectEngine(ctx context.Context, engine string, crd 
 		)
 	}
 
+	// The CRD alone is no evidence of an install: neither `helm uninstall` nor
+	// `kubectl delete -f install.yaml` removes CRDs, so a removed engine would
+	// stay "installed" forever and outrank the engine that replaced it. Running
+	// controllers are the evidence -- except when they could not be listed at
+	// all, where the CRD is the only thing left to go by.
+	detection.installed = detection.installed || len(detection.controllers) > 0 || listErr != nil
+
 	return detection
 }
 
 // listEngineDeployments returns the engine's controller deployments across all
-// namespaces. Any error yields an empty list: namespace/version/controllers are
-// enrichment, the engine stays "detected" through its CRD alone.
-func (d *reconcilerModule) listEngineDeployments(ctx context.Context, partOf string) []unstructured.Unstructured {
+// namespaces. The error is handed up rather than swallowed: an empty list means
+// the engine has no controllers, and only the error tells that apart from not
+// having been allowed to look.
+func (d *reconcilerModule) listEngineDeployments(ctx context.Context, partOf string) ([]unstructured.Unstructured, error) {
 	gvr := kubernetes.CreateGroupVersionResource(utils.DeploymentResource.ApiVersion, utils.DeploymentResource.Plural)
 	list, err := d.clientProvider.DynamicClient().Resource(gvr).List(ctx, metav1.ListOptions{
 		LabelSelector: partOfLabel + "=" + partOf,
 	})
 	if err != nil {
 		d.logger.Debug("GitOps detection: listing engine deployments failed", "partOf", partOf, "error", err)
-		return nil
+		return nil, err
 	}
-	return list.Items
+	return list.Items, nil
 }
 
-// fluxReportVersion reads the distribution version from the Flux Operator's
-// FluxReport. The CRD is frequently absent, so every failure is silent.
-func (d *reconcilerModule) fluxReportVersion(ctx context.Context, namespace string) string {
+// fluxReport reads the Flux Operator's FluxReport and returns the distribution
+// version it carries plus whether the report exists at all. The CRD is
+// frequently absent, so every failure is silent and reports "not found".
+func (d *reconcilerModule) fluxReport(ctx context.Context, namespace string) (version string, found bool) {
 	if namespace == "" {
 		namespace = fluxcdDefaultNamespace
 	}
 	report, err := d.clientProvider.DynamicClient().Resource(fluxReportGVR).Namespace(namespace).Get(ctx, fluxReportName, metav1.GetOptions{})
 	if err != nil {
 		d.logger.Debug("GitOps detection: FluxReport unavailable", "namespace", namespace, "error", err)
-		return ""
+		return "", false
 	}
 	for _, path := range [][]string{
 		{"spec", "distribution", "version"},
 		{"status", "distribution", "version"},
 	} {
-		if version, found, err := unstructured.NestedString(report.Object, path...); err == nil && found && version != "" {
-			return version
+		if version, ok, err := unstructured.NestedString(report.Object, path...); err == nil && ok && version != "" {
+			return version, true
 		}
 	}
-	return ""
+	return "", true
 }
 
 func controllerStatus(deployment unstructured.Unstructured) v1alpha1.GitOpsControllerStatus {

--- a/src/reconciler/platform_gitops_status_test.go
+++ b/src/reconciler/platform_gitops_status_test.go
@@ -35,6 +35,12 @@ func argoCDDetection() *engineDetection {
 	}
 }
 
+// leftoverDetection is what an uninstalled engine leaves behind: its CRDs are
+// still registered, but nothing runs.
+func leftoverDetection(engine string) *engineDetection {
+	return &engineDetection{engine: engine, installed: false}
+}
+
 func TestBuildGitOpsStatusSpecWins(t *testing.T) {
 	t.Parallel()
 
@@ -334,4 +340,54 @@ func TestDeliveryEngineNoEngineAnywhere(t *testing.T) {
 	engine, namespace = deliveryEngine("", "", nil)
 	assert.Empty(t, engine)
 	assert.Empty(t, namespace)
+}
+
+func TestBuildGitOpsStatusLeftoverCRDsDoNotOutrankRunningEngine(t *testing.T) {
+	t.Parallel()
+
+	// The reported symptom: Argo CD was uninstalled, its CRDs stayed, and Flux
+	// is what actually runs. Reporting Argo CD here also hides Flux, because the
+	// API matches the reported engine before it believes either is installed.
+	spec := v1alpha1.PlatformConfigSpec{
+		GitOps: &v1alpha1.GitOpsConfig{
+			FluxCD: &v1alpha1.FluxCDInstallConfig{Enabled: false},
+		},
+	}
+	detection := gitOpsDetection{argoCD: leftoverDetection(gitOpsEngineArgoCD), flux: fluxDetection()}
+
+	status := buildGitOpsStatus(spec, detection)
+
+	assert.Equal(t, gitOpsEngineFlux, status.Engine)
+	assert.Equal(t, gitOpsSourceDetected, status.Source)
+	assert.True(t, status.Installed)
+	assert.Equal(t, "flux-system", status.Namespace)
+}
+
+func TestBuildGitOpsStatusLeftoverCRDsAreNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	spec := v1alpha1.PlatformConfigSpec{
+		GitOps: &v1alpha1.GitOpsConfig{
+			ArgoCD: &v1alpha1.ArgoCDInstallConfig{Enabled: false},
+		},
+	}
+
+	status := buildGitOpsStatus(spec, gitOpsDetection{argoCD: leftoverDetection(gitOpsEngineArgoCD)})
+
+	// Nothing runs, so nothing may be delivered through it either.
+	assert.False(t, status.Installed)
+	engine, namespace := deliveryEngine("", "", status)
+	assert.Empty(t, engine)
+	assert.Empty(t, namespace)
+}
+
+func TestPreferredIgnoresEnginesThatDoNotRun(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, gitOpsDetection{}.preferred())
+	assert.Nil(t, gitOpsDetection{argoCD: leftoverDetection(gitOpsEngineArgoCD)}.preferred())
+
+	// Both running: Argo CD wins, it is the engine mogenius installs by default.
+	both := gitOpsDetection{argoCD: argoCDDetection(), flux: fluxDetection()}
+	assert.Equal(t, gitOpsEngineArgoCD, both.preferred().engine)
 }

--- a/src/reconciler/platform_gitops_status_test.go
+++ b/src/reconciler/platform_gitops_status_test.go
@@ -147,7 +147,34 @@ func TestBuildGitOpsStatusDisabledSpecWithoutDetection(t *testing.T) {
 	assert.Equal(t, gitOpsSourceSpec, status.Source)
 	assert.True(t, status.IsUserManaged)
 	assert.False(t, status.Installed)
-	assert.Equal(t, argoCDDefaultProject, status.DefaultProjectName)
+	// A disabled spec means the engine belongs to the user, so the reported
+	// project must be one that exists there. "mogenius" only exists where
+	// mogenius installed Argo CD and created it.
+	assert.Equal(t, argoCDFallbackProject, status.DefaultProjectName)
+}
+
+func TestArgoProjectName(t *testing.T) {
+	t.Parallel()
+
+	// Explicit wins in both directions -- it is the user's declaration.
+	assert.Equal(t, "custom", argoProjectName(&v1alpha1.GitOpsConfig{
+		ArgoCD: &v1alpha1.ArgoCDInstallConfig{Enabled: true, Project: "custom"},
+	}))
+	assert.Equal(t, "custom", argoProjectName(&v1alpha1.GitOpsConfig{
+		ArgoCD: &v1alpha1.ArgoCDInstallConfig{Enabled: false, Project: "custom"},
+	}))
+
+	// mogenius owns the engine, so it also creates the project it names.
+	assert.Equal(t, argoCDDefaultProject, argoProjectName(&v1alpha1.GitOpsConfig{
+		ArgoCD: &v1alpha1.ArgoCDInstallConfig{Enabled: true},
+	}))
+
+	// The engine is the user's: only Argo CD's built-in project can be assumed.
+	assert.Equal(t, argoCDFallbackProject, argoProjectName(&v1alpha1.GitOpsConfig{
+		ArgoCD: &v1alpha1.ArgoCDInstallConfig{Enabled: false},
+	}))
+	assert.Equal(t, argoCDFallbackProject, argoProjectName(nil))
+	assert.Equal(t, argoCDFallbackProject, argoProjectName(&v1alpha1.GitOpsConfig{}))
 }
 
 func TestBuildGitOpsStatusNothingFound(t *testing.T) {
@@ -250,4 +277,61 @@ func TestMostCommonControllerVersion(t *testing.T) {
 	}
 	assert.Equal(t, "v1.7.1", mostCommonControllerVersion(controllers))
 	assert.Empty(t, mostCommonControllerVersion(nil))
+}
+
+func TestDeliveryEngineSpecWins(t *testing.T) {
+	t.Parallel()
+
+	// mogenius installs the engine, so its own namespace is authoritative even
+	// when a different engine happens to be running as well.
+	engine, namespace := deliveryEngine(gitOpsEngineArgoCD, "argocd", &v1alpha1.GitOpsStatus{
+		Engine:    gitOpsEngineFlux,
+		Installed: true,
+		Namespace: "flux-system",
+	})
+
+	assert.Equal(t, gitOpsEngineArgoCD, engine)
+	assert.Equal(t, "argocd", namespace)
+}
+
+func TestDeliveryEngineFallsBackToDetected(t *testing.T) {
+	t.Parallel()
+
+	// The onboarding case: Helm installed the engine, spec.gitOps leaves it
+	// disabled. Components must still be delivered through it.
+	engine, namespace := deliveryEngine("", "", &v1alpha1.GitOpsStatus{
+		Engine:    gitOpsEngineFlux,
+		Installed: true,
+		Namespace: "flux-system",
+	})
+
+	assert.Equal(t, gitOpsEngineFlux, engine)
+	assert.Equal(t, "flux-system", namespace)
+}
+
+func TestDeliveryEngineIgnoresDeclaredButAbsentEngine(t *testing.T) {
+	t.Parallel()
+
+	// Declared without running: there is no namespace to create Applications
+	// in, so this must not be mistaken for a usable engine.
+	engine, namespace := deliveryEngine("", "", &v1alpha1.GitOpsStatus{
+		Engine:    gitOpsEngineArgoCD,
+		Installed: false,
+		Namespace: "argocd",
+	})
+
+	assert.Empty(t, engine)
+	assert.Empty(t, namespace)
+}
+
+func TestDeliveryEngineNoEngineAnywhere(t *testing.T) {
+	t.Parallel()
+
+	engine, namespace := deliveryEngine("", "", &v1alpha1.GitOpsStatus{})
+	assert.Empty(t, engine)
+	assert.Empty(t, namespace)
+
+	engine, namespace = deliveryEngine("", "", nil)
+	assert.Empty(t, engine)
+	assert.Empty(t, namespace)
 }

--- a/src/reconciler/platform_repositories.go
+++ b/src/reconciler/platform_repositories.go
@@ -1,0 +1,139 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	"mogenius-operator/src/crds/v1alpha1"
+	"mogenius-operator/src/gitops"
+	"mogenius-operator/src/kubernetes"
+	"mogenius-operator/src/utils"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// repositorySecretSuffix is the conventional name of a repository's credential
+// Secret: <repository>-repository, in the engine's namespace. The bootstrap
+// chart writes it under that name and so does the mogenius API, so the operator
+// can find it without the PlatformConfig having to name it.
+const repositorySecretSuffix = "-repository"
+
+// reconcilePlatformRepositories creates the objects that make a GitOps engine
+// sync spec.gitOps.repositories.
+//
+// Only for an engine mogenius does not own. When it does own one, the same
+// objects ship as extra objects of the release it installs — doing both would
+// have two writers for one Application.
+//
+// This is what closes the bootstrap loop. The operator seeds the PlatformConfig
+// with the repository it was installed with, and reconciling that entry is what
+// brings the real config into the cluster. It runs on every sweep, so a CRD
+// that is not established yet simply succeeds on a later pass instead of
+// needing anything to retry it from outside.
+func (d *reconcilerModule) reconcilePlatformRepositories(
+	ctx context.Context,
+	spec v1alpha1.PlatformConfigSpec,
+	engine string,
+	namespace string,
+) *ReconcileResult {
+	if spec.GitOps == nil || len(spec.GitOps.Repositories) == 0 {
+		return nil
+	}
+
+	if engine == gitOpsEngineFlux {
+		// The FluxInstance deploys the controllers; the flux-operator chart
+		// ships none. Absent on a cluster whose Flux was set up by hand, where
+		// the controllers exist already and this CRD does not.
+		if d.crdChecker.IsAvailable(utils.FluxInstanceResource) {
+			if err := d.applyPlatformObject(utils.FluxInstanceResource, namespace, fluxInstanceObject(namespace)); err != nil {
+				return &ReconcileResult{Err: fmt.Errorf("apply flux instance: %w", err)}
+			}
+		}
+	}
+
+	for _, repo := range spec.GitOps.Repositories {
+		name := repo.Name
+		if name == "" {
+			name = repositorySecretName(repo.URL)
+		}
+		// Without a path there is no directory to sync, which is how the engine
+		// addresses a repository at all.
+		if repo.Path == "" {
+			continue
+		}
+
+		switch engine {
+		case gitOpsEngineArgoCD:
+			// No credential reference: Argo CD discovers repository credentials
+			// by label, so the Secret stands on its own.
+			object := argoApplicationObject(name, repo, namespace, argoProjectName(spec.GitOps))
+			if err := d.applyPlatformObject(utils.ArgoApplicationResource, namespace, object); err != nil {
+				return &ReconcileResult{Err: fmt.Errorf("apply application %q: %w", name, err)}
+			}
+
+		case gitOpsEngineFlux:
+			source := fluxGitRepositoryObject(name, repo, namespace)
+			// Flux is pointed at its credential by name, and a secretRef naming
+			// a Secret that is not there fails the source outright -- so it is
+			// only set once the Secret exists. A public repository needs none.
+			if repo.ExternalSecret == nil && d.platformRepositorySecretExists(ctx, namespace, name+repositorySecretSuffix) {
+				if spec, ok := source["spec"].(map[string]any); ok {
+					spec["secretRef"] = map[string]any{"name": name + repositorySecretSuffix}
+				}
+			}
+			if err := d.applyPlatformObject(utils.GitRepositoryResource, namespace, source); err != nil {
+				return &ReconcileResult{Err: fmt.Errorf("apply git repository %q: %w", name, err)}
+			}
+			if err := d.applyPlatformObject(utils.KustomizationResource, namespace, fluxKustomizationObject(name, repo, namespace)); err != nil {
+				return &ReconcileResult{Err: fmt.Errorf("apply kustomization %q: %w", name, err)}
+			}
+		}
+	}
+
+	return nil
+}
+
+// applyPlatformObject applies one object, labelled so it is recognisable as the
+// platform's. No owner reference: these objects are what sync the PlatformConfig
+// in, so tying their lifetime to it would have the object delete itself the
+// moment the resource it delivers is removed.
+func (d *reconcilerModule) applyPlatformObject(resource utils.ResourceDescriptor, namespace string, object map[string]any) error {
+	if !d.crdChecker.IsAvailable(resource) {
+		// The engine's CRDs are not registered yet. A later sweep finds them.
+		d.logger.Info("skipping platform repository object, CRD not available yet",
+			"kind", resource.Kind, "namespace", namespace)
+		return nil
+	}
+
+	obj := &unstructured.Unstructured{Object: object}
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["app.kubernetes.io/managed-by"] = "mogenius-operator"
+	labels["app.kubernetes.io/component"] = "platform-config"
+	obj.SetLabels(labels)
+
+	return gitops.Apply(
+		d.clientProvider,
+		kubernetes.CreateGroupVersionResource(resource.ApiVersion, resource.Plural),
+		namespace,
+		obj,
+	)
+}
+
+func (d *reconcilerModule) platformRepositorySecretExists(ctx context.Context, namespace, name string) bool {
+	_, err := d.clientProvider.K8sClientSet().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		return true
+	}
+	if !apierrors.IsNotFound(err) {
+		// Anything other than absence -- RBAC, an unreachable API server -- is
+		// not evidence that the Secret is missing, and dropping the reference
+		// over it would break a source that works.
+		d.logger.Warn("could not check platform repository secret", "name", name, "error", err)
+	}
+	return false
+}

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -273,6 +273,26 @@ var AppProjectResource = ResourceDescriptor{
 	Namespaced: true,
 }
 
+// ArgoApplicationResource is Argo CD's Application. Its presence is not what
+// proves Argo CD runs -- see AppProjectResource and the engine detection -- but
+// it is the object the platform's repositories are synced through.
+var ArgoApplicationResource = ResourceDescriptor{
+	Kind:       "Application",
+	Plural:     "applications",
+	ApiVersion: "argoproj.io/v1alpha1",
+	Namespaced: true,
+}
+
+// FluxInstanceResource is the flux-operator's own resource. It is what deploys
+// the Flux controllers; the flux-operator chart ships none. Absent on clusters
+// whose Flux was installed without the operator.
+var FluxInstanceResource = ResourceDescriptor{
+	Kind:       "FluxInstance",
+	Plural:     "fluxinstances",
+	ApiVersion: "fluxcd.controlplane.io/v1",
+	Namespaced: true,
+}
+
 var KustomizationResource = ResourceDescriptor{
 	Kind:       "Kustomization",
 	Plural:     "kustomizations",


### PR DESCRIPTION
Makes the PlatformConfig path work when the GitOps engine is **not** owned by the operator — which is what cluster onboarding does, and for Flux the only thing that can work.

### The bug this fixes

Onboarding installs the engine with Helm and leaves `spec.gitOps` disabled, so the operator reports it as `isUserManaged`. In that state `inferGitOpsEngine` returns no engine — and the early return in `reconcilePlatformConfig` then skipped **every** component, not just the engine. Those clusters got nothing at all.

Split into two separate decisions:

- `deliveryEngine()` picks the engine components ship *through*, falling back to the detected one when the spec enables none. Only a running engine counts — a declared-but-absent one has no namespace to create objects in.
- the engine itself is still only reconciled when mogenius owns it, so a Helm release someone else installed is never adopted.

### Second bug, in the same path

`argoProjectName()` replaces two copies of the project fallback. Without an explicit project it now resolves to `default` on a user-managed engine: `mogenius` only exists where mogenius installed Argo CD and created the AppProject, so every component Application would have been rejected with *"project mogenius does not exist"*.

### Detection

`fix(gitops): report an engine as installed only when its controllers run` is included here, and it is what makes the fallback above safe. Detection previously marked an engine installed as soon as its CRD was registered — and neither `helm uninstall` nor `kubectl delete` removes CRDs, so a cluster that once ran Argo CD reported it forever and would have had its components addressed at an engine that is not there.

### Always on

The PlatformConfig CRDs are installed and the resource is watched on every cluster, with no opt-in. An empty spec only publishes the detected GitOps status, so watching costs a cluster nothing until it declares components — which makes a flag guarding it a setting nobody would have a reason to turn off. This replaces the previous `IsDevBuild()` guards, which could not be turned on for a single cluster either.

### New chart: `mogenius-platform-bootstrap`

The GitOps engine as a conditional dependency (`argo-cd` or `flux-operator`, versions tracking `platform-defaults`) plus the repository credential in the engine's own format.

The objects that *sync* the PlatformConfig are deliberately **not** in it: Helm resolves every manifest through the RESTMapper before creating anything, so a custom resource shipped with the CRD that defines it fails the install on exactly the clusters being onboarded. The platform creates them once the operator reports the engine as running — which is also the path a pre-existing engine takes.

### Also

`platformVersion` now defaults to `main`. Empty built the URL `.../refs/heads//traefik.yaml`, so every component's defaults fetch 404'd and nothing installed — a confusing failure for a field the UI does not even offer.

### Verification

`go build`, `just test-unit` (572 passed), `helm lint` and `helm template` for both engines. `just check` is red on `main` already (3 pre-existing staticcheck issues in `src/dtos/` and `src/services/`, untouched here); CI's `golangci-lint` passes.

MOG-4649

🤖 Generated with [Claude Code](https://claude.com/claude-code)