### PR TITLE
feat(core): create the gitops repository credentials in the operator

### DIFF
--- a/src/core/api.go
+++ b/src/core/api.go
@@ -94,6 +94,8 @@ type Api interface {
 	UpdateAiModel(name string, spec v1alpha1.AiModelSpec, apiKey string) (string, error)
 	DeleteAiModel(name string) (string, error)
 
+	UpsertGitOpsCredentials(request GitOpsCredentialsRequest) (string, error)
+
 	GetWorkspaceResources(workspaceName string, whitelist []*utils.ResourceDescriptor, blacklist []*utils.ResourceDescriptor, namespaceWhitelist []string) ([]unstructured.Unstructured, error)
 	GetResourceListByWhitelistPaginated(req ResourcesPaginatedRequest) (ResourcesPaginatedResponse, error)
 	GetWorkspaceResourcesPaginated(workspaceName string, req WorkspaceResourcesPaginatedRequest) (WorkspaceResourcesPaginatedResponse, error)
@@ -464,6 +466,13 @@ func (self *api) RequestAiModelUsageReset(name string) (string, error) {
 		return "", err
 	}
 	return "AiModel usage reset requested", nil
+}
+
+// UpsertGitOpsCredentials materializes the read and write credential Secrets
+// for a platform repository. Idempotent: the same call with a new token rotates
+// both in place.
+func (self *api) UpsertGitOpsCredentials(request GitOpsCredentialsRequest) (string, error) {
+	return self.workspaceManager.UpsertGitOpsCredentials(request)
 }
 
 // GetAiModelResult is the wire shape for AiModel CRs, mirroring GetAgentResult.

--- a/src/core/gitops_credentials.go
+++ b/src/core/gitops_credentials.go
@@ -1,0 +1,531 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strings"
+
+	"mogenius-operator/src/gitops"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+// ╭──────────────────────────────────────╮
+// │ GitOps repository credential secrets │
+// ╰──────────────────────────────────────╯
+//
+// The two Secrets a mogenius platform repository needs, previously rendered by
+// the mogenius-platform-bootstrap Helm chart and now created here from a
+// command the platform API pushes over the websocket connection.
+//
+// They are deliberately separate objects, because they are read by different
+// parties and only one of them may write:
+//
+//   - the read credential (<repository>-repository, in the GitOps engine's
+//     namespace) is the engine's. Argo CD or Flux pulls platformconfig.yaml out
+//     of the repository with it. Its shape is the engine's, not ours.
+//   - the write credential (mogenius-gitops-write-<repository>, in the
+//     operator's namespace) is the platform API's. Committing platformconfig.yaml
+//     back needs a git provider API token, which the engine's credential cannot
+//     do — for Flux it may not even be a token.
+//
+// The operator only ever materializes them. Committing to git stays the API's
+// job: the token reaches exactly one cluster, and the platform never holds it.
+//
+// Name, keys, labels and annotations of the write credential are the API's
+// format, not ours — it looks the credential up by name in the operator's
+// namespace, so a different name produces a Secret nobody reads, and an empty
+// provider is silently skipped by the reader. Both are therefore validated
+// here rather than deferred to a first commit weeks later.
+//
+// The token must never leave this file except inside Secret.Data: not in error
+// messages, not in log attributes, not in audit objects.
+
+const (
+	// gitOpsWriteSecretPrefix is a contract with the platform API: it reads
+	// the write credential as mogenius-gitops-write-<repository name> from the
+	// operator's namespace.
+	gitOpsWriteSecretPrefix = "mogenius-gitops-write-"
+
+	// gitOpsRepositorySecretSuffix is the conventional name of a repository's
+	// read credential, <repository>-repository, in the engine's namespace. The
+	// platform repository reconciler looks the Secret up under that name, so
+	// the PlatformConfig does not have to name it.
+	gitOpsRepositorySecretSuffix = "-repository"
+)
+
+// Data keys of the two Secrets.
+const (
+	gitOpsWriteSecretTokenKey    = "token"
+	gitOpsWriteSecretUsernameKey = "username"
+	gitOpsWriteSecretProviderKey = "provider"
+
+	gitOpsReadSecretTypeKey     = "type"
+	gitOpsReadSecretURLKey      = "url"
+	gitOpsReadSecretUsernameKey = "username"
+	gitOpsReadSecretPasswordKey = "password"
+)
+
+// Annotations on the write credential. The repository name is how the platform
+// finds its own entry in spec.gitOps.repositories[] again; the write mode lives
+// on the Secret rather than in the platform database so a restored backup or a
+// re-registered cluster keeps the setting.
+const (
+	gitOpsWriteRepositoryAnnotation    = "mogenius.com/gitops-repository"
+	gitOpsWriteRepositoryURLAnnotation = "mogenius.com/gitops-repository-url"
+	gitOpsWriteModeAnnotation          = "mogenius.com/gitops-write-mode"
+)
+
+const (
+	// gitOpsWriteManagedByLabelKey is bare, not app.kubernetes.io/managed-by:
+	// this is the label the platform API recognises its own write credentials
+	// by, so a Secret created here and one the UI writes on a token rotation
+	// are the same object.
+	gitOpsWriteManagedByLabelKey   = "managed-by"
+	gitOpsWriteManagedByLabelValue = "mogenius"
+
+	gitOpsComponentLabelKey        = "mogenius.com/component"
+	gitOpsWriteComponentLabelValue = "gitops-write"
+
+	gitOpsManagedByLabelKey    = "app.kubernetes.io/managed-by"
+	gitOpsManagedByLabelValue  = "mogenius"
+	gitOpsPartOfLabelKey       = "app.kubernetes.io/part-of"
+	gitOpsPartOfLabelValue     = "mogenius"
+	gitOpsComponentK8sLabelKey = "app.kubernetes.io/component"
+	gitOpsComponentK8sValue    = "platform-config"
+
+	// argoCDSecretTypeLabelKey is how Argo CD discovers repository
+	// credentials: by label, with the repository URL inside the Secret.
+	argoCDSecretTypeLabelKey   = "argocd.argoproj.io/secret-type"
+	argoCDSecretTypeLabelValue = "repository"
+)
+
+// Write modes the platform API accepts. PULL_REQUEST is its own default and the
+// safer one — a pull request is reviewable, a direct commit is already live.
+const (
+	GitOpsWriteModePullRequest  = "PULL_REQUEST"
+	GitOpsWriteModeDirectCommit = "DIRECT_COMMIT"
+)
+
+// Git providers, in the platform's spelling. Only these three are accepted:
+// committing a PlatformConfig needs an API that can both read and write a file,
+// and the API reports anything else as unsupported rather than attempting it.
+const (
+	GitOpsProviderGitHub = "GIT_HUB"
+	GitOpsProviderGitLab = "GIT_LAB"
+	GitOpsProviderGitea  = "GITEA"
+)
+
+// gitOpsWriteDefaultUsername is the platform's default; only some provider
+// APIs use the username at all.
+const gitOpsWriteDefaultUsername = "mogenius"
+
+// Default namespaces of the engines, used when the command does not name one.
+const (
+	gitOpsFluxDefaultNamespace   = "flux-system"
+	gitOpsArgoCDDefaultNamespace = "argocd"
+)
+
+// Usernames of the read credential. x-token-auth is accepted as the username by
+// GitHub, GitLab and Gitea alike; Flux's basic-auth Secret conventionally
+// carries git.
+const (
+	gitOpsArgoCDReadUsername = "x-token-auth"
+	gitOpsFluxReadUsername   = "git"
+)
+
+// GitOpsCredentialsRequest is the platform API's command payload: the
+// repository and the token to materialize credentials for.
+//
+// Everything but the repository, its URL and the token is optional and
+// defaulted the way the bootstrap chart defaulted it, so the API only has to
+// send what deviates.
+type GitOpsCredentialsRequest struct {
+	// RepositoryName is the repository as spec.gitOps.repositories[] names it;
+	// both Secret names are derived from it.
+	RepositoryName string `json:"repositoryName" validate:"required"`
+	// RepositoryURL is the clone URL. The git provider is derived from it
+	// unless Provider says which.
+	RepositoryURL string `json:"repositoryUrl" validate:"required"`
+	// Token is the git provider token. Redacted in the audit log by the
+	// "token" field name — do not rename without updating
+	// sensitiveAuditPayloadKeys (store).
+	Token string `json:"token" validate:"required"`
+	// Username is stored next to the token in the write credential. Defaults
+	// to mogenius.
+	Username string `json:"username,omitempty"`
+	// Provider overrides the URL-derived provider, for a self-hosted host
+	// whose name says nothing.
+	Provider string `json:"provider,omitempty" validate:"omitempty,oneof=GIT_HUB GIT_LAB GITEA"`
+	// WriteMode is how the platform commits: PULL_REQUEST or DIRECT_COMMIT.
+	// Defaults to PULL_REQUEST.
+	WriteMode string `json:"writeMode,omitempty" validate:"omitempty,oneof=PULL_REQUEST DIRECT_COMMIT"`
+	// Engine is the GitOps engine reading the repository, "flux" or "argo-cd".
+	// Defaults to flux, matching the engine the charts install by default.
+	Engine string `json:"engine,omitempty"`
+	// EngineNamespace is where the engine runs and where its read credential
+	// goes. Defaults to flux-system or argocd.
+	EngineNamespace string `json:"engineNamespace,omitempty"`
+}
+
+// resolvedGitOpsCredentials is a request with every default applied and every
+// value validated — the shape the two upserts work from.
+type resolvedGitOpsCredentials struct {
+	repositoryName  string
+	repositoryURL   string
+	token           string
+	username        string
+	provider        string
+	writeMode       string
+	engine          string
+	engineNamespace string
+}
+
+// gitOpsWriteSecretName returns the name the platform API reads the write
+// credential under.
+func gitOpsWriteSecretName(repositoryName string) string {
+	return gitOpsWriteSecretPrefix + repositoryName
+}
+
+// gitOpsReadSecretName returns the name the GitOps engine's credential is
+// looked up under.
+func gitOpsReadSecretName(repositoryName string) string {
+	return repositoryName + gitOpsRepositorySecretSuffix
+}
+
+// resolveGitOpsWriteMode defaults an empty mode and rejects an unknown one. An
+// unknown value is silently ignored by the platform's reader, which would leave
+// the cluster on a write mode nobody chose.
+func resolveGitOpsWriteMode(mode string) (string, error) {
+	switch mode {
+	case "":
+		return GitOpsWriteModePullRequest, nil
+	case GitOpsWriteModePullRequest, GitOpsWriteModeDirectCommit:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("writeMode must be %s or %s, got %q", GitOpsWriteModePullRequest, GitOpsWriteModeDirectCommit, mode)
+	}
+}
+
+// resolveGitOpsEngine normalizes the engine name. Empty means Flux, the engine
+// the charts install by default, so an unset field lands where the bootstrap
+// did. The alternative spellings are accepted because the PlatformConfig spells
+// the same engines "fluxcd" and "argocd" in spec.gitOps.
+func resolveGitOpsEngine(engine string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(engine)) {
+	case "", gitops.EngineFlux, "fluxcd":
+		return gitops.EngineFlux, nil
+	case gitops.EngineArgoCD, "argocd", "argo":
+		return gitops.EngineArgoCD, nil
+	default:
+		return "", fmt.Errorf("engine must be %s or %s, got %q", gitops.EngineFlux, gitops.EngineArgoCD, engine)
+	}
+}
+
+// defaultGitOpsEngineNamespace is where each engine runs by convention.
+func defaultGitOpsEngineNamespace(engine string) string {
+	if engine == gitops.EngineArgoCD {
+		return gitOpsArgoCDDefaultNamespace
+	}
+	return gitOpsFluxDefaultNamespace
+}
+
+// deriveGitOpsProvider maps a repository URL onto the platform's provider
+// spelling, mirroring the host list the API itself matches on (github.,
+// gitlab., gitea., codeberg.org).
+//
+// The host is matched when the URL has one, and the whole string otherwise, so
+// an scp-style SSH remote (git@github.com:acme/platform.git) — which parses
+// without a host — is still recognised.
+//
+// A URL that says nothing is an error, not an empty provider: a write
+// credential without a provider is skipped by the platform, so the alternative
+// is a cluster that looks onboarded and a first commit that cannot find a
+// credential.
+func deriveGitOpsProvider(repositoryURL string) (string, error) {
+	haystack := strings.ToLower(repositoryURL)
+	if parsed, err := url.Parse(repositoryURL); err == nil && parsed.Host != "" {
+		haystack = strings.ToLower(parsed.Host)
+	}
+
+	switch {
+	case strings.Contains(haystack, "github."):
+		return GitOpsProviderGitHub, nil
+	case strings.Contains(haystack, "gitlab."):
+		return GitOpsProviderGitLab, nil
+	case strings.Contains(haystack, "gitea."), strings.Contains(haystack, "codeberg.org"):
+		return GitOpsProviderGitea, nil
+	default:
+		return "", fmt.Errorf("cannot derive the git provider of %s: set provider to %s, %s or %s",
+			repositoryURL, GitOpsProviderGitHub, GitOpsProviderGitLab, GitOpsProviderGitea)
+	}
+}
+
+// resolveGitOpsProvider prefers an explicit provider — the self-hosted
+// installation whose host says nothing — and derives one otherwise.
+func resolveGitOpsProvider(provider string, repositoryURL string) (string, error) {
+	switch provider {
+	case "":
+		return deriveGitOpsProvider(repositoryURL)
+	case GitOpsProviderGitHub, GitOpsProviderGitLab, GitOpsProviderGitea:
+		return provider, nil
+	default:
+		return "", fmt.Errorf("provider %q cannot write files: set it to one of %s, %s, %s",
+			provider, GitOpsProviderGitHub, GitOpsProviderGitLab, GitOpsProviderGitea)
+	}
+}
+
+// resolveGitOpsCredentials applies every default and validates every field,
+// including the two Secret names: the platform reads the write credential by
+// name, so a repository name that renders an invalid one has to fail here
+// rather than at the API server.
+func resolveGitOpsCredentials(request GitOpsCredentialsRequest) (resolvedGitOpsCredentials, error) {
+	var resolved resolvedGitOpsCredentials
+
+	name := strings.TrimSpace(request.RepositoryName)
+	if name == "" {
+		return resolved, fmt.Errorf("repositoryName is required")
+	}
+	if request.RepositoryURL == "" {
+		return resolved, fmt.Errorf("repositoryUrl is required")
+	}
+	if request.Token == "" {
+		return resolved, fmt.Errorf("token is required")
+	}
+
+	for _, secretName := range []string{gitOpsWriteSecretName(name), gitOpsReadSecretName(name)} {
+		if problems := validation.IsDNS1123Subdomain(secretName); len(problems) > 0 {
+			return resolved, fmt.Errorf("repositoryName %q renders an invalid secret name %q: %s",
+				name, secretName, strings.Join(problems, "; "))
+		}
+	}
+
+	writeMode, err := resolveGitOpsWriteMode(request.WriteMode)
+	if err != nil {
+		return resolved, err
+	}
+	provider, err := resolveGitOpsProvider(request.Provider, request.RepositoryURL)
+	if err != nil {
+		return resolved, err
+	}
+	engine, err := resolveGitOpsEngine(request.Engine)
+	if err != nil {
+		return resolved, err
+	}
+
+	engineNamespace := strings.TrimSpace(request.EngineNamespace)
+	if engineNamespace == "" {
+		engineNamespace = defaultGitOpsEngineNamespace(engine)
+	}
+	if problems := validation.IsDNS1123Label(engineNamespace); len(problems) > 0 {
+		return resolved, fmt.Errorf("engineNamespace %q is not a valid namespace: %s", engineNamespace, strings.Join(problems, "; "))
+	}
+
+	username := strings.TrimSpace(request.Username)
+	if username == "" {
+		username = gitOpsWriteDefaultUsername
+	}
+
+	return resolvedGitOpsCredentials{
+		repositoryName:  name,
+		repositoryURL:   request.RepositoryURL,
+		token:           request.Token,
+		username:        username,
+		provider:        provider,
+		writeMode:       writeMode,
+		engine:          engine,
+		engineNamespace: engineNamespace,
+	}, nil
+}
+
+// gitOpsWriteCredentialSecret is the desired write credential: the Secret the
+// platform API commits platformconfig.yaml with.
+//
+// Everything goes into Data rather than StringData. The platform's own secret
+// validation only ever looks at data, so a Secret carrying just stringData is
+// rejected as having no keys when the API updates it on the next rotation.
+func gitOpsWriteCredentialSecret(namespace string, resolved resolvedGitOpsCredentials) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gitOpsWriteSecretName(resolved.repositoryName),
+			Namespace: namespace,
+			Labels: map[string]string{
+				gitOpsWriteManagedByLabelKey: gitOpsWriteManagedByLabelValue,
+				gitOpsComponentLabelKey:      gitOpsWriteComponentLabelValue,
+				gitOpsManagedByLabelKey:      gitOpsManagedByLabelValue,
+				gitOpsComponentK8sLabelKey:   gitOpsComponentK8sValue,
+				gitOpsPartOfLabelKey:         gitOpsPartOfLabelValue,
+			},
+			Annotations: map[string]string{
+				gitOpsWriteRepositoryAnnotation:    resolved.repositoryName,
+				gitOpsWriteRepositoryURLAnnotation: resolved.repositoryURL,
+				gitOpsWriteModeAnnotation:          resolved.writeMode,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			gitOpsWriteSecretTokenKey:    []byte(resolved.token),
+			gitOpsWriteSecretUsernameKey: []byte(resolved.username),
+			gitOpsWriteSecretProviderKey: []byte(resolved.provider),
+		},
+	}
+}
+
+// gitOpsReadCredentialSecret is the desired read credential: the Secret the
+// GitOps engine syncs the repository with.
+//
+// Its shape is the engine's, not ours. Argo CD discovers repository credentials
+// by label and expects the repository URL inside the Secret; Flux expects plain
+// basic-auth keys and is pointed at the Secret by name from the GitRepository.
+func gitOpsReadCredentialSecret(resolved resolvedGitOpsCredentials) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gitOpsReadSecretName(resolved.repositoryName),
+			Namespace: resolved.engineNamespace,
+			Labels: map[string]string{
+				gitOpsManagedByLabelKey:    gitOpsManagedByLabelValue,
+				gitOpsComponentK8sLabelKey: gitOpsComponentK8sValue,
+				gitOpsPartOfLabelKey:       gitOpsPartOfLabelValue,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			gitOpsReadSecretPasswordKey: []byte(resolved.token),
+		},
+	}
+
+	if resolved.engine == gitops.EngineArgoCD {
+		secret.Labels[argoCDSecretTypeLabelKey] = argoCDSecretTypeLabelValue
+		secret.Data[gitOpsReadSecretTypeKey] = []byte("git")
+		secret.Data[gitOpsReadSecretURLKey] = []byte(resolved.repositoryURL)
+		secret.Data[gitOpsReadSecretUsernameKey] = []byte(gitOpsArgoCDReadUsername)
+		return secret
+	}
+
+	secret.Data[gitOpsReadSecretUsernameKey] = []byte(gitOpsFluxReadUsername)
+	return secret
+}
+
+// upsertGitOpsSecret creates desired, or updates an existing Secret of the same
+// name in place.
+//
+// An existing Secret is adopted rather than refused. Rotating a token is the
+// same call again, and the Secret it has to rotate may have been created by the
+// bootstrap chart or by the platform UI — refusing anything without our own
+// labels would break rotation on exactly the clusters that were onboarded
+// before this code existed.
+//
+// Data keys are merged, not replaced: only the keys we manage are written, so a
+// key an operator added next to them (an Argo CD tlsClientCert, say) survives a
+// rotation.
+func upsertGitOpsSecret(ctx context.Context, client kubernetes.Interface, desired *corev1.Secret) (created bool, err error) {
+	secrets := client.CoreV1().Secrets(desired.Namespace)
+
+	_, err = secrets.Get(ctx, desired.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("get secret %q: %w", desired.Name, err)
+	}
+	if apierrors.IsNotFound(err) {
+		if _, err = secrets.Create(ctx, desired, metav1.CreateOptions{}); err == nil {
+			return true, nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
+			return false, fmt.Errorf("create secret %q: %w", desired.Name, err)
+		}
+		// Lost a create race; fall through to the update path.
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := secrets.Get(ctx, desired.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if current.Labels == nil {
+			current.Labels = map[string]string{}
+		}
+		for key, value := range desired.Labels {
+			current.Labels[key] = value
+		}
+		if current.Annotations == nil {
+			current.Annotations = map[string]string{}
+		}
+		for key, value := range desired.Annotations {
+			current.Annotations[key] = value
+		}
+		if current.Data == nil {
+			current.Data = map[string][]byte{}
+		}
+		for key, value := range desired.Data {
+			current.Data[key] = value
+		}
+		// StringData wins over Data on the API server, so a leftover entry
+		// from a Secret written with stringData would shadow the new token.
+		delete(current.StringData, gitOpsWriteSecretTokenKey)
+		delete(current.StringData, gitOpsReadSecretPasswordKey)
+		_, err = secrets.Update(ctx, current, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		return false, fmt.Errorf("update secret %q: %w", desired.Name, err)
+	}
+	return false, nil
+}
+
+// UpsertGitOpsCredentials materializes both credentials for one platform
+// repository and is idempotent: calling it again with a new token rotates both
+// Secrets in place.
+//
+// The read credential goes first. It is what lets the engine sync the
+// repository at all, and the write credential is only useful once there is a
+// PlatformConfig in the cluster to commit changes to.
+func UpsertGitOpsCredentials(
+	ctx context.Context,
+	client kubernetes.Interface,
+	logger *slog.Logger,
+	operatorNamespace string,
+	request GitOpsCredentialsRequest,
+) (string, error) {
+	resolved, err := resolveGitOpsCredentials(request)
+	if err != nil {
+		return "", err
+	}
+	if operatorNamespace == "" {
+		return "", fmt.Errorf("operator namespace is empty: cannot place the write credential where the platform reads it")
+	}
+
+	readSecret := gitOpsReadCredentialSecret(resolved)
+	readCreated, err := upsertGitOpsSecret(ctx, client, readSecret)
+	if err != nil {
+		return "", fmt.Errorf("upsert repository read credential: %w", err)
+	}
+
+	writeSecret := gitOpsWriteCredentialSecret(operatorNamespace, resolved)
+	writeCreated, err := upsertGitOpsSecret(ctx, client, writeSecret)
+	if err != nil {
+		return "", fmt.Errorf("upsert repository write credential: %w", err)
+	}
+
+	logger.Info("materialized gitops repository credentials",
+		"repository", resolved.repositoryName,
+		"engine", resolved.engine,
+		"readSecret", readSecret.Name,
+		"readSecretNamespace", readSecret.Namespace,
+		"readSecretCreated", readCreated,
+		"writeSecret", writeSecret.Name,
+		"writeSecretNamespace", writeSecret.Namespace,
+		"writeSecretCreated", writeCreated,
+		"provider", resolved.provider,
+		"writeMode", resolved.writeMode)
+
+	return fmt.Sprintf("gitops credentials for repository %q stored: %s/%s and %s/%s",
+		resolved.repositoryName,
+		readSecret.Namespace, readSecret.Name,
+		writeSecret.Namespace, writeSecret.Name), nil
+}

--- a/src/core/gitops_credentials_test.go
+++ b/src/core/gitops_credentials_test.go
@@ -1,0 +1,624 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"mogenius-operator/src/gitops"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// These tests are the Go port of the bootstrap chart's
+// unittests/write-credential-secret_test.yaml, which is the contract with the
+// platform API: it reads the write credential by name from the operator's
+// namespace, keyed and labelled exactly this way.
+
+const (
+	testRepositoryURL = "https://github.com/acme/platform.git"
+	testRepository    = "platform"
+	testEngineNs      = "flux-system"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// testCredentialsRequest is the minimal valid command: repository, url, token.
+func testCredentialsRequest() GitOpsCredentialsRequest {
+	return GitOpsCredentialsRequest{
+		RepositoryName: testRepository,
+		RepositoryURL:  testRepositoryURL,
+		Token:          "ghp_test",
+	}
+}
+
+func upsertForTest(t *testing.T, client *fake.Clientset, request GitOpsCredentialsRequest) string {
+	t.Helper()
+	result, err := UpsertGitOpsCredentials(context.Background(), client, discardLogger(), testNamespace, request)
+	require.NoError(t, err)
+	return result
+}
+
+func writeSecretOf(t *testing.T, client *fake.Clientset, repositoryName string) *corev1.Secret {
+	t.Helper()
+	secret, err := client.CoreV1().Secrets(testNamespace).Get(context.Background(), gitOpsWriteSecretName(repositoryName), metav1.GetOptions{})
+	require.NoError(t, err)
+	return secret
+}
+
+func readSecretOf(t *testing.T, client *fake.Clientset, namespace string, repositoryName string) *corev1.Secret {
+	t.Helper()
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), gitOpsReadSecretName(repositoryName), metav1.GetOptions{})
+	require.NoError(t, err)
+	return secret
+}
+
+// ╭──────────────────────────────╮
+// │ names, namespaces, and keys  │
+// ╰──────────────────────────────╯
+
+func TestGitOpsSecretNames(t *testing.T) {
+	// Both names are contracts: the platform API reads the write credential
+	// under this exact name, and the platform repository reconciler looks the
+	// read credential up under the -repository suffix.
+	assert.Equal(t, "mogenius-gitops-write-platform", gitOpsWriteSecretName("platform"))
+	assert.Equal(t, "platform-repository", gitOpsReadSecretName("platform"))
+	assert.Equal(t, "mogenius-gitops-write-platform-eu", gitOpsWriteSecretName("platform-eu"))
+}
+
+// "creates the write credential when a token is given"
+func TestUpsertGitOpsCredentialsCreatesWriteCredential(t *testing.T) {
+	client := fake.NewClientset()
+	upsertForTest(t, client, testCredentialsRequest())
+
+	secret := writeSecretOf(t, client, testRepository)
+	assert.Equal(t, "mogenius-gitops-write-platform", secret.Name)
+	// The operator's namespace, not the engine's: getting this wrong produces
+	// a Secret nobody looks for.
+	assert.Equal(t, testNamespace, secret.Namespace)
+	assert.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+	assert.Equal(t, []byte("ghp_test"), secret.Data[gitOpsWriteSecretTokenKey])
+	assert.Equal(t, []byte("mogenius"), secret.Data[gitOpsWriteSecretUsernameKey])
+	assert.Equal(t, []byte(GitOpsProviderGitHub), secret.Data[gitOpsWriteSecretProviderKey])
+	// data, never stringData: the platform's secret validation only looks at
+	// data and rejects a Secret carrying just stringData as having no keys.
+	assert.Empty(t, secret.StringData)
+}
+
+// "labels the credential the way the platform recognises it"
+func TestUpsertGitOpsCredentialsWriteLabels(t *testing.T) {
+	client := fake.NewClientset()
+	upsertForTest(t, client, testCredentialsRequest())
+
+	secret := writeSecretOf(t, client, testRepository)
+	assert.Equal(t, "mogenius", secret.Labels[gitOpsWriteManagedByLabelKey])
+	assert.Equal(t, "gitops-write", secret.Labels[gitOpsComponentLabelKey])
+	assert.Equal(t, "mogenius", secret.Labels[gitOpsManagedByLabelKey])
+	assert.Equal(t, "platform-config", secret.Labels[gitOpsComponentK8sLabelKey])
+	assert.Equal(t, "mogenius", secret.Labels[gitOpsPartOfLabelKey])
+}
+
+// "annotates the repository, its url and the write mode"
+func TestUpsertGitOpsCredentialsWriteAnnotations(t *testing.T) {
+	client := fake.NewClientset()
+	upsertForTest(t, client, testCredentialsRequest())
+
+	secret := writeSecretOf(t, client, testRepository)
+	assert.Equal(t, testRepository, secret.Annotations[gitOpsWriteRepositoryAnnotation])
+	assert.Equal(t, testRepositoryURL, secret.Annotations[gitOpsWriteRepositoryURLAnnotation])
+	assert.Equal(t, GitOpsWriteModePullRequest, secret.Annotations[gitOpsWriteModeAnnotation])
+}
+
+// "writes directly when asked to"
+func TestUpsertGitOpsCredentialsDirectCommitMode(t *testing.T) {
+	client := fake.NewClientset()
+	request := testCredentialsRequest()
+	request.WriteMode = GitOpsWriteModeDirectCommit
+	upsertForTest(t, client, request)
+
+	assert.Equal(t, GitOpsWriteModeDirectCommit,
+		writeSecretOf(t, client, testRepository).Annotations[gitOpsWriteModeAnnotation])
+}
+
+// "follows the repository name into the secret name"
+func TestUpsertGitOpsCredentialsFollowsRepositoryName(t *testing.T) {
+	client := fake.NewClientset()
+	request := testCredentialsRequest()
+	request.RepositoryName = "platform-eu"
+	upsertForTest(t, client, request)
+
+	secret := writeSecretOf(t, client, "platform-eu")
+	assert.Equal(t, "mogenius-gitops-write-platform-eu", secret.Name)
+	assert.Equal(t, "platform-eu", secret.Annotations[gitOpsWriteRepositoryAnnotation])
+	assert.Equal(t, "platform-eu-repository", readSecretOf(t, client, testEngineNs, "platform-eu").Name)
+}
+
+// "honors a custom operator namespace"
+func TestUpsertGitOpsCredentialsHonorsOperatorNamespace(t *testing.T) {
+	client := fake.NewClientset()
+	_, err := UpsertGitOpsCredentials(context.Background(), client, discardLogger(), "mogenius-system", testCredentialsRequest())
+	require.NoError(t, err)
+
+	secret, err := client.CoreV1().Secrets("mogenius-system").Get(context.Background(), gitOpsWriteSecretName(testRepository), metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "mogenius-system", secret.Namespace)
+
+	// An empty operator namespace is refused rather than defaulted: the write
+	// credential would land nowhere the platform reads it.
+	_, err = UpsertGitOpsCredentials(context.Background(), fake.NewClientset(), discardLogger(), "", testCredentialsRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operator namespace is empty")
+}
+
+// "stores a custom username"
+func TestUpsertGitOpsCredentialsCustomUsername(t *testing.T) {
+	client := fake.NewClientset()
+	request := testCredentialsRequest()
+	request.Username = "mo-bot"
+	upsertForTest(t, client, request)
+
+	assert.Equal(t, []byte("mo-bot"), writeSecretOf(t, client, testRepository).Data[gitOpsWriteSecretUsernameKey])
+}
+
+// "is created for Argo CD just the same" — the write credential does not move
+// with the engine; only the read credential does.
+func TestUpsertGitOpsCredentialsWriteCredentialIsEngineIndependent(t *testing.T) {
+	client := fake.NewClientset()
+	request := testCredentialsRequest()
+	request.Engine = gitops.EngineArgoCD
+	upsertForTest(t, client, request)
+
+	secret := writeSecretOf(t, client, testRepository)
+	assert.Equal(t, "mogenius-gitops-write-platform", secret.Name)
+	assert.Equal(t, testNamespace, secret.Namespace)
+}
+
+// ╭──────────────────╮
+// │ the write mode   │
+// ╰──────────────────╯
+
+func TestResolveGitOpsWriteMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		want    string
+		wantErr string
+	}{
+		{name: "empty defaults to the reviewable mode", mode: "", want: GitOpsWriteModePullRequest},
+		{name: "pull request", mode: GitOpsWriteModePullRequest, want: GitOpsWriteModePullRequest},
+		{name: "direct commit", mode: GitOpsWriteModeDirectCommit, want: GitOpsWriteModeDirectCommit},
+		// "refuses an unknown write mode": silently ignored by the platform's
+		// reader, which would leave the cluster on a mode nobody chose.
+		{name: "unknown mode is refused", mode: "YOLO", wantErr: `writeMode must be PULL_REQUEST or DIRECT_COMMIT, got "YOLO"`},
+		{name: "lowercase is not accepted", mode: "pull_request", wantErr: "writeMode must be"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveGitOpsWriteMode(tt.mode)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ╭───────────────────╮
+// │ the git provider  │
+// ╰───────────────────╯
+
+func TestResolveGitOpsProvider(t *testing.T) {
+	tests := []struct {
+		name          string
+		provider      string
+		repositoryURL string
+		want          string
+		wantErr       string
+	}{
+		{name: "derives GIT_HUB from a github url", repositoryURL: "https://github.com/acme/platform.git", want: GitOpsProviderGitHub},
+		{name: "derives GIT_LAB from a gitlab url", repositoryURL: "https://gitlab.com/acme/platform.git", want: GitOpsProviderGitLab},
+		{name: "derives GITEA from a self-hosted gitea url", repositoryURL: "https://gitea.acme.internal/acme/platform.git", want: GitOpsProviderGitea},
+		{name: "derives GITEA from codeberg", repositoryURL: "https://codeberg.org/acme/platform.git", want: GitOpsProviderGitea},
+		{name: "derives from an scp-style ssh remote", repositoryURL: "git@github.com:acme/platform.git", want: GitOpsProviderGitHub},
+		{name: "derives from a self-hosted gitlab host", repositoryURL: "https://gitlab.acme.internal/acme/platform.git", want: GitOpsProviderGitLab},
+		{name: "is case insensitive", repositoryURL: "https://GitHub.com/acme/platform.git", want: GitOpsProviderGitHub},
+		// "refuses a url whose provider cannot be derived": a Secret with an
+		// empty provider is silently skipped by the platform, so failing here
+		// beats a first commit weeks later that finds no credential.
+		{
+			name:          "refuses a url whose provider cannot be derived",
+			repositoryURL: "https://git.acme.internal/acme/platform.git",
+			wantErr:       "cannot derive the git provider of https://git.acme.internal/acme/platform.git",
+		},
+		// "takes an explicit provider for a host that says nothing"
+		{
+			name:          "explicit provider wins for a host that says nothing",
+			provider:      GitOpsProviderGitea,
+			repositoryURL: "https://git.acme.internal/acme/platform.git",
+			want:          GitOpsProviderGitea,
+		},
+		{
+			name:          "explicit provider overrides the derived one",
+			provider:      GitOpsProviderGitea,
+			repositoryURL: "https://github.com/acme/platform.git",
+			want:          GitOpsProviderGitea,
+		},
+		// "refuses a provider that cannot write files"
+		{
+			name:          "refuses a provider that cannot write files",
+			provider:      "BITBUCKET",
+			repositoryURL: testRepositoryURL,
+			wantErr:       `provider "BITBUCKET" cannot write files`,
+		},
+		{
+			name:          "refuses a repository path that only looks like a host",
+			repositoryURL: "https://git.acme.internal/acme/github.mirror.git",
+			wantErr:       "cannot derive the git provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveGitOpsProvider(tt.provider, tt.repositoryURL)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// A missing provider makes the platform silently skip the credential, so the
+// command has to fail instead of writing one.
+func TestUpsertGitOpsCredentialsRefusesUndeducibleProvider(t *testing.T) {
+	client := fake.NewClientset()
+	request := testCredentialsRequest()
+	request.RepositoryURL = "https://git.acme.internal/acme/platform.git"
+
+	_, err := UpsertGitOpsCredentials(context.Background(), client, discardLogger(), testNamespace, request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive the git provider")
+
+	// Nothing at all was written: neither credential is useful without the
+	// other, and a half-onboarded repository is harder to diagnose.
+	secrets, listErr := client.CoreV1().Secrets(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, secrets.Items)
+}
+
+// ╭──────────────────────────╮
+// │ the engine's credential  │
+// ╰──────────────────────────╯
+
+func TestUpsertGitOpsCredentialsFluxReadCredential(t *testing.T) {
+	client := fake.NewClientset()
+	upsertForTest(t, client, testCredentialsRequest())
+
+	secret := readSecretOf(t, client, testEngineNs, testRepository)
+	assert.Equal(t, "platform-repository", secret.Name)
+	// Flux runs in flux-system by default, and its credential goes with it.
+	assert.Equal(t, "flux-system", secret.Namespace)
+	assert.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+	// Plain basic auth: Flux is pointed at the Secret by name and reads no url
+	// from it.
+	assert.Equal(t, []byte("git"), secret.Data[gitOpsReadSecretUsernameKey])
+	assert.Equal(t, []byte("ghp_test"), secret.Data[gitOpsReadSecretPasswordKey])
+	assert.NotContains(t, secret.Data, gitOpsReadSecretURLKey)
+	assert.NotContains(t, secret.Data, gitOpsReadSecretTypeKey)
+	assert.NotContains(t, secret.Labels, argoCDSecretTypeLabelKey, "the Argo CD discovery label must not leak into a Flux secret")
+}
+
+func TestUpsertGitOpsCredentialsArgoCDReadCredential(t *testing.T) {
+	client := fake.NewClientset()
+	request := testCredentialsRequest()
+	request.Engine = gitops.EngineArgoCD
+	upsertForTest(t, client, request)
+
+	secret := readSecretOf(t, client, "argocd", request.RepositoryName)
+	assert.Equal(t, "platform-repository", secret.Name)
+	assert.Equal(t, "argocd", secret.Namespace)
+	// Argo CD discovers repository credentials by label and expects the
+	// repository url inside the Secret.
+	assert.Equal(t, argoCDSecretTypeLabelValue, secret.Labels[argoCDSecretTypeLabelKey])
+	assert.Equal(t, []byte("git"), secret.Data[gitOpsReadSecretTypeKey])
+	assert.Equal(t, []byte(testRepositoryURL), secret.Data[gitOpsReadSecretURLKey])
+	// x-token-auth is accepted as the username by GitHub, GitLab and Gitea alike.
+	assert.Equal(t, []byte("x-token-auth"), secret.Data[gitOpsReadSecretUsernameKey])
+	assert.Equal(t, []byte("ghp_test"), secret.Data[gitOpsReadSecretPasswordKey])
+}
+
+func TestUpsertGitOpsCredentialsHonorsExplicitEngineNamespace(t *testing.T) {
+	client := fake.NewClientset()
+	request := testCredentialsRequest()
+	request.Engine = gitops.EngineArgoCD
+	request.EngineNamespace = "gitops"
+	upsertForTest(t, client, request)
+
+	assert.Equal(t, "gitops", readSecretOf(t, client, "gitops", testRepository).Namespace)
+	// The write credential stays in the operator's namespace regardless.
+	assert.Equal(t, testNamespace, writeSecretOf(t, client, testRepository).Namespace)
+}
+
+func TestResolveGitOpsEngine(t *testing.T) {
+	tests := []struct {
+		name      string
+		engine    string
+		want      string
+		wantNs    string
+		wantError bool
+	}{
+		{name: "empty defaults to flux", engine: "", want: gitops.EngineFlux, wantNs: "flux-system"},
+		{name: "flux", engine: gitops.EngineFlux, want: gitops.EngineFlux, wantNs: "flux-system"},
+		// The PlatformConfig spells the same engines fluxcd/argocd.
+		{name: "fluxcd spelling", engine: "fluxcd", want: gitops.EngineFlux, wantNs: "flux-system"},
+		{name: "argo-cd", engine: gitops.EngineArgoCD, want: gitops.EngineArgoCD, wantNs: "argocd"},
+		{name: "argocd spelling", engine: "argocd", want: gitops.EngineArgoCD, wantNs: "argocd"},
+		{name: "mixed case", engine: "Argo-CD", want: gitops.EngineArgoCD, wantNs: "argocd"},
+		{name: "unknown engine is refused", engine: "jenkins", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveGitOpsEngine(tt.engine)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantNs, defaultGitOpsEngineNamespace(got))
+		})
+	}
+}
+
+// ╭─────────────────────────╮
+// │ required input          │
+// ╰─────────────────────────╯
+
+func TestResolveGitOpsCredentialsRequiredFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*GitOpsCredentialsRequest)
+		wantErr string
+	}{
+		{name: "missing repository name", mutate: func(r *GitOpsCredentialsRequest) { r.RepositoryName = "" }, wantErr: "repositoryName is required"},
+		{name: "blank repository name", mutate: func(r *GitOpsCredentialsRequest) { r.RepositoryName = "   " }, wantErr: "repositoryName is required"},
+		{name: "missing url", mutate: func(r *GitOpsCredentialsRequest) { r.RepositoryURL = "" }, wantErr: "repositoryUrl is required"},
+		{name: "missing token", mutate: func(r *GitOpsCredentialsRequest) { r.Token = "" }, wantErr: "token is required"},
+		{
+			name:    "repository name that renders an invalid secret name",
+			mutate:  func(r *GitOpsCredentialsRequest) { r.RepositoryName = "Platform_EU" },
+			wantErr: "renders an invalid secret name",
+		},
+		{
+			name:    "repository name too long for the secret name",
+			mutate:  func(r *GitOpsCredentialsRequest) { r.RepositoryName = strings.Repeat("a", 253) },
+			wantErr: "renders an invalid secret name",
+		},
+		{
+			name:    "invalid engine namespace",
+			mutate:  func(r *GitOpsCredentialsRequest) { r.EngineNamespace = "Flux System" },
+			wantErr: "is not a valid namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := testCredentialsRequest()
+			tt.mutate(&request)
+			_, err := resolveGitOpsCredentials(request)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.NotContains(t, err.Error(), "ghp_test", "errors must not leak the token")
+		})
+	}
+}
+
+func TestResolveGitOpsCredentialsTrimsAndDefaults(t *testing.T) {
+	request := testCredentialsRequest()
+	request.RepositoryName = "  platform  "
+	request.Username = "  "
+	request.EngineNamespace = "  "
+
+	resolved, err := resolveGitOpsCredentials(request)
+	require.NoError(t, err)
+	assert.Equal(t, "platform", resolved.repositoryName)
+	assert.Equal(t, gitOpsWriteDefaultUsername, resolved.username)
+	assert.Equal(t, "flux-system", resolved.engineNamespace)
+	assert.Equal(t, GitOpsWriteModePullRequest, resolved.writeMode)
+	assert.Equal(t, GitOpsProviderGitHub, resolved.provider)
+}
+
+// ╭──────────────────────────────╮
+// │ rotation and idempotency     │
+// ╰──────────────────────────────╯
+
+// Rotating a token is the same command again. It must update in place, not
+// error on the Secret that is already there.
+func TestUpsertGitOpsCredentialsRotatesInPlace(t *testing.T) {
+	client := fake.NewClientset()
+	upsertForTest(t, client, testCredentialsRequest())
+
+	rotated := testCredentialsRequest()
+	rotated.Token = "ghp_rotated"
+	rotated.WriteMode = GitOpsWriteModeDirectCommit
+	rotated.Username = "mo-bot"
+	upsertForTest(t, client, rotated)
+
+	write := writeSecretOf(t, client, testRepository)
+	assert.Equal(t, []byte("ghp_rotated"), write.Data[gitOpsWriteSecretTokenKey])
+	assert.Equal(t, []byte("mo-bot"), write.Data[gitOpsWriteSecretUsernameKey])
+	assert.Equal(t, GitOpsWriteModeDirectCommit, write.Annotations[gitOpsWriteModeAnnotation])
+
+	read := readSecretOf(t, client, testEngineNs, testRepository)
+	assert.Equal(t, []byte("ghp_rotated"), read.Data[gitOpsReadSecretPasswordKey])
+
+	// Exactly one Secret per namespace — an upsert must not fan out copies.
+	writeSecrets, err := client.CoreV1().Secrets(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, writeSecrets.Items, 1)
+	readSecrets, err := client.CoreV1().Secrets(testEngineNs).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, readSecrets.Items, 1)
+}
+
+// A cluster onboarded by the bootstrap chart has Secrets labelled
+// mogenius-platform-bootstrap. Rotation has to adopt those, not refuse them.
+func TestUpsertGitOpsCredentialsAdoptsChartCreatedSecret(t *testing.T) {
+	client := fake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gitOpsWriteSecretName(testRepository),
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				gitOpsWriteManagedByLabelKey: "mogenius",
+				gitOpsManagedByLabelKey:      "mogenius-platform-bootstrap",
+			},
+			Annotations: map[string]string{gitOpsWriteModeAnnotation: GitOpsWriteModePullRequest},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{gitOpsWriteSecretTokenKey: []byte("ghp_old")},
+	})
+
+	rotated := testCredentialsRequest()
+	rotated.Token = "ghp_new"
+	upsertForTest(t, client, rotated)
+
+	secret := writeSecretOf(t, client, testRepository)
+	assert.Equal(t, []byte("ghp_new"), secret.Data[gitOpsWriteSecretTokenKey])
+	// The chart never wrote these; the upsert has to fill them in.
+	assert.Equal(t, gitOpsWriteComponentLabelValue, secret.Labels[gitOpsComponentLabelKey])
+	assert.Equal(t, gitOpsManagedByLabelValue, secret.Labels[gitOpsManagedByLabelKey])
+	assert.Equal(t, testRepositoryURL, secret.Annotations[gitOpsWriteRepositoryURLAnnotation])
+	assert.Equal(t, []byte(GitOpsProviderGitHub), secret.Data[gitOpsWriteSecretProviderKey])
+}
+
+// Keys next to the ones we manage survive a rotation: an Argo CD
+// tlsClientCertData an operator added by hand must not be dropped.
+func TestUpsertGitOpsCredentialsPreservesForeignKeys(t *testing.T) {
+	client := fake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gitOpsReadSecretName(testRepository),
+			Namespace: testEngineNs,
+		},
+		Data: map[string][]byte{"tlsClientCertData": []byte("cert")},
+	})
+
+	upsertForTest(t, client, testCredentialsRequest())
+
+	secret := readSecretOf(t, client, testEngineNs, testRepository)
+	assert.Equal(t, []byte("cert"), secret.Data["tlsClientCertData"])
+	assert.Equal(t, []byte("ghp_test"), secret.Data[gitOpsReadSecretPasswordKey])
+}
+
+// A Secret written with stringData would have the old value shadow the new one,
+// because stringData wins over data on the API server.
+func TestUpsertGitOpsCredentialsClearsShadowingStringData(t *testing.T) {
+	client := fake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gitOpsWriteSecretName(testRepository),
+			Namespace: testNamespace,
+		},
+		StringData: map[string]string{gitOpsWriteSecretTokenKey: "ghp_old"},
+	})
+
+	rotated := testCredentialsRequest()
+	rotated.Token = "ghp_new"
+	upsertForTest(t, client, rotated)
+
+	secret := writeSecretOf(t, client, testRepository)
+	assert.NotContains(t, secret.StringData, gitOpsWriteSecretTokenKey)
+	assert.Equal(t, []byte("ghp_new"), secret.Data[gitOpsWriteSecretTokenKey])
+}
+
+// A concurrent create (two replicas, or a retried command) must land on the
+// update path rather than failing the command.
+func TestUpsertGitOpsSecretToleratesCreateRace(t *testing.T) {
+	client := fake.NewClientset()
+	desired := gitOpsWriteCredentialSecret(testNamespace, resolvedGitOpsCredentials{
+		repositoryName: testRepository,
+		repositoryURL:  testRepositoryURL,
+		token:          "ghp_test",
+		username:       gitOpsWriteDefaultUsername,
+		provider:       GitOpsProviderGitHub,
+		writeMode:      GitOpsWriteModePullRequest,
+	})
+
+	// Get says NotFound, Create then loses the race with another writer.
+	client.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		client.ReactionChain = client.ReactionChain[1:]
+		require.NoError(t, client.Tracker().Add(desired.DeepCopy()))
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "secrets"}, desired.Name)
+	})
+
+	created, err := upsertGitOpsSecret(context.Background(), client, desired)
+	require.NoError(t, err)
+	assert.False(t, created, "the loser of the race did not create it")
+	assert.Equal(t, []byte("ghp_test"), writeSecretOf(t, client, testRepository).Data[gitOpsWriteSecretTokenKey])
+}
+
+func TestUpsertGitOpsSecretWrapsGetError(t *testing.T) {
+	client := fake.NewClientset()
+	client.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("api server is down")
+	})
+
+	_, err := upsertGitOpsSecret(context.Background(), client, gitOpsWriteCredentialSecret(testNamespace, resolvedGitOpsCredentials{
+		repositoryName: testRepository,
+		token:          "ghp_test",
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api server is down")
+	assert.Contains(t, err.Error(), gitOpsWriteSecretName(testRepository))
+}
+
+// A failure on the write credential must be reported, not swallowed — the
+// engine could sync while the platform silently could not commit.
+func TestUpsertGitOpsCredentialsReportsWriteCredentialFailure(t *testing.T) {
+	client := fake.NewClientset()
+	client.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		create, ok := action.(k8stesting.CreateAction)
+		require.True(t, ok)
+		secret, ok := create.GetObject().(*corev1.Secret)
+		require.True(t, ok)
+		if secret.Name == gitOpsWriteSecretName(testRepository) {
+			return true, nil, fmt.Errorf("forbidden")
+		}
+		return false, nil, nil
+	})
+
+	_, err := UpsertGitOpsCredentials(context.Background(), client, discardLogger(), testNamespace, testCredentialsRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upsert repository write credential")
+	assert.NotContains(t, err.Error(), "ghp_test", "errors must not leak the token")
+}
+
+// The result string names both Secrets, so an onboarding log says where the
+// credentials landed.
+func TestUpsertGitOpsCredentialsResultNamesBothSecrets(t *testing.T) {
+	client := fake.NewClientset()
+	result := upsertForTest(t, client, testCredentialsRequest())
+
+	assert.Contains(t, result, "mogenius/mogenius-gitops-write-platform")
+	assert.Contains(t, result, "flux-system/platform-repository")
+	assert.NotContains(t, result, "ghp_test")
+}

--- a/src/core/socketapi.go
+++ b/src/core/socketapi.go
@@ -2501,6 +2501,28 @@ func (self *socketApi) registerPatterns() {
 	}
 
 	{
+		// The credentials for a platform repository, materialized from a token
+		// the platform API pushes. Previously the job of the
+		// mogenius-platform-bootstrap Helm chart.
+		//
+		// The operator only writes the two Secrets; committing
+		// platformconfig.yaml stays the API's job. Idempotent, so rotating a
+		// token is the same call again.
+		//
+		// GitOpsCredentialsRequest.Token is redacted in the audit log by its
+		// field name (sensitiveAuditPayloadKeys in store), and the audit entry
+		// carries no object diff — a diff of a Secret is a diff of the token.
+		RegisterPatternHandler(
+			PatternHandle{self, "platform/upsert-gitops-credentials"},
+			PatternConfig{},
+			func(datagram structs.Datagram, request GitOpsCredentialsRequest) (string, error) {
+				res, err := self.apiService.UpsertGitOpsCredentials(request)
+				return store.AddToAuditLog(datagram, self.logger, res, err, nil, nil)
+			},
+		)
+	}
+
+	{
 		type Request struct {
 			AgentName string `json:"agentName" validate:"required"`
 		}

--- a/src/core/workspacemanager.go
+++ b/src/core/workspacemanager.go
@@ -49,6 +49,10 @@ type WorkspaceManager interface {
 	UpdateAiModel(name string, spec v1alpha1.AiModelSpec, apiKey string) (*v1alpha1.AiModel, error)
 	DeleteAiModel(name string) error
 
+	// UpsertGitOpsCredentials materializes the read/write credential Secrets
+	// for a platform repository from a token the platform API pushes.
+	UpsertGitOpsCredentials(request GitOpsCredentialsRequest) (string, error)
+
 	GetAllMcpServers() ([]v1alpha1.McpServer, error)
 	GetMcpServer(name string) (*v1alpha1.McpServer, error)
 	CreateMcpServer(name string, spec v1alpha1.McpServerSpec) (*v1alpha1.McpServer, error)
@@ -299,6 +303,15 @@ func (self *workspaceManager) DeleteAiModel(name string) error {
 	self.namespaceLock.RLock()
 	defer self.namespaceLock.RUnlock()
 	return self.mogeniusClientSet.MogeniusV1alpha1.DeleteAiModel(self.namespace, name)
+}
+
+// UpsertGitOpsCredentials places the write credential in the operator's own
+// namespace, which is where the platform API reads it; the read credential goes
+// to the engine's namespace, named by the request.
+func (self *workspaceManager) UpsertGitOpsCredentials(request GitOpsCredentialsRequest) (string, error) {
+	self.namespaceLock.RLock()
+	defer self.namespaceLock.RUnlock()
+	return UpsertGitOpsCredentials(context.Background(), self.clientProvider.K8sClientSet(), self.logger, self.namespace, request)
 }
 
 func (self *workspaceManager) GetAllMcpServers() ([]v1alpha1.McpServer, error) {


### PR DESCRIPTION
Ports the two Secrets the `mogenius-platform-bootstrap` chart renders into the operator, driven by a new inbound websocket command `platform/upsert-gitops-credentials` — the platform API pushes the token, the operator materializes the Secrets. Committing `platformconfig.yaml` stays the API's job.

- **Read credential** `<repository>-repository` in the engine's namespace (`flux-system`/`argocd`), in the engine's own shape: Argo CD labelled `argocd.argoproj.io/secret-type=repository` with `type`/`url`/`username`/`password`, Flux plain basic auth. Compatible with the name `reconcilePlatformRepositories` looks it up by.
- **Write credential** `mogenius-gitops-write-<repository>` in `MO_OWN_NAMESPACE` with `token`/`username`/`provider`, the `mogenius.com/gitops-*` annotations and the labels the platform recognises its own credentials by. Provider is derived from the URL host (github./gitlab./gitea./codeberg.org) or passed explicitly for a self-hosted host; an underivable provider fails the command instead of writing a credential the API would silently skip.
- Idempotent: the same call with a new token rotates both Secrets in place and adopts a Secret the chart or the UI created, so rotation keeps working on clusters onboarded before this.

New: `src/core/gitops_credentials.go` plus `gitops_credentials_test.go`, which ports every assertion of the chart's `unittests/write-credential-secret_test.yaml`. Wiring only in `api.go` / `workspacemanager.go` / `socketapi.go`; nothing under `src/reconciler/` is touched.

**This must merge before the bootstrap chart is deleted** — until then the chart is the only thing creating these Secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)