### PR TITLE
feat(chart): Platform-Write-Credential beim Bootstrap anlegen

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -28,6 +28,16 @@ jobs:
     with:
       path: ./helm/charts/mogenius-operator
 
+  lint-bootstrap:
+    uses: mogenius/github-actions/.github/workflows/helm-lint.yml@c3e043d602a88fea39b680b67480b4a90d8d31d2 # v1.8.0
+    with:
+      path: ./helm/charts/mogenius-platform-bootstrap
+
+  tests-bootstrap:
+    uses: mogenius/github-actions/.github/workflows/helm-unittest.yml@c3e043d602a88fea39b680b67480b4a90d8d31d2 # v1.8.0
+    with:
+      path: ./helm/charts/mogenius-platform-bootstrap
+
   template:
     uses: mogenius/github-actions/.github/workflows/helm-template.yml@c3e043d602a88fea39b680b67480b4a90d8d31d2 # v1.8.0
     with:

--- a/Justfile
+++ b/Justfile
@@ -80,6 +80,7 @@ test-unit: generate
 # Execute Helm chart unit tests (requires the helm-unittest plugin)
 test-helm:
     helm unittest -f 'unittests/*_test.yaml' helm/charts/mogenius-operator
+    helm unittest -f 'unittests/*_test.yaml' helm/charts/mogenius-platform-bootstrap
 
 # Execute integration tests
 test-integration: generate

--- a/helm/charts/mogenius-platform-bootstrap/.helmignore
+++ b/helm/charts/mogenius-platform-bootstrap/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Helm unit tests
+unittests/

--- a/helm/charts/mogenius-platform-bootstrap/README.md
+++ b/helm/charts/mogenius-platform-bootstrap/README.md
@@ -1,7 +1,8 @@
 # mogenius-platform-bootstrap
 
-Installs the GitOps engine for a mogenius platform and the credential it needs
-to read the repository holding your `PlatformConfig`.
+Installs the GitOps engine for a mogenius platform and the two credentials for
+the repository holding your `PlatformConfig`: the read credential the engine
+syncs it with, and the write credential the mogenius platform commits it with.
 
 Installed alongside `mogenius-operator` during cluster onboarding. The mogenius
 UI generates the exact command; this README explains what it does.
@@ -22,6 +23,41 @@ the platform components through it without trying to take it over.
 
 **Do not also enable the engine in your `PlatformConfig`** — the operator would
 install a second one next to this release.
+
+## Why there are two credentials
+
+`templates/repository-secret.yaml` is the engine's, and it only ever reads:
+Argo CD or Flux pulls `platformconfig.yaml` out of the repository with it.
+
+`templates/write-credential-secret.yaml` is the mogenius platform's, and it
+writes: editing the platform configuration in the UI means committing that file
+back through the git provider's API, which the engine's Secret cannot do (for
+Flux it may even be an SSH key no API accepts).
+
+The write credential is created **per cluster, in the cluster**, from the token
+given to this install. The platform holds none of it centrally, so a token
+reaches exactly one cluster's repository — and a cluster that is restored from a
+backup or re-registered keeps working, because the credential and the write mode
+travel with it.
+
+Both are driven by the same `repository.token`. Set
+`repository.writeCredential.enabled=false` to let the engine read with that
+token without letting the platform write with it; the `PlatformConfig` then has
+to be edited in git by hand.
+
+### The write credential lands in the operator's namespace
+
+Everything else this chart creates lands in the release namespace — the
+engine's, `flux-system` or `argocd`. The write credential does not: the platform
+API reads it from the namespace the mogenius operator runs in, by the name
+`mogenius-gitops-write-<repository.name>`. That is `operatorNamespace`
+(`mogenius` by default), which has to match where `mogenius-operator` was
+installed and has to exist before this release is installed.
+
+Rotating the token later through the mogenius UI updates the same Secret in
+place. A `helm upgrade` of this release that still passes the old
+`repository.token` would put the old token back, so pass the new one — or drop
+it and use `repository.writeCredential.existingSecret.name`.
 
 ## Why the sync objects are not in this chart
 
@@ -51,9 +87,16 @@ all.
 | `repository.url` | *required* | Clone URL of the repository holding `platformconfig.yaml`. |
 | `repository.token` | `""` | Token for a private repository. Written into a Secret in the engine's own format. Leave empty for a public repository. |
 | `repository.existingSecret.name` | `""` | Use a credential Secret you created yourself instead of passing a token. It must already be in the engine's format: labelled `argocd.argoproj.io/secret-type=repository` for Argo CD, a basic-auth Secret for Flux. Wins over `token`. |
+| `repository.writeCredential.enabled` | `true` | Create the Secret the mogenius platform commits `platformconfig.yaml` with. Rendered only when `repository.token` is set. Turn it off to let the engine read with the token without letting the platform write with it. |
+| `repository.writeCredential.mode` | `PULL_REQUEST` | How the platform writes: `PULL_REQUEST` opens a branch and a PR against the tracked branch, `DIRECT_COMMIT` commits straight to it. The `PlatformConfig`'s own `spec.gitOps.repositories[].write.mode` wins over it once the config is synced. |
+| `repository.writeCredential.provider` | `""` | Git provider in the platform's spelling: `GIT_HUB`, `GIT_LAB` or `GITEA`. Derived from `repository.url` when the host says which (`github.`, `gitlab.`, `gitea.`, `codeberg.org`); required for a self-hosted host that does not, otherwise the install fails rather than writing a credential the platform would skip. |
+| `repository.writeCredential.username` | `mogenius` | Username stored next to the token. Only some provider APIs use it. |
+| `repository.writeCredential.existingSecret.name` | `""` | Use a write credential Secret you created yourself; nothing is rendered when set. It has to be in `operatorNamespace` with `token`/`username`/`provider` keys, and unless it is named `mogenius-gitops-write-<repository.name>` the `PlatformConfig` has to point `spec.gitOps.repositories[].write.secretRef` at it. |
+| `operatorNamespace` | `mogenius` | Namespace the mogenius operator runs in. The write credential is created there, not in the release namespace, because that is where the platform API reads it. |
 
 Install into the namespace the engine should run in — `flux-system` or `argocd`
-by convention. Every object this chart creates lands in the release namespace.
+by convention. Every object this chart creates lands in the release namespace,
+except the write credential, which goes to `operatorNamespace`.
 
 Because the engine charts are aliased (`argoCd`, `flux`) so that one value both
 selects the engine and carries its settings, subchart resources render with a

--- a/helm/charts/mogenius-platform-bootstrap/templates/NOTES.txt
+++ b/helm/charts/mogenius-platform-bootstrap/templates/NOTES.txt
@@ -2,7 +2,13 @@
 
 GitOps engine: {{ if .Values.argoCd.enabled }}Argo CD{{ else }}Flux{{ end }}
 Repository:    {{ .Values.repository.url }}
-
+{{ if and .Values.repository.token .Values.repository.writeCredential.enabled (not .Values.repository.writeCredential.existingSecret.name) -}}
+Write access:  {{ include "bootstrap.writeCredentialMode" . }}, with the credential in
+               {{ .Values.operatorNamespace }}/{{ include "bootstrap.writeCredentialSecretName" . }}
+{{ else -}}
+Write access:  none. The platform cannot commit platformconfig.yaml back, so
+               edit it in git{{ if .Values.repository.writeCredential.existingSecret.name }} or point the PlatformConfig at {{ .Values.repository.writeCredential.existingSecret.name }}{{ end }}.
+{{ end }}
 What happens next is driven by the mogenius platform, not by this chart:
 
   1. the mogenius operator connects and reports the engine it found here

--- a/helm/charts/mogenius-platform-bootstrap/templates/_helpers.tpl
+++ b/helm/charts/mogenius-platform-bootstrap/templates/_helpers.tpl
@@ -33,3 +33,78 @@ app.kubernetes.io/managed-by: mogenius-platform-bootstrap
 app.kubernetes.io/component: platform-config
 app.kubernetes.io/part-of: mogenius
 {{- end -}}
+
+{{/*
+Name of the Secret the mogenius platform commits the PlatformConfig with.
+
+Not a name of our choosing: the platform API looks the credential up by
+`mogenius-gitops-write-<repository name>` in the operator's namespace, so the
+prefix and the repository name together are a contract with it. Rendering a
+different name produces a Secret nobody reads.
+*/}}
+{{- define "bootstrap.writeCredentialSecretName" -}}
+{{- printf "mogenius-gitops-write-%s" .Values.repository.name -}}
+{{- end -}}
+
+{{/*
+Labels the platform recognises its own write credentials by. Kept identical to
+the ones the API writes when a token is rotated through the UI, so a Secret
+created here and one created there are the same object.
+*/}}
+{{- define "bootstrap.writeCredentialLabels" -}}
+managed-by: mogenius
+mogenius.com/component: gitops-write
+{{- end -}}
+
+{{/*
+How the platform is allowed to write. PULL_REQUEST is the API's own default and
+the safer one -- a pull request is reviewable, a direct commit is already live.
+Validated here because an unknown value is silently ignored by the reader,
+which would leave the cluster on a mode nobody chose.
+*/}}
+{{- define "bootstrap.writeCredentialMode" -}}
+{{- $mode := .Values.repository.writeCredential.mode | default "PULL_REQUEST" -}}
+{{- if not (has $mode (list "DIRECT_COMMIT" "PULL_REQUEST")) -}}
+{{- fail (printf "repository.writeCredential.mode must be PULL_REQUEST or DIRECT_COMMIT, got %q" $mode) -}}
+{{- end -}}
+{{- $mode -}}
+{{- end -}}
+
+{{/*
+Git provider of repository.url, in the platform's own spelling.
+
+Only the three providers whose API can read and write a file are accepted --
+committing a PlatformConfig needs both, and the API reports anything else as
+unsupported rather than attempting it. Host matching mirrors the API's list
+(github., gitlab., gitea., codeberg.org).
+
+An explicit repository.writeCredential.provider wins, for the self-hosted
+installation whose host says nothing. Neither an explicit nor a derived
+provider fails the render: a Secret with an empty provider is skipped by the
+reader, so the alternative is an install that looks fine and a first commit
+weeks later that cannot find a credential.
+*/}}
+{{- define "bootstrap.writeCredentialProvider" -}}
+{{- $supported := list "GIT_HUB" "GIT_LAB" "GITEA" -}}
+{{- $explicit := .Values.repository.writeCredential.provider | default "" -}}
+{{- if $explicit -}}
+{{- if not (has $explicit $supported) -}}
+{{- fail (printf "repository.writeCredential.provider %q cannot write files: set it to one of GIT_HUB, GIT_LAB, GITEA" $explicit) -}}
+{{- end -}}
+{{- $explicit -}}
+{{- else -}}
+{{- $url := .Values.repository.url | lower -}}
+{{- $derived := "" -}}
+{{- if contains "github." $url -}}
+{{- $derived = "GIT_HUB" -}}
+{{- else if contains "gitlab." $url -}}
+{{- $derived = "GIT_LAB" -}}
+{{- else if or (contains "gitea." $url) (contains "codeberg.org" $url) -}}
+{{- $derived = "GITEA" -}}
+{{- end -}}
+{{- if not $derived -}}
+{{- fail (printf "cannot derive the git provider of %s: set repository.writeCredential.provider to GIT_HUB, GIT_LAB or GITEA, or set repository.writeCredential.enabled=false to install without a write credential" .Values.repository.url) -}}
+{{- end -}}
+{{- $derived -}}
+{{- end -}}
+{{- end -}}

--- a/helm/charts/mogenius-platform-bootstrap/templates/write-credential-secret.yaml
+++ b/helm/charts/mogenius-platform-bootstrap/templates/write-credential-secret.yaml
@@ -1,0 +1,52 @@
+{{- include "bootstrap.validateEngine" . -}}
+{{/*
+The credential the mogenius platform commits platformconfig.yaml with -- a
+second, deliberately separate Secret next to repository-secret.yaml.
+
+That one belongs to the GitOps engine and only ever reads. This one is read by
+the platform API, which needs a git provider API token to write a file, and it
+is created per cluster from the token given to this install: the platform never
+holds it, so one token reaches exactly one cluster's repository.
+
+Its name, keys, labels and annotations are the API's format, not ours -- the
+same one the UI writes when a token is rotated later.
+*/}}
+{{- if and .Values.repository.token .Values.repository.writeCredential.enabled (not .Values.repository.writeCredential.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "bootstrap.writeCredentialSecretName" . }}
+  {{- /*
+  The operator's namespace, not this release's: the engine runs in flux-system
+  or argocd, while the platform API reads this Secret from the namespace the
+  mogenius operator lives in. Landing it in the release namespace produces a
+  Secret nobody looks for.
+  */}}
+  namespace: {{ .Values.operatorNamespace }}
+  labels:
+    {{- include "bootstrap.writeCredentialLabels" . | nindent 4 }}
+    {{- include "bootstrap.labels" . | nindent 4 }}
+  annotations:
+    {{- /*
+    The repository as the PlatformConfig names it in spec.gitOps.repositories[],
+    which is how the platform finds its own entry again.
+    */}}
+    mogenius.com/gitops-repository: {{ .Values.repository.name | quote }}
+    mogenius.com/gitops-repository-url: {{ .Values.repository.url | quote }}
+    {{- /*
+    The write mode lives on the Secret rather than in the platform database, so
+    a restored backup or a re-registered cluster keeps the setting. A write
+    block in the PlatformConfig still wins over it.
+    */}}
+    mogenius.com/gitops-write-mode: {{ include "bootstrap.writeCredentialMode" . | quote }}
+type: Opaque
+{{- /*
+`data`, base64 by hand, not `stringData`: the platform's own secret validation
+only ever looks at `data`, so a Secret carrying just `stringData` is rejected as
+having no keys when the API updates it on the next token rotation.
+*/}}
+data:
+  token: {{ .Values.repository.token | b64enc | quote }}
+  username: {{ .Values.repository.writeCredential.username | default "mogenius" | b64enc | quote }}
+  provider: {{ include "bootstrap.writeCredentialProvider" . | b64enc | quote }}
+{{- end }}

--- a/helm/charts/mogenius-platform-bootstrap/unittests/write-credential-secret_test.yaml
+++ b/helm/charts/mogenius-platform-bootstrap/unittests/write-credential-secret_test.yaml
@@ -1,0 +1,194 @@
+suite: platform write credential
+templates:
+  - write-credential-secret.yaml
+# Every render needs a repository url: without one the chart refuses to install
+# at all, engine or not.
+set:
+  repository.url: https://github.com/acme/platform.git
+tests:
+  - it: creates the write credential when a token is given
+    set:
+      repository.token: ghp_test
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: mogenius-gitops-write-platform
+      # the operator's namespace, not the release namespace the engine runs in
+      - equal:
+          path: metadata.namespace
+          value: mogenius
+      - equal:
+          path: type
+          value: Opaque
+      - equal:
+          path: data.token
+          value: Z2hwX3Rlc3Q=
+      - equal:
+          path: data.username
+          value: bW9nZW5pdXM=
+      - equal:
+          path: data.provider
+          value: R0lUX0hVQg==
+
+  - it: labels the credential the way the platform recognises it
+    set:
+      repository.token: ghp_test
+    asserts:
+      - equal:
+          path: metadata.labels["managed-by"]
+          value: mogenius
+      - equal:
+          path: metadata.labels["mogenius.com/component"]
+          value: gitops-write
+
+  - it: annotates the repository, its url and the write mode
+    set:
+      repository.token: ghp_test
+    asserts:
+      - equal:
+          path: metadata.annotations["mogenius.com/gitops-repository"]
+          value: platform
+      - equal:
+          path: metadata.annotations["mogenius.com/gitops-repository-url"]
+          value: https://github.com/acme/platform.git
+      - equal:
+          path: metadata.annotations["mogenius.com/gitops-write-mode"]
+          value: PULL_REQUEST
+
+  - it: writes directly when asked to
+    set:
+      repository.token: ghp_test
+      repository.writeCredential.mode: DIRECT_COMMIT
+    asserts:
+      - equal:
+          path: metadata.annotations["mogenius.com/gitops-write-mode"]
+          value: DIRECT_COMMIT
+
+  - it: refuses an unknown write mode
+    set:
+      repository.token: ghp_test
+      repository.writeCredential.mode: YOLO
+    asserts:
+      - failedTemplate:
+          errorMessage: repository.writeCredential.mode must be PULL_REQUEST or DIRECT_COMMIT, got "YOLO"
+
+  - it: renders nothing without a token
+    set:
+      repository.token: ""
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when the write credential is turned off
+    set:
+      repository.token: ghp_test
+      repository.writeCredential.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when an existing write credential is referenced
+    set:
+      repository.token: ghp_test
+      repository.writeCredential.existingSecret.name: my-own-write-credential
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: follows the repository name into the secret name
+    set:
+      repository.name: platform-eu
+      repository.token: ghp_test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: mogenius-gitops-write-platform-eu
+      - equal:
+          path: metadata.annotations["mogenius.com/gitops-repository"]
+          value: platform-eu
+
+  - it: honors a custom operator namespace
+    set:
+      repository.token: ghp_test
+      operatorNamespace: mogenius-system
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: mogenius-system
+
+  - it: derives GIT_LAB from a gitlab url
+    set:
+      repository.url: https://gitlab.com/acme/platform.git
+      repository.token: glpat_test
+    asserts:
+      - equal:
+          path: data.provider
+          value: R0lUX0xBQg==
+
+  - it: derives GITEA from a self-hosted gitea url
+    set:
+      repository.url: https://gitea.acme.internal/acme/platform.git
+      repository.token: t
+    asserts:
+      - equal:
+          path: data.provider
+          value: R0lURUE=
+
+  - it: derives GITEA from codeberg
+    set:
+      repository.url: https://codeberg.org/acme/platform.git
+      repository.token: t
+    asserts:
+      - equal:
+          path: data.provider
+          value: R0lURUE=
+
+  - it: refuses a url whose provider cannot be derived
+    set:
+      repository.url: https://git.acme.internal/acme/platform.git
+      repository.token: t
+    asserts:
+      - failedTemplate:
+          errorMessage: "cannot derive the git provider of https://git.acme.internal/acme/platform.git: set repository.writeCredential.provider to GIT_HUB, GIT_LAB or GITEA, or set repository.writeCredential.enabled=false to install without a write credential"
+
+  - it: takes an explicit provider for a host that says nothing
+    set:
+      repository.url: https://git.acme.internal/acme/platform.git
+      repository.token: t
+      repository.writeCredential.provider: GITEA
+    asserts:
+      - equal:
+          path: data.provider
+          value: R0lURUE=
+
+  - it: refuses a provider that cannot write files
+    set:
+      repository.token: t
+      repository.writeCredential.provider: BITBUCKET
+    asserts:
+      - failedTemplate:
+          errorMessage: 'repository.writeCredential.provider "BITBUCKET" cannot write files: set it to one of GIT_HUB, GIT_LAB, GITEA'
+
+  - it: stores a custom username
+    set:
+      repository.token: ghp_test
+      repository.writeCredential.username: mo-bot
+    asserts:
+      - equal:
+          path: data.username
+          value: bW8tYm90
+
+  - it: is created for Argo CD just the same
+    set:
+      flux.enabled: false
+      argoCd.enabled: true
+      repository.token: ghp_test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: mogenius-gitops-write-platform
+      - equal:
+          path: metadata.namespace
+          value: mogenius

--- a/helm/charts/mogenius-platform-bootstrap/values.yaml
+++ b/helm/charts/mogenius-platform-bootstrap/values.yaml
@@ -22,6 +22,50 @@ repository:
   existingSecret:
     # -- name of the existing Secret, in this release's namespace
     name: ""
+  # -- credential the mogenius platform commits platformconfig.yaml back with.
+  # -- A second Secret next to the engine's: the engine only reads, while the
+  # -- platform needs a git provider API token to write the file. Created from
+  # -- repository.token above, per cluster and in the operator's namespace, so
+  # -- the platform never holds a token that reaches more than one repository.
+  # --
+  # -- Rendered only when repository.token is set -- a write credential without
+  # -- a token is meaningless.
+  writeCredential:
+    # -- create the write credential. Turn it off to let the engine read with
+    # -- the token above without letting the platform commit with it. The
+    # -- PlatformConfig then has to be edited in git by hand.
+    enabled: true
+    # -- how the platform writes: PULL_REQUEST opens a branch and a PR against
+    # -- the tracked branch, DIRECT_COMMIT commits straight to it. The
+    # -- PlatformConfig's own spec.gitOps.repositories[].write.mode wins over
+    # -- this once the config is synced.
+    mode: PULL_REQUEST
+    # -- git provider, in the platform's spelling: GIT_HUB, GIT_LAB or GITEA.
+    # -- Derived from repository.url when the host says which (github.,
+    # -- gitlab., gitea., codeberg.org); required for a self-hosted host that
+    # -- does not. The install fails rather than writing a credential with no
+    # -- provider, which the platform would skip.
+    provider: ""
+    # -- username stored alongside the token. Only some provider APIs use it;
+    # -- the platform's default is mogenius.
+    username: mogenius
+    # -- reference a write credential Secret you created yourself instead of
+    # -- letting this chart create one. Nothing is rendered when set. It has to
+    # -- be in the operator's namespace with token/username/provider keys, and
+    # -- unless it is named mogenius-gitops-write-<repository.name> the
+    # -- PlatformConfig has to point spec.gitOps.repositories[].write.secretRef
+    # -- at it.
+    existingSecret:
+      # -- name of the existing Secret, in operatorNamespace
+      name: ""
+
+# -- namespace the mogenius operator runs in. Only the write credential goes
+# -- there -- everything else this chart creates lands in the release namespace,
+# -- which is the engine's (flux-system or argocd). The platform API reads the
+# -- credential from the operator's namespace, so this has to match the
+# -- namespace mogenius-operator was installed into, and that namespace has to
+# -- exist before this release is installed.
+operatorNamespace: mogenius
 
 # -- Flux as the GitOps engine, via the flux-operator chart. The default engine.
 # -- Values of that chart pass through under this key. Mutually exclusive with


### PR DESCRIPTION
## Worum es geht

Die Platform-API committet die `platformconfig.yaml` eines Clusters zurück ins
Git-Repository. Dafür braucht sie ein **Schreib**-Credential – das Repository-
Secret der GitOps-Engine kann das nicht: es liest nur und ist bei Flux
womöglich ein SSH-Key, mit dem keine Provider-API arbeiten kann.

Dieser PR legt im Chart `mogenius-platform-bootstrap` deshalb ein **zweites**
Secret neben `templates/repository-secret.yaml` an, exakt im Format, das die
API im Feature `git-ops-flux-write-config` schon etabliert hat:

- Name `mogenius-gitops-write-<repository.name>` (also `mogenius-gitops-write-platform`)
- `type: Opaque`, `data` (base64) mit `token`, `username`, `provider`
- Annotations `mogenius.com/gitops-repository`, `mogenius.com/gitops-repository-url`, `mogenius.com/gitops-write-mode`
- Labels `managed-by: mogenius` und `mogenius.com/component: gitops-write`

Format, Keys, Labels und Annotations sind 1:1 aus
`mo-git-ops-nest.const.ts` bzw. `saveCredential()` übernommen, nicht geraten.

## Warum ein eigenes, zweites Secret

Das Credential entsteht **pro Cluster im Cluster**, aus dem Token, das dieser
Install mitbekommt. Die Platform hält zentral keins – ein Token erreicht damit
genau ein Cluster-Repository. Und ein Cluster, der aus einem Backup
wiederhergestellt oder neu registriert wird, funktioniert weiter, weil Token
und Write-Mode mit ihm reisen.

## Die Namespace-Feinheit

Das Chart installiert in den Namespace der Engine (`flux-system` bzw.
`argocd`), die API liest das Credential aber aus dem Namespace des Operators.
Das Secret geht deshalb bewusst **nicht** nach `.Release.Namespace`, sondern in
den neuen Wert `operatorNamespace` (Default `mogenius`). Falscher Namespace =
ein Secret, das niemand sucht.

## Neue Values

| Key | Default |
| --- | --- |
| `repository.writeCredential.enabled` | `true` |
| `repository.writeCredential.mode` | `PULL_REQUEST` |
| `repository.writeCredential.provider` | `""` (aus `repository.url` abgeleitet) |
| `repository.writeCredential.username` | `mogenius` |
| `repository.writeCredential.existingSecret.name` | `""` |
| `operatorNamespace` | `mogenius` |

Gerendert wird nur, wenn `repository.token` gesetzt ist – ein Write-Credential
ohne Token ist sinnlos, ein öffentliches Repository braucht ohnehin keins.
`enabled=false` erlaubt „Engine liest mit dem Token, Platform schreibt nicht“.
Der Provider wird über dieselbe Host-Liste wie in der API abgeleitet
(`github.` / `gitlab.` / `gitea.` / `codeberg.org`); lässt er sich nicht
ableiten und ist keiner gesetzt, **schlägt das Rendern mit klarer Meldung
fehl** statt ein Credential ohne Provider zu schreiben, das erst beim ersten
Commit auffällt. Alles in `values.yaml` (`# --`-Stil) und in der README-Tabelle
dokumentiert.

## Verifiziert

Alles lokal ausgeführt, mit den gezeigten Ergebnissen:

- `helm template ... --set repository.url=https://github.com/acme/platform.git --set repository.token=ghp_test`
  → beide Secrets. Engine-Secret `platform-repository` in `default` (Release-NS),
  Write-Secret `mogenius-gitops-write-platform` in `mogenius`. Base64 dekodiert:
  `token=ghp_test`, `username=mogenius`, `provider=GIT_HUB`; Annotations
  `gitops-repository=platform`, `gitops-repository-url=https://github.com/acme/platform.git`,
  `gitops-write-mode=PULL_REQUEST`; Labels wie oben.
- `--set repository.token=""` → kein Write-Secret (nur Engine-Pfad).
- `--set repository.writeCredential.enabled=false` → kein Write-Secret.
- `--set repository.writeCredential.existingSecret.name=...` → kein Write-Secret.
- GitLab-URL → `GIT_LAB`, `gitea.acme.internal` → `GITEA`, `codeberg.org` → `GITEA`,
  `git.acme.internal` → Render-Fehler mit Hinweis, mit explizitem
  `provider=GITEA` → `GITEA`, `provider=BITBUCKET` → Fehler, `mode=YOLO` → Fehler.
- Argo-CD-Pfad (`argoCd.enabled=true`) → Write-Secret identisch in `mogenius`.
- `helm lint helm/charts/mogenius-platform-bootstrap` → `1 chart(s) linted, 0 chart(s) failed`.
- `just test-helm` → Operator-Chart 27/27, Bootstrap-Chart 18/18 Tests grün.
  Die neuen Tests liegen als `unittests/write-credential-secret_test.yaml` im
  Stil der Operator-Chart-Tests; Justfile und der Helm-Workflow führen sie
  jetzt auch für dieses Chart aus (`lint-bootstrap`, `tests-bootstrap`).
  Dazu eine `.helmignore` (Kopie der Operator-Chart-Version), damit `unittests/`
  nicht mitgepackt wird.

## Randnotiz (nicht in diesem PR gefixt)

Der Release-Workflow lässt `helm-docs` mit `chart-search-root: helm` laufen.
Das Operator-Chart hat dafür ein `README.md.gotmpl`, dieses Chart nicht – die
handgeschriebene README könnte beim Release also überschrieben werden. Besteht
schon seit #1229, sollte aber jemand ansehen.
