### PR TITLE
feat(platform): install the GitOps engine with the Helm SDK

### DIFF
--- a/src/gitops/argocd.go
+++ b/src/gitops/argocd.go
@@ -31,12 +31,23 @@ func (a *argocdInstaller) Install(component string, artifact GitOpsArtifact) err
 		return fmt.Errorf("apply argocd application %s: %w", component, err)
 	}
 
-	if len(artifact.ExtraObjects) > 0 {
-		moacApp := buildArgoMoacApplication(component, artifact, a.namespace)
-		moacApp.SetOwnerReferences(a.ownerRefs)
-		if err := Apply(a.clientProvider, argoApplicationGVR, a.namespace, moacApp); err != nil {
-			return fmt.Errorf("apply argocd moac application %s-resources: %w", component, err)
-		}
+	return a.ApplyExtras(component, artifact)
+}
+
+// ApplyExtras ships only the artifact's extra objects, without the component's
+// own chart. The engine itself needs this: mogenius installs it with the Helm
+// SDK rather than as an Application, so Argo CD never syncs the release its own
+// controllers come from, while the objects that belong to it still travel the
+// normal way.
+func (a *argocdInstaller) ApplyExtras(component string, artifact GitOpsArtifact) error {
+	if len(artifact.ExtraObjects) == 0 {
+		return nil
+	}
+
+	moacApp := buildArgoMoacApplication(component, artifact, a.namespace)
+	moacApp.SetOwnerReferences(a.ownerRefs)
+	if err := Apply(a.clientProvider, argoApplicationGVR, a.namespace, moacApp); err != nil {
+		return fmt.Errorf("apply argocd moac application %s-resources: %w", component, err)
 	}
 
 	return nil

--- a/src/gitops/flux.go
+++ b/src/gitops/flux.go
@@ -68,18 +68,29 @@ func (f *fluxInstaller) Install(component string, artifact GitOpsArtifact) error
 		}
 	}
 
-	if len(artifact.ExtraObjects) > 0 {
-		moacRepo := buildFluxHelmRepository(component+"-resources", moacRepository, f.namespace)
-		moacRepo.SetOwnerReferences(f.ownerRefs)
-		if err := Apply(f.clientProvider, fluxHelmRepositoryGVR, f.namespace, moacRepo); err != nil {
-			return fmt.Errorf("apply flux moac helmrepository %s-resources: %w", component, err)
-		}
+	return f.ApplyExtras(component, artifact)
+}
 
-		moacRelease := buildFluxMoacHelmRelease(component, artifact, f.namespace)
-		moacRelease.SetOwnerReferences(f.ownerRefs)
-		if err := Apply(f.clientProvider, fluxHelmReleaseGVR, f.namespace, moacRelease); err != nil {
-			return fmt.Errorf("apply flux moac helmrelease %s-resources: %w", component, err)
-		}
+// ApplyExtras ships only the artifact's extra objects, without the component's
+// own chart. The engine itself needs this: mogenius installs it with the Helm
+// SDK rather than as a HelmRelease — a HelmRelease for flux-operator would have
+// helm-controller manage the release its own controllers come from — but the
+// objects that belong to it still travel the normal way.
+func (f *fluxInstaller) ApplyExtras(component string, artifact GitOpsArtifact) error {
+	if len(artifact.ExtraObjects) == 0 {
+		return nil
+	}
+
+	moacRepo := buildFluxHelmRepository(component+"-resources", moacRepository, f.namespace)
+	moacRepo.SetOwnerReferences(f.ownerRefs)
+	if err := Apply(f.clientProvider, fluxHelmRepositoryGVR, f.namespace, moacRepo); err != nil {
+		return fmt.Errorf("apply flux moac helmrepository %s-resources: %w", component, err)
+	}
+
+	moacRelease := buildFluxMoacHelmRelease(component, artifact, f.namespace)
+	moacRelease.SetOwnerReferences(f.ownerRefs)
+	if err := Apply(f.clientProvider, fluxHelmReleaseGVR, f.namespace, moacRelease); err != nil {
+		return fmt.Errorf("apply flux moac helmrelease %s-resources: %w", component, err)
 	}
 
 	return nil

--- a/src/gitops/installer.go
+++ b/src/gitops/installer.go
@@ -55,6 +55,9 @@ type HelmChartReference struct {
 
 type GitOpsInstaller interface {
 	Install(string, GitOpsArtifact) error
+	// ApplyExtras ships an artifact's extra objects without its chart, for a
+	// component whose release mogenius installs with the Helm SDK instead.
+	ApplyExtras(string, GitOpsArtifact) error
 	UnInstall(string) error
 }
 
@@ -69,8 +72,9 @@ const (
 // reconcilers can call Install/UnInstall without panicking.
 type noopInstaller struct{}
 
-func (n *noopInstaller) Install(_ string, _ GitOpsArtifact) error { return nil }
-func (n *noopInstaller) UnInstall(_ string) error                 { return nil }
+func (n *noopInstaller) Install(_ string, _ GitOpsArtifact) error     { return nil }
+func (n *noopInstaller) ApplyExtras(_ string, _ GitOpsArtifact) error { return nil }
+func (n *noopInstaller) UnInstall(_ string) error                     { return nil }
 
 // NewGitOpsInstaller returns an installer for the given engine type.
 // namespace is where the engine's own CRDs (Applications, HelmReleases, …) live.

--- a/src/helm/helm.go
+++ b/src/helm/helm.go
@@ -1000,7 +1000,7 @@ func HelmOciInstall(data HelmChartOciInstallUpgradeRequest) (result string, err 
 	// See HelmReleaseUpgrade: take sole ownership on SSA conflicts (MOG-4393).
 	install.ForceConflicts = true
 	install.Labels = map[string]string{
-		"mogenius.com/installed-via": "mogenius-operator",
+		InstalledViaLabel: InstalledViaValue,
 		"mogenius.com/oci-chart":     "true",
 	}
 
@@ -1176,7 +1176,7 @@ func HelmChartInstall(data HelmChartInstallUpgradeRequest) (result string, err e
 	// See HelmReleaseUpgrade: take sole ownership on SSA conflicts (MOG-4393).
 	install.ForceConflicts = true
 	install.Labels = map[string]string{
-		"mogenius.com/installed-via": "mogenius-operator",
+		InstalledViaLabel: InstalledViaValue,
 		"mogenius.com/oci-chart":     "false",
 	}
 

--- a/src/helm/release_owner.go
+++ b/src/helm/release_owner.go
@@ -1,0 +1,67 @@
+package helm
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"helm.sh/helm/v4/pkg/action"
+	release "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/storage/driver"
+)
+
+const (
+	// InstalledViaLabel is stamped on every release this operator installs. It
+	// is what makes an existing release attributable later: a release without
+	// it was put there by someone else.
+	InstalledViaLabel = "mogenius.com/installed-via"
+	// InstalledViaValue is the label's value for releases the operator owns.
+	InstalledViaValue = "mogenius-operator"
+)
+
+// ReleaseOwnership is the answer to "may this operator write to that release?".
+type ReleaseOwnership int
+
+const (
+	// ReleaseAbsent means no release of that name exists in the namespace.
+	ReleaseAbsent ReleaseOwnership = iota
+	// ReleaseOwnedByOperator means this operator installed it and may upgrade it.
+	ReleaseOwnedByOperator
+	// ReleaseForeign means a release exists that the operator did not install.
+	// Upgrading it would overwrite someone else's values.
+	ReleaseForeign
+)
+
+// LookupReleaseOwnership reports whether a release exists and whether this
+// operator installed it.
+//
+// Anything other than a clean "not found" is returned as an error rather than
+// as ReleaseAbsent: treating an unreachable API server as absence would install
+// a second release next to one that is already there.
+func LookupReleaseOwnership(namespace string, releaseName string) (ReleaseOwnership, error) {
+	settings := NewCli()
+	settings.SetNamespace(namespace)
+
+	actionConfig := new(action.Configuration)
+	if err := actionConfig.Init(settings.RESTClientGetter(), namespace, ""); err != nil {
+		return ReleaseAbsent, fmt.Errorf("init helm config for %s/%s: %w", namespace, releaseName, err)
+	}
+
+	rel, err := action.NewGet(actionConfig).Run(releaseName)
+	if err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) || strings.Contains(err.Error(), "release: not found") {
+			return ReleaseAbsent, nil
+		}
+		return ReleaseAbsent, fmt.Errorf("get release %s/%s: %w", namespace, releaseName, err)
+	}
+
+	re, ok := rel.(*release.Release)
+	if !ok || re == nil {
+		return ReleaseAbsent, nil
+	}
+
+	if re.Labels[InstalledViaLabel] == InstalledViaValue {
+		return ReleaseOwnedByOperator, nil
+	}
+	return ReleaseForeign, nil
+}

--- a/src/reconciler/crd_checker.go
+++ b/src/reconciler/crd_checker.go
@@ -74,3 +74,15 @@ func (c *crdChecker) checkAPI(resource utils.ResourceDescriptor) bool {
 	}
 	return false
 }
+
+// forget drops a cached absence so the next IsAvailable asks the API server
+// again. Needed right after installing a chart that registers CRDs: absence is
+// cached for absentTTL, and without this the operator would keep skipping the
+// custom resources it just created the definitions for.
+func (c *crdChecker) forget(resource utils.ResourceDescriptor) {
+	key := resource.ApiVersion + "/" + resource.Kind
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.absentAt, key)
+}

--- a/src/reconciler/platformConfig.go
+++ b/src/reconciler/platformConfig.go
@@ -110,7 +110,8 @@ func (d *reconcilerModule) reconcilePlatformConfig(ctx context.Context, obj *uns
 		return []ReconcileResult{{Err: fmt.Errorf("failed to parse PlatformConfig: %w", err)}}
 	}
 
-	gitOpsStatus := buildGitOpsStatus(platformConfig.Spec, d.detectGitOpsStatus(ctx))
+	detection := d.detectGitOpsStatus(ctx)
+	gitOpsStatus := buildGitOpsStatus(platformConfig.Spec, detection)
 
 	// specEngine is the engine mogenius is asked to install; it is empty unless
 	// spec.gitOps enables one.
@@ -144,16 +145,16 @@ func (d *reconcilerModule) reconcilePlatformConfig(ctx context.Context, obj *uns
 		result *ReconcileResult
 	}
 
-	// Capacity: the eight non-engine components plus the engine, when mogenius
-	// owns it. The engine is only reconciled in that case — reconciling a
-	// user-managed engine would adopt a Helm release someone else installed and
-	// overwrite their values on the next sweep.
+	// Capacity: the eight non-engine components plus the engine, when the spec
+	// asks mogenius to install one. It goes first and blocks until the engine
+	// answers, because everything after it is delivered as a custom resource
+	// that engine has to pick up.
 	components := make([]componentResult, 0, 9)
 	switch specEngine {
 	case gitOpsEngineArgoCD:
-		components = append(components, componentResult{name: componentArgoCD, result: d.reconcileArgoCD(ctx, platformConfig.Spec, installer, op)})
+		components = append(components, componentResult{name: componentArgoCD, result: d.reconcileArgoCD(ctx, platformConfig.Spec, installer, detection)})
 	case gitOpsEngineFlux:
-		components = append(components, componentResult{name: componentFluxCD, result: d.reconcileFluxCD(ctx, platformConfig.Spec, installer, op)})
+		components = append(components, componentResult{name: componentFluxCD, result: d.reconcileFluxCD(ctx, platformConfig.Spec, installer, detection)})
 	}
 
 	// Repositories the platform syncs itself. Only when mogenius does not own

--- a/src/reconciler/platform_argocd.go
+++ b/src/reconciler/platform_argocd.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-func (d *reconcilerModule) reconcileArgoCD(ctx context.Context, spec v1alpha1.PlatformConfigSpec, installer gitops.GitOpsInstaller, op operation) *ReconcileResult {
+func (d *reconcilerModule) reconcileArgoCD(ctx context.Context, spec v1alpha1.PlatformConfigSpec, installer gitops.GitOpsInstaller, detection gitOpsDetection) *ReconcileResult {
 	// Not declared: leave whatever is installed alone (see reconcileComponent).
 	// Unreachable through reconcilePlatformConfig, which only dispatches here
 	// for an engine the spec enables — but a nil spec.GitOps would panic.
@@ -17,9 +17,9 @@ func (d *reconcilerModule) reconcileArgoCD(ctx context.Context, spec v1alpha1.Pl
 		return nil
 	}
 	cfg := spec.GitOps.ArgoCD
-	namespace := helmNamespace(cfg.Chart, argocdDefaultNamespace)
-	return d.reconcileComponent(ctx, spec, installer, op,
-		componentSpec{
+	return d.reconcileGitOpsEngine(ctx, spec, installer, detection, engineSpec{
+		engine: gitOpsEngineArgoCD,
+		component: componentSpec{
 			enabled:          cfg.Enabled,
 			chart:            cfg.Chart,
 			patches:          cfg.Patches,
@@ -29,25 +29,31 @@ func (d *reconcilerModule) reconcileArgoCD(ctx context.Context, spec v1alpha1.Pl
 			defaultName:      "argocd",
 			defaultNamespace: argocdDefaultNamespace,
 		},
-		func(ctx context.Context) ([]any, error) {
-			extraObjects := []any{}
-
+		// The AppProject has to exist before anything is placed in it — and
+		// every Application the platform creates is, including the one that
+		// would otherwise have carried this object.
+		bootstrapObjects: func(namespace string) []engineBootstrapObject {
+			return []engineBootstrapObject{{
+				resource: utils.AppProjectResource,
+				object: map[string]any{
+					"apiVersion": utils.AppProjectResource.ApiVersion,
+					"kind":       utils.AppProjectResource.Kind,
+					"metadata": map[string]any{
+						"name":      argoProjectName(spec.GitOps),
+						"namespace": namespace,
+					},
+					"spec": map[string]any{
+						"clusterResourceWhitelist": []map[string]any{{"group": "*", "kind": "*"}},
+						"destinations":             []map[string]any{{"namespace": "*", "server": "*"}},
+						"sourceRepos":              []string{"*"},
+					},
+				},
+			}}
+		},
+		extraObjects: func(ctx context.Context) ([]any, error) {
+			namespace := helmNamespace(cfg.Chart, argocdDefaultNamespace)
 			project := argoProjectName(spec.GitOps)
-
-			appProject := map[string]any{
-				"apiVersion": utils.AppProjectResource.ApiVersion,
-				"kind":       utils.AppProjectResource.Kind,
-				"metadata": map[string]any{
-					"name":      project,
-					"namespace": namespace,
-				},
-				"spec": map[string]any{
-					"clusterResourceWhitelist": []map[string]any{{"group": "*", "kind": "*"}},
-					"destinations":             []map[string]any{{"namespace": "*", "server": "*"}},
-					"sourceRepos":              []string{"*"},
-				},
-			}
-			extraObjects = append(extraObjects, appProject)
+			extraObjects := []any{}
 
 			for _, repo := range spec.GitOps.Repositories {
 				name := repo.Name
@@ -100,7 +106,7 @@ func (d *reconcilerModule) reconcileArgoCD(ctx context.Context, spec v1alpha1.Pl
 
 			return extraObjects, nil
 		},
-		func(ctx context.Context) (map[string]any, error) {
+		extraValues: func(ctx context.Context) (map[string]any, error) {
 			if d.crdChecker.IsAvailable(utils.ServiceMonitorResource) {
 				metricsBlock := map[string]any{
 					"enabled": true,
@@ -117,7 +123,7 @@ func (d *reconcilerModule) reconcileArgoCD(ctx context.Context, spec v1alpha1.Pl
 			}
 			return nil, nil
 		},
-	)
+	})
 }
 
 func argoApplicationObject(name string, repo v1alpha1.GitOpsRepositoryConfig, namespace, project string) map[string]any {

--- a/src/reconciler/platform_component.go
+++ b/src/reconciler/platform_component.go
@@ -56,9 +56,34 @@ func (d *reconcilerModule) reconcileComponent(
 		return nil
 	}
 
+	artifact, result := d.buildComponentArtifact(ctx, platformSpec, cs, buildExtraObjects, buildExtraValues)
+	if result != nil {
+		return result
+	}
+
+	if err := installer.Install(cs.name, artifact); err != nil {
+		return &ReconcileResult{Err: fmt.Errorf("failed to install %s: %w", cs.name, err)}
+	}
+
+	return nil
+}
+
+// buildComponentArtifact resolves a component's chart, values and extra objects
+// into the artifact an installer ships. Shared with the engine path, which
+// needs the same resolution but installs the chart itself with the Helm SDK.
+//
+// A non-nil ReconcileResult is the failure; the artifact is only valid when it
+// is nil.
+func (d *reconcilerModule) buildComponentArtifact(
+	ctx context.Context,
+	platformSpec v1alpha1.PlatformConfigSpec,
+	cs componentSpec,
+	buildExtraObjects func(ctx context.Context) ([]any, error),
+	buildExtraValues func(ctx context.Context) (map[string]any, error),
+) (gitops.GitOpsArtifact, *ReconcileResult) {
 	defaultComponentConfig, err := getDefaultConfig(platformSpec.PlatformSource, platformSpec.PlatformVersion, cs.name)
 	if err != nil {
-		return &ReconcileResult{Err: fmt.Errorf("fetch default config for %s: %w", cs.name, err)}
+		return gitops.GitOpsArtifact{}, &ReconcileResult{Err: fmt.Errorf("fetch default config for %s: %w", cs.name, err)}
 	}
 
 	chart := gitops.HelmChartReference{
@@ -73,7 +98,7 @@ func (d *reconcilerModule) reconcileComponent(
 		for _, patchRef := range cs.patches {
 			patch, err := d.fetchPlatformPatch(ctx, patchRef)
 			if err != nil && !apierrors.IsNotFound(err) {
-				return &ReconcileResult{Err: fmt.Errorf("fetch platform patch for %s: %w", cs.name, err)}
+				return gitops.GitOpsArtifact{}, &ReconcileResult{Err: fmt.Errorf("fetch platform patch for %s: %w", cs.name, err)}
 			}
 			patches = append(patches, *patch)
 		}
@@ -81,41 +106,35 @@ func (d *reconcilerModule) reconcileComponent(
 
 	componentValues, err := buildExtraValues(ctx)
 	if err != nil {
-		return &ReconcileResult{Err: fmt.Errorf("failed to create component values for %s: %w", cs.name, err)}
+		return gitops.GitOpsArtifact{}, &ReconcileResult{Err: fmt.Errorf("failed to create component values for %s: %w", cs.name, err)}
 	}
 
 	mergedValues, err := mergeHelmValues(defaultComponentConfig, componentValues, patches)
 	if err != nil {
-		return &ReconcileResult{Err: fmt.Errorf("merge helm values for %s: %w", cs.name, err)}
+		return gitops.GitOpsArtifact{}, &ReconcileResult{Err: fmt.Errorf("merge helm values for %s: %w", cs.name, err)}
 	}
 
 	extraObjects, err := buildExtraObjects(ctx)
 	if err != nil {
-		return &ReconcileResult{Err: fmt.Errorf("build extra objects for %s: %w", cs.name, err)}
+		return gitops.GitOpsArtifact{}, &ReconcileResult{Err: fmt.Errorf("build extra objects for %s: %w", cs.name, err)}
 	}
 
 	extraPatchObjects, err := extractPatchExtraObjects(patches)
 	if err != nil {
-		return &ReconcileResult{Err: fmt.Errorf("extract extra objects for %s: %w", cs.name, err)}
+		return gitops.GitOpsArtifact{}, &ReconcileResult{Err: fmt.Errorf("extract extra objects for %s: %w", cs.name, err)}
 	}
 	extraObjects = append(extraObjects, extraPatchObjects...)
 
 	argoConfig, fluxConfig := getSpecificGitOpsConfig(platformSpec.GitOps)
 
-	artifact := gitops.GitOpsArtifact{
+	return gitops.GitOpsArtifact{
 		Namespace:    helmNamespace(cs.chart, cs.defaultNamespace),
 		HelmChart:    chart,
 		Values:       mergedValues,
 		ExtraObjects: extraObjects,
 		ArgoCD:       argoConfig,
 		FluxCD:       fluxConfig,
-	}
-
-	if err := installer.Install(cs.name, artifact); err != nil {
-		return &ReconcileResult{Err: fmt.Errorf("failed to install %s: %w", cs.name, err)}
-	}
-
-	return nil
+	}, nil
 }
 
 func getSpecificGitOpsConfig(settings *v1alpha1.GitOpsConfig) (*gitops.ArgoCDSettings, *gitops.FluxCDSettings) {

--- a/src/reconciler/platform_component_test.go
+++ b/src/reconciler/platform_component_test.go
@@ -18,10 +18,16 @@ import (
 type recordingInstaller struct {
 	installed   []string
 	uninstalled []string
+	extras      []string
 }
 
 func (r *recordingInstaller) Install(component string, _ gitops.GitOpsArtifact) error {
 	r.installed = append(r.installed, component)
+	return nil
+}
+
+func (r *recordingInstaller) ApplyExtras(component string, _ gitops.GitOpsArtifact) error {
+	r.extras = append(r.extras, component)
 	return nil
 }
 
@@ -114,22 +120,6 @@ func componentCases() []componentCase {
 			disabled:  v1alpha1.PlatformConfigSpec{ExternalSecretsOperator: &v1alpha1.ExternalSecretsOperatorConfig{Enabled: false}},
 			enabled:   v1alpha1.PlatformConfigSpec{ExternalSecretsOperator: &v1alpha1.ExternalSecretsOperatorConfig{Enabled: true}},
 		},
-		{
-			name:      "fluxcd",
-			component: componentFluxCD,
-			reconcile: (*reconcilerModule).reconcileFluxCD,
-			absent:    v1alpha1.PlatformConfigSpec{},
-			disabled:  v1alpha1.PlatformConfigSpec{GitOps: &v1alpha1.GitOpsConfig{FluxCD: &v1alpha1.FluxCDInstallConfig{Enabled: false}}},
-			enabled:   v1alpha1.PlatformConfigSpec{GitOps: &v1alpha1.GitOpsConfig{FluxCD: &v1alpha1.FluxCDInstallConfig{Enabled: true}}},
-		},
-		{
-			name:      "argocd",
-			component: componentArgoCD,
-			reconcile: (*reconcilerModule).reconcileArgoCD,
-			absent:    v1alpha1.PlatformConfigSpec{},
-			disabled:  v1alpha1.PlatformConfigSpec{GitOps: &v1alpha1.GitOpsConfig{ArgoCD: &v1alpha1.ArgoCDInstallConfig{Enabled: false}}},
-			enabled:   v1alpha1.PlatformConfigSpec{GitOps: &v1alpha1.GitOpsConfig{ArgoCD: &v1alpha1.ArgoCDInstallConfig{Enabled: true}}},
-		},
 	}
 }
 
@@ -203,4 +193,51 @@ func TestReconcilePlatformConfigIgnoresDelete(t *testing.T) {
 	results := testModule().reconcilePlatformConfig(context.Background(), obj, deleteOperation)
 
 	assert.Nil(t, results)
+}
+
+// The engine is the one component that is never removed implicitly. Disabling
+// it hands ownership back to the user rather than pulling the engine out from
+// under every component it delivers.
+func TestGitOpsEngineIsNeverUninstalled(t *testing.T) {
+	cases := []struct {
+		name      string
+		reconcile func(*reconcilerModule, context.Context, v1alpha1.PlatformConfigSpec, gitops.GitOpsInstaller, gitOpsDetection) *ReconcileResult
+		absent    v1alpha1.PlatformConfigSpec
+		disabled  v1alpha1.PlatformConfigSpec
+	}{
+		{
+			name:      "fluxcd",
+			reconcile: (*reconcilerModule).reconcileFluxCD,
+			absent:    v1alpha1.PlatformConfigSpec{},
+			disabled:  v1alpha1.PlatformConfigSpec{GitOps: &v1alpha1.GitOpsConfig{FluxCD: &v1alpha1.FluxCDInstallConfig{Enabled: false}}},
+		},
+		{
+			name:      "argocd",
+			reconcile: (*reconcilerModule).reconcileArgoCD,
+			absent:    v1alpha1.PlatformConfigSpec{},
+			disabled:  v1alpha1.PlatformConfigSpec{GitOps: &v1alpha1.GitOpsConfig{ArgoCD: &v1alpha1.ArgoCDInstallConfig{Enabled: false}}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/absent", func(t *testing.T) {
+			installer := &recordingInstaller{}
+
+			result := tc.reconcile(testModule(), context.Background(), tc.absent, installer, gitOpsDetection{})
+
+			assert.Nil(t, result)
+			assert.Empty(t, installer.uninstalled)
+			assert.Empty(t, installer.extras)
+		})
+
+		t.Run(tc.name+"/disabled", func(t *testing.T) {
+			installer := &recordingInstaller{}
+
+			result := tc.reconcile(testModule(), context.Background(), tc.disabled, installer, gitOpsDetection{})
+
+			assert.Nil(t, result)
+			assert.Empty(t, installer.uninstalled, "a disabled engine must be left running, not uninstalled")
+			assert.Empty(t, installer.extras)
+		})
+	}
 }

--- a/src/reconciler/platform_engine_install.go
+++ b/src/reconciler/platform_engine_install.go
@@ -1,0 +1,289 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"mogenius-operator/src/crds/v1alpha1"
+	"mogenius-operator/src/gitops"
+	"mogenius-operator/src/helm"
+	"mogenius-operator/src/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	// engineReadyTimeout bounds the wait for the engine's controllers after the
+	// chart went in. Long enough for image pulls on a cold cluster, short
+	// enough that a reconcile slot is not held for minutes when something is
+	// actually broken.
+	engineReadyTimeout = 3 * time.Minute
+	// engineCRDTimeout bounds the wait for the CRDs the engine's chart
+	// registers. They land with the release manifest, so this only absorbs API
+	// server registration lag.
+	engineCRDTimeout = 30 * time.Second
+	// enginePollInterval is how often those two waits re-probe.
+	enginePollInterval = 3 * time.Second
+)
+
+// engineBootstrapObject is applied straight through the dynamic client, before
+// the engine is able to deliver anything itself.
+//
+// Flux's FluxInstance is the reason this exists: the flux-operator chart ships
+// no controllers, they come from that resource, so it cannot travel the normal
+// way — the normal way needs a running helm-controller. Argo CD's AppProject
+// has the same shape of problem: every Application the platform creates is
+// placed in that project, including the one that would have carried it.
+type engineBootstrapObject struct {
+	resource utils.ResourceDescriptor
+	object   map[string]any
+}
+
+// engineSpec describes a GitOps engine the operator installs and owns.
+type engineSpec struct {
+	// component carries chart, patches and namespace, exactly as for any other
+	// platform component.
+	component componentSpec
+	// engine is the detection name, gitOpsEngineFlux or gitOpsEngineArgoCD.
+	engine string
+	// bootstrapObjects are applied directly once the chart's CRDs exist.
+	bootstrapObjects func(namespace string) []engineBootstrapObject
+	// extraObjects and extraValues match reconcileComponent's callbacks.
+	extraObjects func(ctx context.Context) ([]any, error)
+	extraValues  func(ctx context.Context) (map[string]any, error)
+}
+
+// reconcileGitOpsEngine installs the GitOps engine with the Helm SDK and keeps
+// owning it there.
+//
+// The engine cannot be delivered the way every other component is. Components
+// ship as HelmReleases and Applications that the engine reconciles, so
+// delivering the engine that way is circular: a HelmRelease for flux-operator
+// needs a helm-controller that only exists once flux-operator ran. And even
+// where it would resolve, it would leave the engine's controllers managing the
+// release they themselves come from, free to delete their own workload halfway
+// through an upgrade.
+//
+// So the chart goes in through the SDK, the objects that must exist before the
+// controllers do are applied directly, and only the rest travels the normal
+// way once the engine answers.
+func (d *reconcilerModule) reconcileGitOpsEngine(
+	ctx context.Context,
+	platformSpec v1alpha1.PlatformConfigSpec,
+	installer gitops.GitOpsInstaller,
+	detection gitOpsDetection,
+	es engineSpec,
+) *ReconcileResult {
+	cs := es.component
+	namespace := helmNamespace(cs.chart, cs.defaultNamespace)
+
+	// Only reachable for an engine the spec enables — reconcilePlatformConfig
+	// dispatches on exactly that. Disabling one is not a request to remove it:
+	// pulling the engine out would strand every component it delivers, so it is
+	// left running and simply stops being managed.
+	if !cs.enabled {
+		return nil
+	}
+
+	artifact, result := d.buildComponentArtifact(ctx, platformSpec, cs, es.extraObjects, es.extraValues)
+	if result != nil {
+		return result
+	}
+
+	ownership, err := helm.LookupReleaseOwnership(namespace, artifact.HelmChart.Name)
+	if err != nil {
+		return &ReconcileResult{Err: fmt.Errorf("check ownership of %s: %w", cs.name, err)}
+	}
+
+	// Someone else's engine. Adopting it would overwrite their values on this
+	// sweep and every one after, so it is left alone — mogenius still delivers
+	// components through it, which is what a user-managed engine is for. The
+	// fix is to stop asking mogenius to install one.
+	if ownership == helm.ReleaseForeign {
+		return &ReconcileResult{Err: fmt.Errorf(
+			"release %s/%s already exists and was not installed by mogenius: set spec.gitOps.%s.enabled to false to keep using it as a user-managed engine",
+			namespace, artifact.HelmChart.Name, es.engine)}
+	}
+
+	if err := d.ensureNamespace(ctx, namespace); err != nil {
+		return &ReconcileResult{Err: fmt.Errorf("ensure namespace %s: %w", namespace, err)}
+	}
+
+	if err := installEngineChart(artifact, namespace, ownership == helm.ReleaseOwnedByOperator); err != nil {
+		return &ReconcileResult{Err: fmt.Errorf("install %s: %w", cs.name, err)}
+	}
+
+	for _, bootstrap := range es.bootstrapObjects(namespace) {
+		// The chart just registered this CRD; the checker may still be holding
+		// a cached absence from before the install.
+		if !d.waitForCRD(ctx, bootstrap.resource) {
+			return &ReconcileResult{Err: fmt.Errorf(
+				"%s installed but %s did not register within %s", cs.name, bootstrap.resource.Kind, engineCRDTimeout)}
+		}
+		if err := d.applyPlatformObject(bootstrap.resource, namespace, bootstrap.object); err != nil {
+			return &ReconcileResult{Err: fmt.Errorf("apply %s for %s: %w", bootstrap.resource.Kind, cs.name, err)}
+		}
+	}
+
+	// Everything downstream — the repository Applications, the other platform
+	// components — is created as a custom resource the engine has to pick up,
+	// so nothing is gained by racing ahead of its controllers.
+	if !d.waitForEngineControllers(ctx, es.engine) {
+		return &ReconcileResult{Err: fmt.Errorf(
+			"%s installed but its controllers were not running within %s", cs.name, engineReadyTimeout)}
+	}
+
+	if err := installer.ApplyExtras(cs.name, artifact); err != nil {
+		return &ReconcileResult{Err: fmt.Errorf("apply resources for %s: %w", cs.name, err)}
+	}
+
+	// The engine that was missing when this reconcile started is running now,
+	// and the detection the caller is about to report predates it.
+	if det := detection.forEngine(es.engine); det == nil || !det.installed {
+		d.requeuePlatformConfig()
+	}
+
+	return nil
+}
+
+// installEngineChart installs or upgrades the engine's Helm release. OCI and
+// classic repositories take different entry points on the way in, but the same
+// one on the way up.
+func installEngineChart(artifact gitops.GitOpsArtifact, namespace string, exists bool) error {
+	values, err := yaml.Marshal(artifact.Values)
+	if err != nil {
+		return fmt.Errorf("marshal values: %w", err)
+	}
+
+	chart := artifact.HelmChart
+
+	if strings.HasPrefix(chart.Repository, "oci://") {
+		request := helm.HelmChartInstallUpgradeRequest{
+			Namespace: namespace,
+			// For OCI the repository already is the full chart reference.
+			Chart:   chart.Repository,
+			Release: chart.Name,
+			Version: chart.Version,
+			Values:  string(values),
+		}
+		if exists {
+			_, err = helm.HelmReleaseUpgrade(request)
+			return err
+		}
+		_, err = helm.HelmOciInstall(helm.HelmChartOciInstallUpgradeRequest{
+			OCIChartUrl: chart.Repository,
+			Namespace:   namespace,
+			Release:     chart.Name,
+			Version:     chart.Version,
+			Values:      string(values),
+		})
+		return err
+	}
+
+	// A classic repository has to be in helm's repository file before the
+	// chart can be located by name. Prefixed so it cannot collide with a
+	// repository the user added under the chart's own name.
+	repoName := "mogenius-" + chart.Chart
+	if _, err := helm.HelmRepoAdd(helm.HelmRepoAddRequest{Name: repoName, Url: chart.Repository}); err != nil &&
+		!strings.Contains(err.Error(), "already exists") {
+		return fmt.Errorf("add repository %s: %w", chart.Repository, err)
+	}
+
+	request := helm.HelmChartInstallUpgradeRequest{
+		Namespace: namespace,
+		Chart:     repoName + "/" + chart.Chart,
+		Release:   chart.Name,
+		Version:   chart.Version,
+		Values:    string(values),
+	}
+	if exists {
+		_, err = helm.HelmReleaseUpgrade(request)
+		return err
+	}
+	_, err = helm.HelmChartInstall(request)
+	return err
+}
+
+// ensureNamespace creates the engine's namespace. Helm does not create it, and
+// on a cluster being onboarded neither flux-system nor argocd exists yet.
+func (d *reconcilerModule) ensureNamespace(ctx context.Context, namespace string) error {
+	client := d.clientProvider.K8sClientSet().CoreV1().Namespaces()
+
+	if _, err := client.Get(ctx, namespace, metav1.GetOptions{}); err == nil {
+		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("read namespace: %w", err)
+	}
+
+	_, err := client.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{"app.kubernetes.io/managed-by": "mogenius-operator"},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create namespace: %w", err)
+	}
+	return nil
+}
+
+// waitForCRD re-probes one resource until the API server serves it. The cached
+// absence is dropped first, because it may predate the install that registered
+// the definition.
+func (d *reconcilerModule) waitForCRD(ctx context.Context, resource utils.ResourceDescriptor) bool {
+	d.crdChecker.forget(resource)
+
+	deadline := time.Now().Add(engineCRDTimeout)
+	for {
+		if d.crdChecker.IsAvailable(resource) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(enginePollInterval):
+			d.crdChecker.forget(resource)
+		}
+	}
+}
+
+// waitForEngineControllers polls the engine detection until it reports the
+// engine as installed, which only happens once its controllers actually run.
+func (d *reconcilerModule) waitForEngineControllers(ctx context.Context, engine string) bool {
+	deadline := time.Now().Add(engineReadyTimeout)
+	for {
+		if detected := d.detectGitOpsStatus(ctx).forEngine(engine); detected != nil && detected.installed {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(enginePollInterval):
+		}
+	}
+}
+
+// requeuePlatformConfig re-reconciles the PlatformConfig without waiting for
+// the background sweep.
+//
+// Installing the engine changes nothing about the resource, so it produces no
+// watch event, and the sweep is fifteen minutes away. Only called after real
+// progress — requeueing while merely waiting for something would spin.
+func (d *reconcilerModule) requeuePlatformConfig() {
+	if d.requeue == nil {
+		return
+	}
+	d.requeue(utils.PlatformConfigResource, func(*unstructured.Unstructured) bool { return true })
+}

--- a/src/reconciler/platform_fluxcd.go
+++ b/src/reconciler/platform_fluxcd.go
@@ -8,7 +8,7 @@ import (
 	"mogenius-operator/src/utils"
 )
 
-func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.PlatformConfigSpec, installer gitops.GitOpsInstaller, op operation) *ReconcileResult {
+func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.PlatformConfigSpec, installer gitops.GitOpsInstaller, detection gitOpsDetection) *ReconcileResult {
 	// Not declared: leave whatever is installed alone (see reconcileComponent).
 	// Unreachable through reconcilePlatformConfig, which only dispatches here
 	// for an engine the spec enables — but a nil spec.GitOps would panic.
@@ -16,9 +16,9 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 		return nil
 	}
 	cfg := spec.GitOps.FluxCD
-	namespace := helmNamespace(cfg.Chart, fluxcdDefaultNamespace)
-	return d.reconcileComponent(ctx, spec, installer, op,
-		componentSpec{
+	return d.reconcileGitOpsEngine(ctx, spec, installer, detection, engineSpec{
+		engine: gitOpsEngineFlux,
+		component: componentSpec{
 			enabled:          cfg.Enabled,
 			chart:            cfg.Chart,
 			patches:          cfg.Patches,
@@ -28,12 +28,18 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 			defaultName:      "flux-operator",
 			defaultNamespace: fluxcdDefaultNamespace,
 		},
-		func(ctx context.Context) ([]any, error) {
-			// The FluxInstance is what actually deploys the Flux controllers; the
-			// flux-operator chart alone installs none. Since extra objects ship via a
-			// moac HelmRelease that needs helm-controller to reconcile, the very first
-			// install requires the Flux controllers to be bootstrapped out-of-band.
-			extraObjects := []any{fluxInstanceObject(namespace)}
+		// The FluxInstance is what actually deploys the Flux controllers; the
+		// flux-operator chart alone installs none. It therefore cannot ship as
+		// an extra object, because those travel through a HelmRelease that
+		// needs the very helm-controller this resource brings up.
+		bootstrapObjects: func(namespace string) []engineBootstrapObject {
+			return []engineBootstrapObject{
+				{resource: utils.FluxInstanceResource, object: fluxInstanceObject(namespace)},
+			}
+		},
+		extraObjects: func(ctx context.Context) ([]any, error) {
+			namespace := helmNamespace(cfg.Chart, fluxcdDefaultNamespace)
+			extraObjects := []any{}
 
 			for _, repo := range spec.GitOps.Repositories {
 				name := repo.Name
@@ -80,7 +86,7 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 
 			return extraObjects, nil
 		},
-		func(ctx context.Context) (map[string]any, error) {
+		extraValues: func(ctx context.Context) (map[string]any, error) {
 			if d.crdChecker.IsAvailable(utils.ServiceMonitorResource) {
 				return map[string]any{
 					"serviceMonitor": map[string]any{
@@ -90,7 +96,7 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 			}
 			return nil, nil
 		},
-	)
+	})
 }
 
 func fluxInstanceObject(namespace string) map[string]any {


### PR DESCRIPTION
Stacked on #1238 — merge that first, this PR retargets to `main` automatically.

## Why

`reconcileFluxCD` was self-referential: it wrote a `HelmRelease` for `flux-operator`, which needs a running `helm-controller` — the thing `flux-operator` brings up. On a cluster with no engine, "mogenius installs the engine" could never work. And where it did resolve, the engine's controllers ended up managing the release their own workload comes from.

## What changed

**Engine goes in through the Helm SDK** (`platform_engine_install.go`). Version and values resolve exactly as before, from `platform-defaults` via `getDefaultConfig` — so no version list is duplicated anywhere.

**Three ordered steps, one reconcile:**
1. namespace + `HelmOciInstall`/`HelmChartInstall` (upgrade when we already own the release)
2. bootstrap objects applied directly: Flux's `FluxInstance`, Argo's `AppProject` — these cannot travel through the engine, because the engine is what they bring up. This also fixes a latent circularity on Argo: the `AppProject` used to ship inside an `Application` that was itself placed in that project.
3. wait for the controllers, then the remaining extras ship the normal way via the new `GitOpsInstaller.ApplyExtras`

**Foreign releases are never adopted.** Both install paths already stamped `mogenius.com/installed-via: mogenius-operator`; `helm.LookupReleaseOwnership` now reads it back. A release without it means someone else's engine: no install, no upgrade, and a condition telling the user to set `enabled: false` and keep it user-managed.

**`crdChecker.forget`** drops a cached absence after the install — absence is cached for a minute, which would otherwise make the operator skip the custom resources it just registered the definitions for.

**Requeue on progress only** (`requeuePlatformConfig`), so the engine coming up does not wait for the 15-minute sweep. Never while merely waiting — that would spin.

## Notes

- A disabled engine is now left running instead of uninstalled: pulling it out would strand every component it delivers.
- `waitForEngineControllers` holds a reconcile slot for up to 3 minutes during onboarding. Bounded, and honours context cancellation.
- `src/services/storagehelper_test.go:57` fails staticcheck. Pre-existing on `main`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)