### PR TITLE
fix(gitops): carry the existing status through the replace-style apply

### DIFF
--- a/src/gitops/apply_test.go
+++ b/src/gitops/apply_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // The renovate-zombie incident: helm-controller parks its uninstall finalizer
@@ -63,4 +64,25 @@ func TestMergePreferringOurs(t *testing.T) {
 	assert.Nil(t, mergePreferringOurs(nil, nil))
 	assert.Equal(t, map[string]string{"a": "1"}, mergePreferringOurs(nil, map[string]string{"a": "1"}))
 	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, mergePreferringOurs(map[string]string{"a": "x", "b": "2"}, map[string]string{"a": "1"}))
+}
+
+// Argo CD's Application CRD has no status subresource, so a replace that omits
+// status erases the health and sync state the application controller wrote.
+// The sweep that erased it then read the empty status right back and reported
+// the component as "waiting for the GitOps engine to apply it" forever, while
+// the component ran fine — caught live on 2026-09-11.
+func TestApplyKeepsExistingStatusOnUpdate(t *testing.T) {
+	existing := helmRelease("traefik", defaultLabels("traefik"))
+	require.NoError(t, unstructured.SetNestedField(existing.Object, "Synced", "status", "sync", "status"))
+	client := testClient(t, existing).Resource(testHelmReleaseGVR).Namespace("flux-system")
+
+	update := helmRelease("traefik", defaultLabels("traefik"))
+	require.NoError(t, applyWith(context.Background(), client, update))
+
+	applied, err := client.Get(context.Background(), "traefik", metav1.GetOptions{})
+	require.NoError(t, err)
+	sync, found, err := unstructured.NestedString(applied.Object, "status", "sync", "status")
+	require.NoError(t, err)
+	assert.True(t, found, "the controller-written status must survive the operator's replace")
+	assert.Equal(t, "Synced", sync)
 }

--- a/src/gitops/installer.go
+++ b/src/gitops/installer.go
@@ -172,6 +172,19 @@ func applyWith(ctx context.Context, client dynamic.ResourceInterface, obj *unstr
 	obj.SetFinalizers(existing.GetFinalizers())
 	obj.SetLabels(mergePreferringOurs(existing.GetLabels(), obj.GetLabels()))
 	obj.SetAnnotations(mergePreferringOurs(existing.GetAnnotations(), obj.GetAnnotations()))
+
+	// The status carries over for the same reason. Argo CD's Application CRD
+	// has no status subresource, so replacing the object without one erases
+	// the health and sync state the application controller wrote — and the
+	// reconcile that did the erasing reads the status right back to report on
+	// the component, pinning every condition at "waiting for the GitOps
+	// engine to apply it" while the component runs fine. On CRDs that do have
+	// the subresource (all of Flux's), a status in the update body is ignored,
+	// so carrying it is never wrong.
+	if status, found, err := unstructured.NestedFieldCopy(existing.Object, "status"); err == nil && found {
+		obj.Object["status"] = status
+	}
+
 	_, err = client.Update(ctx, obj, metav1.UpdateOptions{})
 	return err
 }


### PR DESCRIPTION
## What

`applyWith` now copies the existing object's `.status` into the update body, next to the finalizer/label/annotation carry-over from #1250.

## Why — live-debugged on docker-desktop today

With an Argo CD engine, every PlatformConfig condition for a delivered component stayed at **`Pending — waiting for the GitOps engine to apply it` forever**, even though the Applications were long `Synced/Healthy` and the workloads ran.

The chain, caught live with a watch on the renovate-operator Application:

1. Argo CD's Application CRD has **no status subresource** (`kubectl get crd applications.argoproj.io -o jsonpath='{.spec.versions[0].subresources}'` → `{}`). Flux's CRDs all have one — which is why the identical flow worked on Flux clusters.
2. The sweep's create-or-replace `Update` sends the freshly built object, which has no `.status` — so it **erases the application controller's health/sync state** (observed: resourceVersion 7876 `sync= health=`, 4 s later Argo re-fills at 7880).
3. The very same reconcile then lists the Applications to build the component conditions (`deliveryStates`) and reads back the status **it just wiped** → every condition pins at Pending, every sweep, forever.

Side effects fixed along the way: Argo no longer has to recompute every Application's state after each 15-minute sweep, and an in-flight sync's `operationState` is no longer discarded.

On CRDs **with** a status subresource, a `status` in the update body is ignored by the API server, so the carry-over is a no-op there — never wrong to do.

## Testing

- New `TestApplyKeepsExistingStatusOnUpdate` in `src/gitops/apply_test.go` (fake dynamic client, controller-written status survives the replace).
- `go test ./src/gitops/` green, full build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)