### PR TITLE
fix(gitops): bind the repository credential on the engine-extras path

### DIFF
--- a/src/reconciler/platform_fluxcd.go
+++ b/src/reconciler/platform_fluxcd.go
@@ -69,8 +69,13 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 					}
 				}
 
+				// The same credential decision the user-managed path makes: a
+				// private repository is unreadable without it, and the Secret
+				// sits right next to the source. This path shipped without it
+				// once -- the engine ran, cloned nothing, and the only symptom
+				// was "authentication required" on the GitRepository.
 				extraObjects = append(extraObjects,
-					fluxGitRepositoryObject(name, repo, namespace),
+					fluxGitRepositoryObject(name, repo, namespace, d.fluxRepositorySecretName(ctx, name, repo, namespace)),
 					fluxKustomizationObject(name, repo, namespace),
 				)
 
@@ -146,7 +151,11 @@ func fluxKustomizationObject(name string, repo v1alpha1.GitOpsRepositoryConfig, 
 	}
 }
 
-func fluxGitRepositoryObject(name string, repo v1alpha1.GitOpsRepositoryConfig, namespace string) map[string]any {
+// fluxGitRepositoryObject builds the source. secretName is the credential the
+// source binds with, empty for none -- the caller decides, because deciding
+// takes a cluster lookup (fluxRepositorySecretName) and this stays a pure
+// builder.
+func fluxGitRepositoryObject(name string, repo v1alpha1.GitOpsRepositoryConfig, namespace string, secretName string) map[string]any {
 	revision := repo.Revision
 	if revision == "" {
 		revision = "main"
@@ -158,8 +167,8 @@ func fluxGitRepositoryObject(name string, repo v1alpha1.GitOpsRepositoryConfig, 
 			"branch": revision,
 		},
 	}
-	if repo.ExternalSecret != nil {
-		spec["secretRef"] = map[string]any{"name": name}
+	if secretName != "" {
+		spec["secretRef"] = map[string]any{"name": secretName}
 	}
 	return map[string]any{
 		"apiVersion": "source.toolkit.fluxcd.io/v1",

--- a/src/reconciler/platform_repositories.go
+++ b/src/reconciler/platform_repositories.go
@@ -74,15 +74,7 @@ func (d *reconcilerModule) reconcilePlatformRepositories(
 			}
 
 		case gitOpsEngineFlux:
-			source := fluxGitRepositoryObject(name, repo, namespace)
-			// Flux is pointed at its credential by name, and a secretRef naming
-			// a Secret that is not there fails the source outright -- so it is
-			// only set once the Secret exists. A public repository needs none.
-			if repo.ExternalSecret == nil && d.platformRepositorySecretExists(ctx, namespace, name+repositorySecretSuffix) {
-				if spec, ok := source["spec"].(map[string]any); ok {
-					spec["secretRef"] = map[string]any{"name": name + repositorySecretSuffix}
-				}
-			}
+			source := fluxGitRepositoryObject(name, repo, namespace, d.fluxRepositorySecretName(ctx, name, repo, namespace))
 			if err := d.applyPlatformObject(utils.GitRepositoryResource, namespace, source); err != nil {
 				return &ReconcileResult{Err: fmt.Errorf("apply git repository %q: %w", name, err)}
 			}
@@ -122,6 +114,32 @@ func (d *reconcilerModule) applyPlatformObject(resource utils.ResourceDescriptor
 		namespace,
 		obj,
 	)
+}
+
+// fluxRepositorySecretName is the credential a repository's GitRepository binds
+// with: the ExternalSecret's target when one is declared, otherwise the
+// conventional <name>-repository Secret -- and only when that Secret actually
+// exists. Flux is pointed at a credential by name, and a secretRef naming a
+// Secret that is not there fails the source outright; a public repository
+// needs none.
+//
+// Shared by both delivery paths on purpose. The engine-extras path once made
+// this decision differently from the user-managed path (namely: not at all),
+// and a private repository then failed with "authentication required" while
+// its credential sat unused in the same namespace.
+func (d *reconcilerModule) fluxRepositorySecretName(
+	ctx context.Context,
+	name string,
+	repo v1alpha1.GitOpsRepositoryConfig,
+	namespace string,
+) string {
+	if repo.ExternalSecret != nil {
+		return name
+	}
+	if d.platformRepositorySecretExists(ctx, namespace, name+repositorySecretSuffix) {
+		return name + repositorySecretSuffix
+	}
+	return ""
 }
 
 func (d *reconcilerModule) platformRepositorySecretExists(ctx context.Context, namespace, name string) bool {

--- a/src/reconciler/platform_repositories_secret_test.go
+++ b/src/reconciler/platform_repositories_secret_test.go
@@ -1,0 +1,36 @@
+package reconciler
+
+import (
+	"testing"
+
+	"mogenius-operator/src/crds/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The incident this pins down: the engine-extras path built the GitRepository
+// without any secretRef, so a private repository failed with "authentication
+// required" while its credential Secret sat unused in the same namespace. Both
+// delivery paths now pass the secret name through this one builder.
+func TestFluxGitRepositoryObjectBindsTheNamedSecret(t *testing.T) {
+	repo := v1alpha1.GitOpsRepositoryConfig{URL: "https://github.com/acme/platform.git", Revision: "main"}
+
+	object := fluxGitRepositoryObject("platform", repo, "flux-system", "platform-repository")
+
+	spec := object["spec"].(map[string]any)
+	assert.Equal(t, map[string]any{"name": "platform-repository"}, spec["secretRef"])
+}
+
+// A public repository needs no credential, and a secretRef naming a Secret
+// that is not there fails the source outright — so no name means no reference.
+func TestFluxGitRepositoryObjectWithoutASecretCarriesNoReference(t *testing.T) {
+	repo := v1alpha1.GitOpsRepositoryConfig{URL: "https://github.com/acme/platform.git"}
+
+	object := fluxGitRepositoryObject("platform", repo, "flux-system", "")
+
+	spec := object["spec"].(map[string]any)
+	_, present := spec["secretRef"]
+	assert.False(t, present)
+	// The default branch when the spec names none.
+	assert.Equal(t, map[string]any{"branch": "main"}, spec["ref"])
+}


### PR DESCRIPTION
Second finding from the same live test as #1247, one layer deeper. With the dependsOn fix in, the GitRepository and Kustomization finally appear — and the source fails:

```
gitrepository/platform   READY=False   failed to checkout ...: authentication required: Repository not found.
```

The credential Secret (`platform-repository`, username/password, valid token) sits right next to it in flux-system, created by the connect call. It is never referenced: the GitRepository spec carries no `secretRef`.

**Cause:** the two delivery paths decided the credential differently. The user-managed-engine path (`reconcilePlatformRepositories`) checks for the conventional `<name>-repository` Secret and sets `secretRef` when it exists. The engine-extras path (`platform_fluxcd.go`, the one every mogenius-installed engine takes) called the bare builder — which only set a reference in the ExternalSecret case — and never made that decision at all.

**Fix:** one decision, `fluxRepositorySecretName` — ExternalSecret target when declared, otherwise the conventional Secret if it exists, otherwise none (a public repository needs none, and a secretRef naming an absent Secret fails the source outright). `fluxGitRepositoryObject` becomes a pure builder taking the resolved name; both paths call the same decision. A token stored later is picked up on the next sweep, since the extras are rebuilt every pass.

Two builder tests pin down both directions. Existing clusters heal on the next sweep after the operator update — the moac release re-renders the GitRepository with the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)