### PR TITLE
fix(platform): never overwrite gitops objects the operator does not own

### DIFF
--- a/src/reconciler/platform_engine_install.go
+++ b/src/reconciler/platform_engine_install.go
@@ -126,7 +126,7 @@ func (d *reconcilerModule) reconcileGitOpsEngine(
 			return &ReconcileResult{Err: fmt.Errorf(
 				"%s installed but %s did not register within %s", cs.name, bootstrap.resource.Kind, engineCRDTimeout)}
 		}
-		if err := d.applyPlatformObject(bootstrap.resource, namespace, bootstrap.object); err != nil {
+		if err := d.applyPlatformObject(ctx, bootstrap.resource, namespace, bootstrap.object); err != nil {
 			return &ReconcileResult{Err: fmt.Errorf("apply %s for %s: %w", bootstrap.resource.Kind, cs.name, err)}
 		}
 	}

--- a/src/reconciler/platform_repositories.go
+++ b/src/reconciler/platform_repositories.go
@@ -47,7 +47,7 @@ func (d *reconcilerModule) reconcilePlatformRepositories(
 		// ships none. Absent on a cluster whose Flux was set up by hand, where
 		// the controllers exist already and this CRD does not.
 		if d.crdChecker.IsAvailable(utils.FluxInstanceResource) {
-			if err := d.applyPlatformObject(utils.FluxInstanceResource, namespace, fluxInstanceObject(namespace)); err != nil {
+			if err := d.applyPlatformObject(ctx, utils.FluxInstanceResource, namespace, fluxInstanceObject(namespace)); err != nil {
 				return &ReconcileResult{Err: fmt.Errorf("apply flux instance: %w", err)}
 			}
 		}
@@ -74,16 +74,16 @@ func (d *reconcilerModule) reconcilePlatformRepositories(
 			// No credential reference: Argo CD discovers repository credentials
 			// by label, so the Secret stands on its own.
 			object := argoApplicationObject(name, repo, namespace, argoProjectName(spec.GitOps))
-			if err := d.applyPlatformObject(utils.ArgoApplicationResource, namespace, object); err != nil {
+			if err := d.applyPlatformObject(ctx, utils.ArgoApplicationResource, namespace, object); err != nil {
 				return &ReconcileResult{Err: fmt.Errorf("apply application %q: %w", name, err)}
 			}
 
 		case gitOpsEngineFlux:
 			source := fluxGitRepositoryObject(name, repo, namespace, d.fluxRepositorySecretName(ctx, name, repo, namespace))
-			if err := d.applyPlatformObject(utils.GitRepositoryResource, namespace, source); err != nil {
+			if err := d.applyPlatformObject(ctx, utils.GitRepositoryResource, namespace, source); err != nil {
 				return &ReconcileResult{Err: fmt.Errorf("apply git repository %q: %w", name, err)}
 			}
-			if err := d.applyPlatformObject(utils.KustomizationResource, namespace, fluxKustomizationObject(name, repo, namespace)); err != nil {
+			if err := d.applyPlatformObject(ctx, utils.KustomizationResource, namespace, fluxKustomizationObject(name, repo, namespace)); err != nil {
 				return &ReconcileResult{Err: fmt.Errorf("apply kustomization %q: %w", name, err)}
 			}
 		}
@@ -96,7 +96,16 @@ func (d *reconcilerModule) reconcilePlatformRepositories(
 // platform's. No owner reference: these objects are what sync the PlatformConfig
 // in, so tying their lifetime to it would have the object delete itself the
 // moment the resource it delivers is removed.
-func (d *reconcilerModule) applyPlatformObject(resource utils.ResourceDescriptor, namespace string, object map[string]any) error {
+//
+// An object of the same name that the operator did not create is never
+// written. gitops.Apply replaces the spec wholesale, so writing someone
+// else's object destroys whatever their spec carried — on a cluster whose
+// Flux came through the flux-operator, overwriting the user's FluxInstance
+// dropped its spec.sync, and the engine garbage-collected the root
+// Kustomization and with it every application it managed. Handing an object
+// over to the platform is explicit: label it
+// app.kubernetes.io/managed-by=mogenius-operator.
+func (d *reconcilerModule) applyPlatformObject(ctx context.Context, resource utils.ResourceDescriptor, namespace string, object map[string]any) error {
 	if !d.crdChecker.IsAvailable(resource) {
 		// The engine's CRDs are not registered yet. A later sweep finds them.
 		d.logger.Info("skipping platform repository object, CRD not available yet",
@@ -113,12 +122,58 @@ func (d *reconcilerModule) applyPlatformObject(resource utils.ResourceDescriptor
 	labels["app.kubernetes.io/component"] = "platform-config"
 	obj.SetLabels(labels)
 
-	return gitops.Apply(
-		d.clientProvider,
-		kubernetes.CreateGroupVersionResource(resource.ApiVersion, resource.Plural),
-		namespace,
-		obj,
-	)
+	gvr := kubernetes.CreateGroupVersionResource(resource.ApiVersion, resource.Plural)
+	existing, err := d.clientProvider.DynamicClient().Resource(gvr).Namespace(namespace).Get(ctx, obj.GetName(), metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+		existing = nil
+	case err != nil:
+		// Not evidence of absence. Writing blind past a failed ownership check
+		// is exactly the overwrite this guard exists to prevent.
+		return fmt.Errorf("check ownership of %s %s/%s: %w", resource.Kind, namespace, obj.GetName(), err)
+	}
+
+	if platformObjectForeign(existing) {
+		d.logger.Warn("skipping platform object: it already exists and was not created by mogenius",
+			"kind", resource.Kind, "namespace", namespace, "name", obj.GetName(),
+			"hint", "label it app.kubernetes.io/managed-by=mogenius-operator to hand it over to the platform")
+		return nil
+	}
+
+	if resource.Kind == utils.FluxInstanceResource.Kind && existing != nil {
+		preserveFluxInstanceSync(existing, obj)
+	}
+
+	return gitops.Apply(d.clientProvider, gvr, namespace, obj)
+}
+
+// platformObjectForeign reports whether an existing object belongs to someone
+// other than the platform reconciler. Absence is not foreign — a missing
+// object is free to create.
+func platformObjectForeign(existing *unstructured.Unstructured) bool {
+	if existing == nil {
+		return false
+	}
+	return existing.GetLabels()["app.kubernetes.io/managed-by"] != "mogenius-operator"
+}
+
+// preserveFluxInstanceSync carries an existing spec.sync over onto the desired
+// object when the template declares none. A FluxInstance's sync is what points
+// the whole cluster at its Git repository; applying the bare template over an
+// instance that carried one removes it, and the flux-operator then
+// garbage-collects the root Kustomization — which prunes everything it ever
+// deployed. The ownership guard keeps foreign instances out of reach; this
+// keeps a sync someone added to an operator-owned instance alive too.
+func preserveFluxInstanceSync(existing, desired *unstructured.Unstructured) {
+	if _, found, _ := unstructured.NestedMap(desired.Object, "spec", "sync"); found {
+		return
+	}
+	sync, found, err := unstructured.NestedMap(existing.Object, "spec", "sync")
+	if err != nil || !found {
+		return
+	}
+	// Errors only on malformed field paths, which "spec", "sync" is not.
+	_ = unstructured.SetNestedMap(desired.Object, sync, "spec", "sync")
 }
 
 // fluxRepositorySecretName is the credential a repository's GitRepository binds

--- a/src/reconciler/platform_repositories_ownership_test.go
+++ b/src/reconciler/platform_repositories_ownership_test.go
@@ -1,0 +1,95 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// The incident this pins down: on a cluster whose Flux came through the
+// flux-operator, the repositories path applied the operator's bare
+// FluxInstance template over the user's existing instance. The apply replaces
+// the spec wholesale, so the instance lost its spec.sync, the flux-operator
+// garbage-collected the root Kustomization, and its prune finalizer deleted
+// every application the cluster ran. An object without the operator's
+// managed-by label must never be written.
+func TestPlatformObjectForeignRejectsUnlabelledObjects(t *testing.T) {
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "flux"},
+	}}
+
+	assert.True(t, platformObjectForeign(existing))
+}
+
+func TestPlatformObjectForeignRejectsObjectsManagedByOthers(t *testing.T) {
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":   "flux",
+			"labels": map[string]any{"app.kubernetes.io/managed-by": "kustomize-controller"},
+		},
+	}}
+
+	assert.True(t, platformObjectForeign(existing))
+}
+
+// Absence is not foreign: a missing object is free to create, and an object
+// the operator labelled on a previous sweep is its own to keep reconciling.
+func TestPlatformObjectForeignAllowsAbsentAndOwnObjects(t *testing.T) {
+	assert.False(t, platformObjectForeign(nil))
+
+	own := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":   "flux",
+			"labels": map[string]any{"app.kubernetes.io/managed-by": "mogenius-operator"},
+		},
+	}}
+	assert.False(t, platformObjectForeign(own))
+}
+
+// A sync someone added to an operator-owned FluxInstance survives the sweep:
+// the template never declares one, and dropping it detaches the cluster from
+// its Git repository — the same failure the ownership guard prevents for
+// foreign instances.
+func TestPreserveFluxInstanceSyncCarriesTheExistingSyncOver(t *testing.T) {
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{
+			"sync": map[string]any{"kind": "GitRepository", "url": "https://github.com/acme/platform.git"},
+		},
+	}}
+	desired := &unstructured.Unstructured{Object: fluxInstanceObject("flux-system")}
+
+	preserveFluxInstanceSync(existing, desired)
+
+	sync, found, err := unstructured.NestedMap(desired.Object, "spec", "sync")
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "https://github.com/acme/platform.git", sync["url"])
+}
+
+// A sync the desired object declares itself wins over the existing one, and an
+// existing instance without a sync adds nothing.
+func TestPreserveFluxInstanceSyncLeavesADeclaredSyncAlone(t *testing.T) {
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{
+			"sync": map[string]any{"url": "https://github.com/acme/old.git"},
+		},
+	}}
+	desired := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{
+			"sync": map[string]any{"url": "https://github.com/acme/declared.git"},
+		},
+	}}
+
+	preserveFluxInstanceSync(existing, desired)
+
+	sync, _, _ := unstructured.NestedMap(desired.Object, "spec", "sync")
+	assert.Equal(t, "https://github.com/acme/declared.git", sync["url"])
+
+	bare := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{}}}
+	desired = &unstructured.Unstructured{Object: fluxInstanceObject("flux-system")}
+	preserveFluxInstanceSync(bare, desired)
+	_, found, _ := unstructured.NestedMap(desired.Object, "spec", "sync")
+	assert.False(t, found)
+}


### PR DESCRIPTION
## Incident

On a homelab cluster whose Flux was installed via flux-operator, applying a PlatformConfig with only `gitOps.repositories` wiped the entire cluster (2026-09-11):

1. `reconcilePlatformRepositories` saw the FluxInstance CRD present and applied the operator's bare `fluxInstanceObject` template (version `2.x`, **no `spec.sync`**) over the user's existing `flux-system/flux` instance.
2. `gitops.Apply` replaces the spec wholesale → the instance lost its `spec.sync` and jumped 2.7.5 → 2.9.5.
3. flux-operator garbage-collected the now-undeclared sync objects: the root `Kustomization` + `GitRepository`.
4. The root Kustomization's prune finalizer deleted all ~50 app Kustomizations → each pruned its objects → including the Kustomization that owned the FluxInstance itself → flux-operator performed a **full Flux uninstall** (controllers + CRDs) while the prune cascade deleted every application namespace.

## Fix

- `applyPlatformObject` now checks ownership before writing: an existing object **without** the `app.kubernetes.io/managed-by=mogenius-operator` label is logged and skipped — for every platform object kind (FluxInstance, GitRepository, Kustomization, Argo Application) and on both delivery paths (repositories + engine bootstrap). This mirrors the `ReleaseForeign` guard that already protects the engine's Helm release.
- Handing an object over to the platform is now an explicit act: label it `app.kubernetes.io/managed-by=mogenius-operator`.
- Defense in depth: a `spec.sync` found on an operator-owned FluxInstance is carried over instead of silently dropped.
- An ownership lookup failure aborts the write instead of writing blind.

## Tests

- `platformObjectForeign`: unlabelled / foreign-managed / absent / own objects
- `preserveFluxInstanceSync`: carry-over, declared-sync precedence, no-sync no-op
- `go build ./...` and full `reconciler` + `gitops` packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)