### PR TITLE
feat(platform): type platform config repositories

### DIFF
--- a/src/crds/v1alpha1/type_platform_config.go
+++ b/src/crds/v1alpha1/type_platform_config.go
@@ -64,9 +64,25 @@ type GitOpsConfig struct {
 	Repositories []GitOpsRepositoryConfig `json:"repositories,omitempty"`
 }
 
+// The two kinds of repository a PlatformConfig can declare.
+const (
+	// RepositoryTypePlatform holds the platform config itself; the operator
+	// turns the entry into the engine's sync objects.
+	RepositoryTypePlatform = "platform"
+	// RepositoryTypeApplication holds application workloads. Declared for the
+	// mogenius platform to read; this operator creates no sync objects for it.
+	RepositoryTypeApplication = "application"
+)
+
 type GitOpsRepositoryConfig struct {
-	Name           string          `json:"name"`
-	URL            string          `json:"url"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+	// Type says what the repository holds: "platform" (the default when
+	// absent — every config written before the field existed means exactly
+	// that) or "application".
+	// +kubebuilder:validation:Enum=platform;application
+	// +optional
+	Type           string          `json:"type,omitempty"`
 	Path           string          `json:"path,omitempty"`
 	Revision       string          `json:"revision,omitempty"`
 	ExternalSecret *ExternalSecret `json:"externalSecret,omitempty"`
@@ -75,6 +91,13 @@ type GitOpsRepositoryConfig struct {
 	// nothing in the cluster on its own.
 	// +optional
 	Write *GitOpsWriteConfig `json:"write,omitempty"`
+}
+
+// IsPlatformRepository answers whether the operator owns this entry's sync
+// objects. Absent type reads as platform: every config written before the
+// field existed declared exactly that.
+func (r GitOpsRepositoryConfig) IsPlatformRepository() bool {
+	return r.Type == "" || r.Type == RepositoryTypePlatform
 }
 
 // GitOpsWriteConfig overrides how the platform commits to a GitOps repository.

--- a/src/crds/yaml/mogenius.com_platformconfigs.yaml
+++ b/src/crds/yaml/mogenius.com_platformconfigs.yaml
@@ -324,6 +324,15 @@ spec:
                           type: string
                         revision:
                           type: string
+                        type:
+                          description: |-
+                            Type says what the repository holds: "platform" (the default when
+                            absent — every config written before the field existed means exactly
+                            that) or "application".
+                          enum:
+                          - platform
+                          - application
+                          type: string
                         url:
                           type: string
                         write:

--- a/src/reconciler/platform_component_status.go
+++ b/src/reconciler/platform_component_status.go
@@ -38,8 +38,14 @@ func declaredComponents(spec v1alpha1.PlatformConfigSpec) map[string]componentDe
 		if spec.GitOps.ArgoCD != nil {
 			declared[componentArgoCD] = componentDeclaration{declared: true, enabled: spec.GitOps.ArgoCD.Enabled}
 		}
-		if len(spec.GitOps.Repositories) > 0 {
-			declared[componentPlatformRepositories] = componentDeclaration{declared: true, enabled: true}
+		for _, repo := range spec.GitOps.Repositories {
+			// Only the platform's own repositories: an application entry gets
+			// no sync objects, so reporting it here would be a claim about
+			// work this operator never does.
+			if repo.IsPlatformRepository() {
+				declared[componentPlatformRepositories] = componentDeclaration{declared: true, enabled: true}
+				break
+			}
 		}
 	}
 	if spec.CertManager != nil {

--- a/src/reconciler/platform_component_status_test.go
+++ b/src/reconciler/platform_component_status_test.go
@@ -49,6 +49,29 @@ func TestDeclaredComponentsSeparatesDisabledFromAbsent(t *testing.T) {
 	assert.False(t, declared[componentLoki].declared)
 }
 
+func TestDeclaredComponentsIgnoresApplicationRepositories(t *testing.T) {
+	// An application entry is declared for the mogenius platform, not for this
+	// operator -- no sync objects, so no condition claiming any.
+	onlyApplications := declaredComponents(v1alpha1.PlatformConfigSpec{
+		GitOps: &v1alpha1.GitOpsConfig{
+			Repositories: []v1alpha1.GitOpsRepositoryConfig{
+				{Name: "apps", URL: "https://example.com/apps.git", Type: v1alpha1.RepositoryTypeApplication},
+			},
+		},
+	})
+	assert.False(t, onlyApplications[componentPlatformRepositories].declared)
+
+	mixed := declaredComponents(v1alpha1.PlatformConfigSpec{
+		GitOps: &v1alpha1.GitOpsConfig{
+			Repositories: []v1alpha1.GitOpsRepositoryConfig{
+				{Name: "apps", URL: "https://example.com/apps.git", Type: v1alpha1.RepositoryTypeApplication},
+				{Name: "platform", URL: "https://example.com/p.git"},
+			},
+		},
+	})
+	assert.True(t, mixed[componentPlatformRepositories].declared, "the untyped entry is a platform repository")
+}
+
 func TestDeclaredComponentsReportsRepositoriesOnlyWhenDeclared(t *testing.T) {
 	without := declaredComponents(v1alpha1.PlatformConfigSpec{GitOps: &v1alpha1.GitOpsConfig{}})
 	assert.False(t, without[componentPlatformRepositories].declared)

--- a/src/reconciler/platform_fluxcd.go
+++ b/src/reconciler/platform_fluxcd.go
@@ -42,6 +42,11 @@ func (d *reconcilerModule) reconcileFluxCD(ctx context.Context, spec v1alpha1.Pl
 			extraObjects := []any{}
 
 			for _, repo := range spec.GitOps.Repositories {
+				// Application repositories are declared for the mogenius
+				// platform, not for this operator: no sync objects.
+				if !repo.IsPlatformRepository() {
+					continue
+				}
 				name := repo.Name
 				if name == "" {
 					name = repositorySecretName(repo.URL)

--- a/src/reconciler/platform_repositories.go
+++ b/src/reconciler/platform_repositories.go
@@ -54,6 +54,11 @@ func (d *reconcilerModule) reconcilePlatformRepositories(
 	}
 
 	for _, repo := range spec.GitOps.Repositories {
+		// Application repositories are declared for the mogenius platform, not
+		// for this operator: no sync objects.
+		if !repo.IsPlatformRepository() {
+			continue
+		}
 		name := repo.Name
 		if name == "" {
 			name = repositorySecretName(repo.URL)


### PR DESCRIPTION
`spec.gitOps.repositories[]` gains an optional `type` — `platform` or `application` — so the list can also declare application repositories without the operator treating them as platform config sources.

Semantics:
- **absent or `platform`** (every config written before the field existed): exactly today's behavior — the operator turns the entry into the engine's sync objects (GitRepository/Kustomization or Application).
- **`application`**: declared for the mogenius platform to read; this operator creates **no sync objects** for it and reports no `platform-repositories` condition about it. What the platform does with these entries is its own feature.

One helper (`IsPlatformRepository`) carries the default-means-platform rule, used by both delivery paths (engine extras and user-managed engine) and by the condition builder. Enum-validated in the CRD; `just generate` ran.

Tests: application-only lists produce no repositories condition, mixed lists keep working through the untyped entry.

The mogenius API's own entry gets `type: platform` explicitly in a separate mo-platform-api-service PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)