### PR TITLE
fix(argocd): read the install config off the PlatformConfig when the legacy ConfigMap is absent

### DIFF
--- a/src/argocd/argo-cd.go
+++ b/src/argocd/argo-cd.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"log/slog"
 	cfg "mogenius-operator/src/config"
+	"mogenius-operator/src/gitops"
 	"mogenius-operator/src/k8sclient"
 	"mogenius-operator/src/kubernetes"
 	"mogenius-operator/src/logging"
@@ -581,7 +582,19 @@ func (self *argocd) initArgoCdConfig() error {
 	// Check if argo-cd-config ConfigMap exists in the MO_OWN_NAMESPACE
 	argoCdConfigUnstructured, err := store.GetResource(self.valkeyClient, utils.ConfigMapResource.ApiVersion, utils.ConfigMapResource.Kind, self.config.Get("MO_OWN_NAMESPACE"), ARGO_CD_CONFIGMAP_NAME, self.logger)
 	if err != nil {
-		return err
+		// The ConfigMap is written only by the legacy GitOps install flow. An
+		// Argo CD installed through the PlatformConfig records the same facts
+		// in the PlatformConfig status instead, so without this fallback every
+		// argocd command — creating the user token above all — failed on such
+		// clusters with "argo-cd-config not found" while Argo ran fine.
+		config, fallbackErr := self.argoCdConfigFromPlatformConfig()
+		if fallbackErr != nil {
+			// The original error names the primary contract; the fallback's
+			// only adds why the second chance did not apply either.
+			return fmt.Errorf("%w (and no PlatformConfig reports an installed Argo CD: %s)", err, fallbackErr.Error())
+		}
+		self.argoCdConfig = config
+		return nil
 	}
 	var argoCdConfig corev1.ConfigMap
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(argoCdConfigUnstructured.Object, &argoCdConfig)
@@ -590,6 +603,40 @@ func (self *argocd) initArgoCdConfig() error {
 	}
 	self.argoCdConfig = &argoCdConfig
 	return nil
+}
+
+// argoCdConfigFromPlatformConfig reads the Argo CD address out of the
+// PlatformConfig status the reconciler maintains.
+func (self *argocd) argoCdConfigFromPlatformConfig() (*corev1.ConfigMap, error) {
+	list, err := self.clientProvider.DynamicClient().
+		Resource(kubernetes.CreateGroupVersionResource(utils.PlatformConfigResource.ApiVersion, utils.PlatformConfigResource.Plural)).
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list PlatformConfigs: %w", err)
+	}
+	return argoCdConfigFromPlatformConfigList(list.Items)
+}
+
+// argoCdConfigFromPlatformConfigList synthesizes the legacy install config out
+// of the first PlatformConfig whose status reports a running Argo CD. Only the
+// two keys the argocd commands actually read are filled: namespaceName and
+// releaseName (initArgoServerUrl matches the server deployment's instance
+// label against the latter).
+func argoCdConfigFromPlatformConfigList(items []unstructured.Unstructured) (*corev1.ConfigMap, error) {
+	for i := range items {
+		engine, _, _ := unstructured.NestedString(items[i].Object, "status", "gitOpsStatus", "engine")
+		installed, _, _ := unstructured.NestedBool(items[i].Object, "status", "gitOpsStatus", "installed")
+		namespace, _, _ := unstructured.NestedString(items[i].Object, "status", "gitOpsStatus", "namespace")
+		releaseName, _, _ := unstructured.NestedString(items[i].Object, "status", "gitOpsStatus", "releaseName")
+		if engine != gitops.EngineArgoCD || !installed || namespace == "" {
+			continue
+		}
+		return &corev1.ConfigMap{Data: map[string]string{
+			"namespaceName": namespace,
+			"releaseName":   releaseName,
+		}}, nil
+	}
+	return nil, fmt.Errorf("none of %d PlatformConfigs reports an installed Argo CD", len(items))
 }
 
 func (self *argocd) getArgoCdSecret() (*corev1.Secret, error) {

--- a/src/argocd/argo-cd_test.go
+++ b/src/argocd/argo-cd_test.go
@@ -1,0 +1,49 @@
+package argocd
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func platformConfigWithGitOpsStatus(engine string, installed bool, namespace, releaseName string) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "mogenius.com/v1alpha1",
+		"kind":       "PlatformConfig",
+		"metadata":   map[string]any{"name": "platform"},
+		"status": map[string]any{
+			"gitOpsStatus": map[string]any{
+				"engine":      engine,
+				"installed":   installed,
+				"namespace":   namespace,
+				"releaseName": releaseName,
+			},
+		},
+	}}
+}
+
+func TestArgoCdConfigFromPlatformConfigList(t *testing.T) {
+	config, err := argoCdConfigFromPlatformConfigList([]unstructured.Unstructured{
+		platformConfigWithGitOpsStatus("argo-cd", true, "argocd", "argocd"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.Data["namespaceName"] != "argocd" || config.Data["releaseName"] != "argocd" {
+		t.Errorf("unexpected config data: %+v", config.Data)
+	}
+}
+
+func TestArgoCdConfigFromPlatformConfigListRejectsUnusable(t *testing.T) {
+	cases := map[string]unstructured.Unstructured{
+		"flux engine":       platformConfigWithGitOpsStatus("flux", true, "flux-system", "flux-operator"),
+		"not installed":     platformConfigWithGitOpsStatus("argo-cd", false, "argocd", "argocd"),
+		"missing namespace": platformConfigWithGitOpsStatus("argo-cd", true, "", "argocd"),
+		"no status":         {Object: map[string]any{"metadata": map[string]any{"name": "platform"}}},
+	}
+	for name, item := range cases {
+		if _, err := argoCdConfigFromPlatformConfigList([]unstructured.Unstructured{item}); err == nil {
+			t.Errorf("%s: expected an error, got a config", name)
+		}
+	}
+}


### PR DESCRIPTION
## What

`initArgoCdConfig` falls back to the PlatformConfig status when the legacy `argo-cd-config` ConfigMap is missing: the first PlatformConfig whose `status.gitOpsStatus` reports an installed Argo CD supplies `namespaceName` and `releaseName` — the only two keys any argocd command reads.

## Why — reproduced live

**Add Argo-CD User** in the GitOps view 404s on a cluster whose Argo CD was installed through the PlatformConfig. Verified on the test cluster: the API side had already succeeded (`accounts.mogenius` in `argocd-cm`, `g, mogenius, role:admin` in `argocd-rbac-cm`, password hashes in `argocd-secret`, the `argo-cd-secret` in the operator namespace) — then the final step, `cluster/argocd-create-api-token`, failed because `initArgoCdConfig` requires the `argo-cd-config` ConfigMap that only the **legacy** GitOps install flow writes. It does not exist anywhere on a PlatformConfig-onboarded cluster.

The suspected hardcoded-namespace mismatch was ruled out: the operator namespace resolves correctly; the missing legacy ConfigMap is the whole story.

This also revives the legacy per-Application refresh/sync/terminate socket commands on such clusters, since they all start with `initArgoCdConfig`.

## Testing

- New pure-function tests for the PlatformConfig-status extraction (usable status → config; flux engine / not installed / missing namespace / no status → error).
- `go test ./src/argocd/` green, full build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)