### PR TITLE
fix(gitops): preserve foreign metadata on apply and reconcile fresh objects

### DIFF
--- a/src/gitops/apply_test.go
+++ b/src/gitops/apply_test.go
@@ -1,0 +1,66 @@
+package gitops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The renovate-zombie incident: helm-controller parks its uninstall finalizer
+// on every HelmRelease, the operator's sweep replaced metadata wholesale and
+// stripped it — and a HelmRelease deleted in that window vanished without the
+// uninstall, leaving the release's workload running with nothing managing it.
+func TestApplyKeepsForeignFinalizersOnUpdate(t *testing.T) {
+	existing := helmRelease("traefik", defaultLabels("traefik"))
+	existing.SetFinalizers([]string{"finalizers.fluxcd.io"})
+	existing.SetAnnotations(map[string]string{"reconcile.fluxcd.io/requestedAt": "sometime"})
+	client := testClient(t, existing).Resource(testHelmReleaseGVR).Namespace("flux-system")
+
+	update := helmRelease("traefik", defaultLabels("traefik"))
+	update.SetAnnotations(map[string]string{"mogenius.com/sweep": "now"})
+	require.NoError(t, applyWith(context.Background(), client, update))
+
+	applied, err := client.Get(context.Background(), "traefik", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"finalizers.fluxcd.io"}, applied.GetFinalizers(),
+		"the uninstall finalizer is what makes deleting the object actually uninstall the release")
+	// Foreign keys survive, ours arrive.
+	assert.Equal(t, "sometime", applied.GetAnnotations()["reconcile.fluxcd.io/requestedAt"])
+	assert.Equal(t, "now", applied.GetAnnotations()["mogenius.com/sweep"])
+	assert.Equal(t, defaultLabels("traefik")["app.kubernetes.io/managed-by"], applied.GetLabels()["app.kubernetes.io/managed-by"])
+}
+
+// Ours win on conflict: the operator owns what it applies, and a foreign write
+// to one of its own keys must not stick.
+func TestApplyPrefersOurValuesOnConflict(t *testing.T) {
+	existing := helmRelease("traefik", map[string]string{"app.kubernetes.io/managed-by": "someone-else"})
+	client := testClient(t, existing).Resource(testHelmReleaseGVR).Namespace("flux-system")
+
+	update := helmRelease("traefik", defaultLabels("traefik"))
+	require.NoError(t, applyWith(context.Background(), client, update))
+
+	applied, err := client.Get(context.Background(), "traefik", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, defaultLabels("traefik")["app.kubernetes.io/managed-by"], applied.GetLabels()["app.kubernetes.io/managed-by"])
+}
+
+func TestApplyCreatesWhenAbsent(t *testing.T) {
+	client := testClient(t).Resource(testHelmReleaseGVR).Namespace("flux-system")
+
+	object := helmRelease("traefik", defaultLabels("traefik"))
+	require.NoError(t, applyWith(context.Background(), client, object))
+
+	applied, err := client.Get(context.Background(), "traefik", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "traefik", applied.GetName())
+}
+
+// Keep the compiler honest about the helper's nil behavior.
+func TestMergePreferringOurs(t *testing.T) {
+	assert.Nil(t, mergePreferringOurs(nil, nil))
+	assert.Equal(t, map[string]string{"a": "1"}, mergePreferringOurs(nil, map[string]string{"a": "1"}))
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, mergePreferringOurs(map[string]string{"a": "x", "b": "2"}, map[string]string{"a": "1"}))
+}

--- a/src/gitops/installer.go
+++ b/src/gitops/installer.go
@@ -142,9 +142,20 @@ func deleteIfManaged(ctx context.Context, logger *slog.Logger, client dynamic.Re
 // not own cannot ship as extra objects of a release it installed, because
 // there is no such release -- they have to be applied directly.
 func Apply(cp k8sclient.K8sClientProvider, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
-	ctx := context.Background()
-	client := cp.DynamicClient().Resource(gvr).Namespace(namespace)
+	return applyWith(context.Background(), cp.DynamicClient().Resource(gvr).Namespace(namespace), obj)
+}
 
+// applyWith creates the object, or replaces it when it exists — carrying over
+// what other controllers put on it.
+//
+// The carry-over is not politeness. helm-controller parks its uninstall
+// finalizer on every HelmRelease it reconciles, and an update that replaces
+// metadata wholesale strips it on every sweep; a HelmRelease deleted in one of
+// those windows vanishes from etcd without helm-controller ever running the
+// uninstall, and the release's workload keeps running with nothing left that
+// manages it. Our own keys win on conflict — the operator is the owner of what
+// it applies — but keys and finalizers it did not write survive.
+func applyWith(ctx context.Context, client dynamic.ResourceInterface, obj *unstructured.Unstructured) error {
 	_, err := client.Create(ctx, obj, metav1.CreateOptions{})
 	if err == nil {
 		return nil
@@ -158,6 +169,24 @@ func Apply(cp k8sclient.K8sClientProvider, gvr schema.GroupVersionResource, name
 		return err
 	}
 	obj.SetResourceVersion(existing.GetResourceVersion())
+	obj.SetFinalizers(existing.GetFinalizers())
+	obj.SetLabels(mergePreferringOurs(existing.GetLabels(), obj.GetLabels()))
+	obj.SetAnnotations(mergePreferringOurs(existing.GetAnnotations(), obj.GetAnnotations()))
 	_, err = client.Update(ctx, obj, metav1.UpdateOptions{})
 	return err
+}
+
+// mergePreferringOurs keeps every key of theirs that ours does not set.
+func mergePreferringOurs(theirs, ours map[string]string) map[string]string {
+	if len(theirs) == 0 {
+		return ours
+	}
+	merged := make(map[string]string, len(theirs)+len(ours))
+	for key, value := range theirs {
+		merged[key] = value
+	}
+	for key, value := range ours {
+		merged[key] = value
+	}
+	return merged
 }

--- a/src/reconciler/platformConfig.go
+++ b/src/reconciler/platformConfig.go
@@ -8,6 +8,7 @@ import (
 	"mogenius-operator/src/gitops"
 	"reflect"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,6 +105,26 @@ func (d *reconcilerModule) reconcilePlatformConfig(ctx context.Context, obj *uns
 		d.logger.Info("PlatformConfig deleted, leaving installed components untouched", "name", obj.GetName())
 		return nil
 	}
+
+	// The event object can be minutes old by the time it is processed: a sweep
+	// works through chart pulls and controller waits, and events queue up
+	// behind it. Acting on a queued copy re-creates components the current
+	// spec already disabled — a HelmRelease that flaps into existence right
+	// after its uninstall — so the sweep starts from what the cluster says now.
+	// Gone entirely is handled like the delete event above: not an instruction.
+	fresh, err := d.clientProvider.DynamicClient().
+		Resource(platformConfigGVR).
+		Get(ctx, obj.GetName(), metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			d.logger.Info("PlatformConfig gone before its reconcile ran, leaving installed components untouched", "name", obj.GetName())
+			return nil
+		}
+		// Stale input is the one thing this must not act on, so a read failure
+		// fails the sweep and the retry works from a fresh object.
+		return []ReconcileResult{{Err: fmt.Errorf("re-read PlatformConfig %s: %w", obj.GetName(), err)}}
+	}
+	obj = fresh
 
 	var platformConfig v1alpha1.PlatformConfig
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &platformConfig); err != nil {


### PR DESCRIPTION
Root-cause fix for the renovate zombie found live on the docker-desktop cluster: after `renovateOperator.enabled: false` synced, the HelmRelease CR was deleted — and deleted again, because something kept re-creating it — and through all of it the renovate workload kept running, orphaned, with its Helm release secret intact and zero uninstall lines in four hours of helm-controller logs.

Two defects, one incident:

**1. `Apply` stripped foreign metadata on every update.** The update path replaced the object wholesale, wiping `metadata.finalizers` — including helm-controller's uninstall finalizer, which it kept re-adding every cycle (the recurring "prefer a domain-qualified finalizer name" log lines). A HelmRelease deleted in one of those windows vanishes from etcd without helm-controller ever running the uninstall: CR gone, workload stays. Fix: the update carries over the existing object's finalizers and merges labels/annotations (foreign keys survive, our keys win). Extracted as `applyWith(dynamic.ResourceInterface, …)` so it is testable with the fake client; three tests pin it down.

**2. The reconciler acted on stale event objects.** `reconcilePlatformConfig` worked with the object from the watch event. A platform sweep takes minutes (chart pulls, controller waits), events queue up behind it, and a queued copy still carrying `enabled: true` re-created the HelmRelease the current spec had just uninstalled — the flapping stopped exactly when the event backlog drained. Fix: the sweep re-reads the PlatformConfig from the API server first; gone-by-now is treated like the delete event (not an instruction), any other read failure fails the sweep so the retry starts fresh. Not unit-testable today (`K8sClientProvider` returns concrete clients), noted as such.

The pre-existing staticcheck finding in `src/services/storagehelper_test.go` is untouched/unrelated.

On the affected cluster the orphaned release needs one manual `helm uninstall renovate-operator -n renovate-operator` (or re-enable + disable once the fixed operator runs) — the fix prevents new orphans, it cannot re-bind the existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)